### PR TITLE
Adds test for "casefold" values in languages.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Unreleased
 -  Added test of phones list generation in `test_data/test_summary.py` (\#363)
 -  Added Min Nan extraction function. (\#397)
 -  Added Tai Dam extraction function, configuration and initial scrape. (\#435)
+-  Added test of `casefold` value for languages in `data/scrape/lib/languages.json` (\#442)
 
 [1.2.0] - 2021-01-30
 --------------------

--- a/data/scrape/lib/languages.json
+++ b/data/scrape/lib/languages.json
@@ -325,7 +325,7 @@
         "iso639_name": "Central Kurdish",
         "wiktionary_name": "Central Kurdish",
         "wiktionary_code": "ckb",
-        "casefold": null
+        "casefold": false
     },
     "che": {
         "iso639_name": "Chechen",
@@ -861,7 +861,7 @@
         "iso639_name": "Karelian",
         "wiktionary_name": "Karelian",
         "wiktionary_code": "krl",
-        "casefold": null
+        "casefold": true
     },
     "kas": {
         "iso639_name": "Kashmiri",
@@ -926,7 +926,7 @@
         "iso639_name": "Konkani (macrolanguage)",
         "wiktionary_name": "Konkani",
         "wiktionary_code": "kok",
-        "casefold": null
+        "casefold": false
     },
     "kor": {
         "iso639_name": "Korean",
@@ -1167,7 +1167,7 @@
         "iso639_name": "Malayalam",
         "wiktionary_name": "Malayalam",
         "wiktionary_code": "ml",
-        "casefold": null,
+        "casefold": false,
         "script": {
             "mlym": "Malayalam",
             "arab": "Arabic"
@@ -1878,7 +1878,7 @@
         "iso639_name": "Southern Yukaghir",
         "wiktionary_name": "Southern Yukaghir",
         "wiktionary_code": "yux",
-        "casefold": null
+        "casefold": true
     },
     "spa": {
         "iso639_name": "Spanish; Castilian",
@@ -2008,7 +2008,7 @@
         "iso639_name": "Tokelau",
         "wiktionary_name": "Tokelauan",
         "wiktionary_code": "tkl",
-        "casefold": null
+        "casefold": true
     },
     "ton": {
         "iso639_name": "Tonga (Tonga Islands)",
@@ -2212,7 +2212,7 @@
         "iso639_name": "Yoruba",
         "wiktionary_name": "Yoruba",
         "wiktionary_code": "yo",
-        "casefold": null
+        "casefold": true
     },
     "zza": {
         "iso639_name": "Zaza",

--- a/tests/test_data/test_languages.py
+++ b/tests/test_data/test_languages.py
@@ -18,8 +18,8 @@ def test_casefold_value():
         if languages[language]["casefold"] is None:
             missing_languages.add(languages[language]["wiktionary_name"])
 
-    assert len(missing_languages) == 0, (
+    assert not missing_languages, (
         "The following languages do not have a 'casefold' value "
         "in data/scrape/lib/languages.json:"
-        f"{[lang for lang in missing_languages]}"
+        f"{missing_languages}"
     )

--- a/tests/test_data/test_languages.py
+++ b/tests/test_data/test_languages.py
@@ -7,7 +7,7 @@ _REPO_DIR = os.path.dirname(
 _LANGUAGES = os.path.join(_REPO_DIR, "data/scrape/lib/languages.json")
 
 
-def test_phones_data_matches_summary():
+def test_casefold_value():
     """Check if each language in data/scrape/lib/languages.json
     has a value for 'casefold' key.
     """

--- a/tests/test_data/test_languages.py
+++ b/tests/test_data/test_languages.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+_REPO_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+)
+_LANGUAGES = os.path.join(_REPO_DIR, "data/scrape/lib/languages.json")
+
+
+def test_phones_data_matches_summary():
+    """Check if each language in data/scrape/lib/languages.json
+    has a value for 'casefold' key.
+    """
+    missing_languages = set()
+    with open(_LANGUAGES, "r") as source:
+        languages = json.load(source)
+    for language in languages:
+        if languages[language]["casefold"] is None:
+            missing_languages.add(languages[language]["wiktionary_name"])
+
+    assert len(missing_languages) == 0, (
+        "The following languages do not have a 'casefold' value "
+        "in data/scrape/lib/languages.json:"
+        f"{[lang for lang in missing_languages]}"
+    )


### PR DESCRIPTION
- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

A few `null` casefold values have snuck into `languages.json`. This PR updates those values and adds a test to make sure we notice when this happens in the future.

A `null` casefold value won't crash the big scrape, but it might lead to undesirable behavior. There are some potential tests we could add to the new `test_languages.py` to make sure that there is nothing in `languages.json` that will crash the big scrape (which I believe there currently is) but I'll have to think about how to do it since it might involve reorganizing `codes.py` again. If that sound interesting I can file an issue.