### PR TITLE
[blt] Fixed scraping test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Unreleased
 -   Fixed column ordering of the test file read by the script in 
     `data/covering_grammar/lib/error_analysis.py` (\#411)
 -   Fixed Common character collection in `common_characters.py` (\#419)
+-   Scraping test fixed for `blt`. (\#436)
 
 ### Under `wikipron/` and elsewhere
 

--- a/tests/test_wikipron/test_scrape.py
+++ b/tests/test_wikipron/test_scrape.py
@@ -51,6 +51,7 @@ _SMOKE_TEST_LANGUAGES = [
     ),
     SmokeTestLanguage("yue", "Cantonese", {"skip_spaces_pron": False}),
     SmokeTestLanguage("nan", "Min Nan", {"skip_spaces_pron": False}),
+    SmokeTestLanguage("blt", "Tai Dam", {}),
 ]
 
 


### PR DESCRIPTION
Please note: timeouts in this test are a pain.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
