### PR TITLE
Simplifies output file opening:

### DIFF
--- a/g2p.py
+++ b/g2p.py
@@ -3,7 +3,6 @@
 import argparse
 import datetime
 import functools
-import os
 import re
 import sys
 from typing import Callable, Optional, TextIO


### PR DESCRIPTION
* just uses sys.stdout instead of print.
* builds up the output file line by line instead of all at once (which
could be very! expensive)