### PR TITLE
Fix for italian broad phonemes

### DIFF
--- a/data/phones/phones/ita_broad.phones
+++ b/data/phones/phones/ita_broad.phones
@@ -6,35 +6,32 @@
 #   Italian, as compared with the varieties spoken in Florence. Journal of the
 #   International Phonetic Association, 35(2): 131-151.
 a
-o
-r
-e
-i
-t
-n
-l
-k
-s
-d
-m
-p
-u
-j
-ɛ
 b
-f
-v
-ɔ
-ɡ
+k
 t͡ʃ
+d
+e
+ɛ
+f
+ɡ
 d͡ʒ
+i
+j
+l
+m
+n
+o
+ɔ
+p
+r
+s
 z
-t͡s
+t
+u
 w
-ʃ
-u̯  # Allophone of /u/ in diphthongs.
+v
+t͡s
 d͡z
+ʃ
 ɲ
 ʎ
-i̯  # Allophone of /i/ in diphthongs.
-

--- a/data/scrape/tsv/ita_latn_broad.tsv
+++ b/data/scrape/tsv/ita_latn_broad.tsv
@@ -243,7 +243,7 @@ abusare	a b u z a r e
 abuso	a b u z o
 acacia	a k a t͡ʃ a
 acagiù	a k a d͡ʒ u
-acaico	a k a i̯ k o
+acaico	a k a i k o
 acalefa	a k a l ɛ f a
 acalefe	a k a l ɛ f e
 acalifa	a k a l i f a
@@ -579,7 +579,7 @@ ai	a i
 aiere	a j e r e
 ailuride	a i l u r i d e
 ailuridi	a i l u r i d i
-ailuro	a i̯ l u r o
+ailuro	a i l u r o
 ailurofobia	a i l u r o f o b i a
 ain	a j n
 aire	a i r e
@@ -645,7 +645,7 @@ alfa	a l f a
 alfabeti	a l f a b ɛ t i
 alfabetico	a l f a b ɛ t i k o
 alfabeto	a l f a b ɛ t o
-alfeide	a l f ɛ i̯ d e
+alfeide	a l f ɛ i d e
 alfiere	a l f j ɛ r e
 alga	a l ɡ a
 algarello	a l ɡ a r ɛ l l o
@@ -951,7 +951,7 @@ andreottiana	a n d r e o t t j a n a
 andreottiano	a n d r e o t t j a n o
 androceo	a n d r o t ʃ ɛ o
 androconio	a n d r o k ɔ n j o
-androide	a n d r ɔ i̯ d e
+androide	a n d r ɔ i d e
 androne	a n d r o n e
 anelante	a n e l a n t e
 anello	a n ɛ l l o
@@ -1078,7 +1078,7 @@ aosta	a o s t a
 aosta	a ɔ s t a
 aostano	a o s t a n o
 apar	a p a r
-apartheid	a p a r t a i̯ d
+apartheid	a p a r t a i d
 apartitico	a p a r t i t i k o
 apatia	a p a t i a
 apatico	a p a t i k o
@@ -1171,7 +1171,7 @@ arcaismo	a r k a i z m o
 arcano	a r k a n o
 archeologico	a r k e o l ɔ d͡ʒ i k o
 archeologo	a r k e ɔ l o ɡ o
-archeozoico	a r k e o̯ d͡z ɔ i̯ k o
+archeozoico	a r k e o̯ d͡z ɔ i k o
 archibugeria	a r k i b u d͡ʒ e r i a
 archibugiare	a r k i b u d͡ʒ a r e
 archibugiata	a r k i b u d͡ʒ a t a
@@ -1499,201 +1499,201 @@ attualità	a t t u a l i t a
 attualizzare	a t t w a l i d d͡z a r e
 audience	ɔ d j e n s
 auffa	a u f f a
-auge	a u̯ d͡ʒ e
-augello	a u̯ d͡ʒ ɛ l l o
-augurare	a u̯ ɡ u r a r e
-augure	a u̯ ɡ u r e
-auguri	a u̯ ɡ u r i
-auledo	a u̯ l ɛ d o
-aulente	a u̯ l ɛ n t e
-aulentissimo	a u̯ l e n t i s s i m o
+auge	a u d͡ʒ e
+augello	a u d͡ʒ ɛ l l o
+augurare	a u ɡ u r a r e
+augure	a u ɡ u r e
+auguri	a u ɡ u r i
+auledo	a u l ɛ d o
+aulente	a u l ɛ n t e
+aulentissimo	a u l e n t i s s i m o
 aulico	a u l i k o
-aulire	a u̯ l i r e
-aulore	a u̯ l o r e
-auloroso	a u̯ l o r o z o
+aulire	a u l i r e
+aulore	a u l o r e
+auloroso	a u l o r o z o
 aureo	a u r e o
 aureola	a u r ɛ o l a
 auriga	a u r i ɡ a
-aurignaciano	a u̯ r i ɲ ɲ a t͡ʃ a n o
-aurignaziano	a u̯ r i ɲ ɲ a t t͡s j a n o
-aurora	a u̯ r ɔ r a
-ausilio	a u̯ z i l j o
+aurignaciano	a u r i ɲ ɲ a t͡ʃ a n o
+aurignaziano	a u r i ɲ ɲ a t t͡s j a n o
+aurora	a u r ɔ r a
+ausilio	a u z i l j o
 auspicio	a u s p i t͡ʃ o
 austero	a u s t ɛ r o
-australopitechi	a u̯ s t r a l o p i t ɛ k i
+australopitechi	a u s t r a l o p i t ɛ k i
 austria	a u s t r j a
-autarchia	a u̯ t a r k i a
+autarchia	a u t a r k i a
 autenticità	a u t e n t i t͡ʃ i t a
-auto	a u̯ t o
-autoabbronzante	a u̯ t o a b b r o n d͡z a n t e
-autoabbronzatura	a u̯ t o a b b r o n d͡z a t u r a
-autoaccelerazione	a u̯ t o a t t͡ʃ e l e r a t t͡s j o n e
-autoaccensione	a u̯ t o a t t͡ʃ e n s j o n e
-autoaccessorio	a u̯ t o a t t͡ʃ e s s ɔ r j o
-autoaccusa	a u̯ t o a k k u z a
-autoaccusarsi	a u̯ t o a k k u z a r s i
-autoadattante	a u̯ t o a d a t t a n t e
-autoadescante	a u̯ t o a d e s k a n t e
-autoadesivo	a u̯ t o a d e z i v o
-autoaffermazione	a u̯ t o a f f e r m a t t͡s j o n e
-autoaffondamento	a u̯ t o a f f o n d a m e n t o
-autoaffondarsi	a u̯ t o a f f o n d a r s i
-autoaggiornamento	a u̯ t o a d d͡ʒ o r n a m e n t o
-autoaggiunto	a u̯ t o a d d͡ʒ u n t o
-autoaggressivo	a u̯ t o a ɡ ɡ r e s s i v o
-autoaiuto	a u̯ t o a j u t o
-autoalienazione	a u̯ t o a l j e n a t t͡s j o n e
-autoalimentarsi	a u̯ t o a l i m e n t a r s i
-autoallergia	a u̯ t o a l l e r d͡ʒ i a
-autoambulanza	a u̯ t o a m b u l a n t͡s a
-autoanalisi	a u̯ t o a n a l i z i
-autoanticorpo	a u̯ t o a n t i k ɔ r p o
-autoantigene	a u̯ t o a n t i d͡ʒ e n e
-autoapprendimento	a u̯ t o a p p r e n d i m e n t o
-autoapprovvigionamento	a u̯ t o a p p r o v v i d͡ʒ o n a m e n t o
-autoarticolato	a u̯ t o a r t i k o l a t o
-autoassoluzione	a u̯ t o a s s o l u t t͡s j o n e
-autoassolversi	a u̯ t o a s s ɔ l v e r s i
-autobetoniera	a u̯ t o b e t o n j ɛ r a
-autobiblioteca	a u̯ t o b i b l j o t ɛ k a
-autobilanciato	a u̯ t o b i l a n t͡ʃ a t o
-autobiografismo	a u̯ t o b j o ɡ r a f i s m o
-autobiografo	a u̯ t o b i ɔ ɡ r a f o
-autoblinda	a u̯ t o b l i n d a
-autoblindato	a u̯ t o b l i n d a t o
-autoblindomitragliatrice	a u̯ t o b l i n d o m i t r a ʎ ʎ a t r i t͡ʃ e
-autobloccante	a u̯ t o b l o k k a n t e
-autobomba	a u̯ t o b o m b a
-autobotte	a u̯ t o b o t t e
-autobruco	a u̯ t o b r u k o
-autocalmiere	a u̯ t o k a l m j ɛ r e
-autocalunnia	a u̯ t o k a l u n n j a
-autocamionale	a u̯ t o k a m j o n a l e
-autocampeggio	a u̯ t o k a m p e d d͡ʒ o
-autocampionatore	a u̯ t o k a m p j o n a t o r e
-autocancellazione	a u̯ t o k a n t͡ʃ e l l a t t͡s j o n e
-autocaravan	a u̯ t o k a r a v a n
-autocaricamento	a u̯ t o k a r i k a m e n t o
-autocaricatura	a u̯ t o k a r i k a t u r a
-autocasa	a u̯ t o k a z a
-autocatalisi	a u̯ t o k a t a l i z i
-autocateterismo	a u̯ t o k a t e t e r i s m o
-autocelebrativo	a u̯ t o t͡ʃ e l e b r a t i v o
-autocensura	a u̯ t o t͡ʃ e n s u r a
-autocentrante	a u̯ t o t͡ʃ e n t r a n t e
-autocentro	a u̯ t o t͡ʃ ɛ n t r o
-autocercante	a u̯ t o t͡ʃ e r k a n t e
-autocertificare	a u̯ t o t͡ʃ e r t i f i k a r e
-autocertificativo	a u̯ t o t͡ʃ e r t i f i k a t i v o
-autocertificato	a u̯ t o t͡ʃ e r t i f i k a t o
-autocertificazione	a u̯ t o t͡ʃ e r t i f i k a t t͡s j o n e
-autocestello	a u̯ t o t͡ʃ e s t ɛ l l o
-autochiusura	a u̯ t o k j u z u r a
-autocinema	a u̯ t o t͡ʃ i n e m a
-autocingolato	a u̯ t o t͡ʃ i n ɡ o l a t o
-autocisterna	a u̯ t o t͡ʃ i s t ɛ r n a
-autocitarsi	a u̯ t o t͡ʃ i t a r s i
-autocitazione	a u̯ t o t͡ʃ i t a t t͡s j o n e
-autocivetta	a u̯ t o t͡ʃ i v e t t a
-autoclastico	a u̯ t o k l a s t i k o
-autocolonna	a u̯ t o k o l o n n a
-autocombustione	a u̯ t o k o m b u s t j o n e
-autocommento	a u̯ t o k o m m e n t o
-autocommiserarsi	a u̯ t o k o m m i z e r a r s i
-autocommiserazione	a u̯ t o k o m m i z e r a t t͡s j o n e
-autocommutatore	a u̯ t o k o m m u t a t o r e
-autocompattatore	a u̯ t o k o m p a t t a t o r e
-autocompiacimento	a u̯ t o k o m p j a t͡ʃ i m e n t o
-autoconcessionaria	a u̯ t o k o n t͡ʃ e s s j o n a r j a
-autoconcessionario	a u̯ t o k o n t͡ʃ e s s j o n a r j o
-autocondanna	a u̯ t o k o n d a n n a
-autoconoscenza	a u̯ t o k o n o ʃ ʃ ɛ n t͡s a
-autoconsapevolezza	a u̯ t o k o n s a p e v o l e t t͡s a
-autoconservazione	a u̯ t o k o n s e r v a t t͡s j o n e
-autoconsistente	a u̯ t o k o n s i s t ɛ n t e
-autoconsistenza	a u̯ t o k o n s i s t ɛ n t͡s a
-autoconsumo	a u̯ t o k o n s u m o
-autocontrarre	a u̯ t o k o n t r a r r e
-autocontrarsi	a u̯ t o k o n t r a r s i
-autocontratto	a u̯ t o k o n t r a t t o
-autocontrollo	a u̯ t o k o n t r ɔ l l o
-autoconvincersi	a u̯ t o k o n v i n t͡ʃ e r s i
-autoconvincimento	a u̯ t o k o n v i n t͡ʃ i m e n t o
-autoconvoglio	a u̯ t o k o n v ɔ ʎ ʎ o
-autocopiante	a u̯ t o k o p j a n t e
-autocorrela	a u̯ t o k o r r ɛ l a
-autocorrelare	a u̯ t o k o r r e l a r e
-autocorrelazione	a u̯ t o k o r r e l a t t͡s j o n e
-autocorrezione	a u̯ t o k o r r e t t͡s j o n e
-autocorriera	a u̯ t o k o r r j ɛ r a
-autocosciente	a u̯ t o k o ʃ ʃ ɛ n t e
-autocoscienza	a u̯ t o k o ʃ ʃ ɛ n t͡s a
-autocritica	a u̯ t o k r i t i k a
-autocritico	a u̯ t o k r i t i k o
-autocross	a u̯ t o k r ɔ s
-autocura	a u̯ t o k u r a
-autodafé	a u̯ t o d a f e
-autodecisione	a u̯ t o d e t͡ʃ i z j o n e
-autodefinizione	a u̯ t o d e f i n i t t͡s j o n e
-autodemolitore	a u̯ t o d e m o l i t o r e
-autodemolizione	a u̯ t o d e m o l i t t͡s j o n e
-autodenuncia	a u̯ t o d e n u n t͡ʃ a
-autodenunciarsi	a u̯ t o d e n u n t͡ʃ a r s i
-autodeterminato	a u̯ t o d e t e r m i n a t o
-autodeterminazione	a u̯ t o d e t e r m i n a t t͡s j o n e
-autodiagnosi	a u̯ t o d i a ɲ ɲ o z i
-autodiagnostica	a u̯ t o d j a ɲ ɲ ɔ s t i k a
-autodichiarare	a u̯ t o d i k j a r a r e
-autodichiararsi	a u̯ t o d i k j a r a r s i
-autodichiarato	a u̯ t o d i k j a r a t o
-autodichiarazione	a u̯ t o d i k j a r a t t͡s j o n e
-autodidatta	a u̯ t o d i d a t t a
-autodidattico	a u̯ t o d i d a t t i k o
-autodidattismo	a u̯ t o d i d a t t i s m o
-autodifesa	a u̯ t o d i f e z a
-autodigestione	a u̯ t o d i d͡ʒ e s t j o n e
-autodina	a u̯ t o d i n a
-autodirezionale	a u̯ t o d i r e t t͡s j o n a l e
-autodistribuito	a u̯ t o d i s t r i b u i t o
-autodistruggersi	a u̯ t o d i s t r u d d͡ʒ e r s i
-autodonazione	a u̯ t o d o n a t t͡s j o n e
-autoeccitante	a u̯ t o e t t͡ʃ i t a n t e
-autoeccitarsi	a u̯ t o e t t͡ʃ i t a r s i
-autoeccitazione	a u̯ t o e t t͡ʃ i t a t t͡s j o n e
-autoecologia	a u̯ t o e k o l o d͡ʒ i a
-autoeditore	a u̯ t o e d i t o r e
-autoeditoria	a u̯ t o e d i t o r i a
-autoeducazione	a u̯ t o e d u k a t t͡s j o n e
-autoefficacia	a u̯ t o e f f i k a t͡ʃ a
-autoemarginazione	a u̯ t o e m a r d͡ʒ i n a t t͡s j o n e
-autoemoteca	a u̯ t o e m o t ɛ k a
-autoemoterapia	a u̯ t o e m o t e r a p i a
-autoemotrasfusione	a u̯ t o e m o t r a s f u z j o n e
-autoerotico	a u̯ t o e r ɔ t i k o
-autoerotismo	a u̯ t o e r o t i s m o
-autoesaltazione	a u̯ t o e z a l t a t t͡s j o n e
-autoesame	a u̯ t o e z a m e
-autoescludersi	a u̯ t o e s k l u d e r s i
-autoestinguente	a u̯ t o e s t i n ɡ w ɛ n t e
-autoeterodina	a u̯ t o e t e r o d i n a
-autofagocitosi	a u̯ t o f a ɡ o t͡ʃ i t ɔ z i
-autofagosoma	a u̯ t o f a ɡ o s ɔ m a
-autofattura	a u̯ t o f a t t u r a
-autofecondazione	a u̯ t o f e k o n d a t t͡s j o n e
-autoferrotranviario	a u̯ t o f ɛ r r o t r a n v j a r j o
-autoferrotranviere	a u̯ t o f ɛ r r o t r a n v j ɛ r e
-autofertile	a u̯ t o f ɛ r t i l e
-autofertilizzante	a u̯ t o f e r t i l i d d͡z a n t e
-autofficina	a u̯ t o f f i t͡ʃ i n a
-autofilettante	a u̯ t o f i l e t t a n t e
-autofilotranviario	a u̯ t o f i l o t r a n v j a r j o
-autofinanziamento	a u̯ t o f i n a n t͡s j a m e n t o
-autofinanziarsi	a u̯ t o f i n a n t͡s j a r s i
-autoflagellazione	a u̯ t o f l a d͡ʒ e l l a t t͡s j o n e
-autofocus	a u̯ t o f ɔ k u s
-autofunebre	a u̯ t o f u n e b r e
-autointrospezione	a u̯ t o i n t r o s p e t t͡s j o n e
-autoistoradiografia	a u̯ t o i s t o r a d j o ɡ r a f i a
+auto	a u t o
+autoabbronzante	a u t o a b b r o n d͡z a n t e
+autoabbronzatura	a u t o a b b r o n d͡z a t u r a
+autoaccelerazione	a u t o a t t͡ʃ e l e r a t t͡s j o n e
+autoaccensione	a u t o a t t͡ʃ e n s j o n e
+autoaccessorio	a u t o a t t͡ʃ e s s ɔ r j o
+autoaccusa	a u t o a k k u z a
+autoaccusarsi	a u t o a k k u z a r s i
+autoadattante	a u t o a d a t t a n t e
+autoadescante	a u t o a d e s k a n t e
+autoadesivo	a u t o a d e z i v o
+autoaffermazione	a u t o a f f e r m a t t͡s j o n e
+autoaffondamento	a u t o a f f o n d a m e n t o
+autoaffondarsi	a u t o a f f o n d a r s i
+autoaggiornamento	a u t o a d d͡ʒ o r n a m e n t o
+autoaggiunto	a u t o a d d͡ʒ u n t o
+autoaggressivo	a u t o a ɡ ɡ r e s s i v o
+autoaiuto	a u t o a j u t o
+autoalienazione	a u t o a l j e n a t t͡s j o n e
+autoalimentarsi	a u t o a l i m e n t a r s i
+autoallergia	a u t o a l l e r d͡ʒ i a
+autoambulanza	a u t o a m b u l a n t͡s a
+autoanalisi	a u t o a n a l i z i
+autoanticorpo	a u t o a n t i k ɔ r p o
+autoantigene	a u t o a n t i d͡ʒ e n e
+autoapprendimento	a u t o a p p r e n d i m e n t o
+autoapprovvigionamento	a u t o a p p r o v v i d͡ʒ o n a m e n t o
+autoarticolato	a u t o a r t i k o l a t o
+autoassoluzione	a u t o a s s o l u t t͡s j o n e
+autoassolversi	a u t o a s s ɔ l v e r s i
+autobetoniera	a u t o b e t o n j ɛ r a
+autobiblioteca	a u t o b i b l j o t ɛ k a
+autobilanciato	a u t o b i l a n t͡ʃ a t o
+autobiografismo	a u t o b j o ɡ r a f i s m o
+autobiografo	a u t o b i ɔ ɡ r a f o
+autoblinda	a u t o b l i n d a
+autoblindato	a u t o b l i n d a t o
+autoblindomitragliatrice	a u t o b l i n d o m i t r a ʎ ʎ a t r i t͡ʃ e
+autobloccante	a u t o b l o k k a n t e
+autobomba	a u t o b o m b a
+autobotte	a u t o b o t t e
+autobruco	a u t o b r u k o
+autocalmiere	a u t o k a l m j ɛ r e
+autocalunnia	a u t o k a l u n n j a
+autocamionale	a u t o k a m j o n a l e
+autocampeggio	a u t o k a m p e d d͡ʒ o
+autocampionatore	a u t o k a m p j o n a t o r e
+autocancellazione	a u t o k a n t͡ʃ e l l a t t͡s j o n e
+autocaravan	a u t o k a r a v a n
+autocaricamento	a u t o k a r i k a m e n t o
+autocaricatura	a u t o k a r i k a t u r a
+autocasa	a u t o k a z a
+autocatalisi	a u t o k a t a l i z i
+autocateterismo	a u t o k a t e t e r i s m o
+autocelebrativo	a u t o t͡ʃ e l e b r a t i v o
+autocensura	a u t o t͡ʃ e n s u r a
+autocentrante	a u t o t͡ʃ e n t r a n t e
+autocentro	a u t o t͡ʃ ɛ n t r o
+autocercante	a u t o t͡ʃ e r k a n t e
+autocertificare	a u t o t͡ʃ e r t i f i k a r e
+autocertificativo	a u t o t͡ʃ e r t i f i k a t i v o
+autocertificato	a u t o t͡ʃ e r t i f i k a t o
+autocertificazione	a u t o t͡ʃ e r t i f i k a t t͡s j o n e
+autocestello	a u t o t͡ʃ e s t ɛ l l o
+autochiusura	a u t o k j u z u r a
+autocinema	a u t o t͡ʃ i n e m a
+autocingolato	a u t o t͡ʃ i n ɡ o l a t o
+autocisterna	a u t o t͡ʃ i s t ɛ r n a
+autocitarsi	a u t o t͡ʃ i t a r s i
+autocitazione	a u t o t͡ʃ i t a t t͡s j o n e
+autocivetta	a u t o t͡ʃ i v e t t a
+autoclastico	a u t o k l a s t i k o
+autocolonna	a u t o k o l o n n a
+autocombustione	a u t o k o m b u s t j o n e
+autocommento	a u t o k o m m e n t o
+autocommiserarsi	a u t o k o m m i z e r a r s i
+autocommiserazione	a u t o k o m m i z e r a t t͡s j o n e
+autocommutatore	a u t o k o m m u t a t o r e
+autocompattatore	a u t o k o m p a t t a t o r e
+autocompiacimento	a u t o k o m p j a t͡ʃ i m e n t o
+autoconcessionaria	a u t o k o n t͡ʃ e s s j o n a r j a
+autoconcessionario	a u t o k o n t͡ʃ e s s j o n a r j o
+autocondanna	a u t o k o n d a n n a
+autoconoscenza	a u t o k o n o ʃ ʃ ɛ n t͡s a
+autoconsapevolezza	a u t o k o n s a p e v o l e t t͡s a
+autoconservazione	a u t o k o n s e r v a t t͡s j o n e
+autoconsistente	a u t o k o n s i s t ɛ n t e
+autoconsistenza	a u t o k o n s i s t ɛ n t͡s a
+autoconsumo	a u t o k o n s u m o
+autocontrarre	a u t o k o n t r a r r e
+autocontrarsi	a u t o k o n t r a r s i
+autocontratto	a u t o k o n t r a t t o
+autocontrollo	a u t o k o n t r ɔ l l o
+autoconvincersi	a u t o k o n v i n t͡ʃ e r s i
+autoconvincimento	a u t o k o n v i n t͡ʃ i m e n t o
+autoconvoglio	a u t o k o n v ɔ ʎ ʎ o
+autocopiante	a u t o k o p j a n t e
+autocorrela	a u t o k o r r ɛ l a
+autocorrelare	a u t o k o r r e l a r e
+autocorrelazione	a u t o k o r r e l a t t͡s j o n e
+autocorrezione	a u t o k o r r e t t͡s j o n e
+autocorriera	a u t o k o r r j ɛ r a
+autocosciente	a u t o k o ʃ ʃ ɛ n t e
+autocoscienza	a u t o k o ʃ ʃ ɛ n t͡s a
+autocritica	a u t o k r i t i k a
+autocritico	a u t o k r i t i k o
+autocross	a u t o k r ɔ s
+autocura	a u t o k u r a
+autodafé	a u t o d a f e
+autodecisione	a u t o d e t͡ʃ i z j o n e
+autodefinizione	a u t o d e f i n i t t͡s j o n e
+autodemolitore	a u t o d e m o l i t o r e
+autodemolizione	a u t o d e m o l i t t͡s j o n e
+autodenuncia	a u t o d e n u n t͡ʃ a
+autodenunciarsi	a u t o d e n u n t͡ʃ a r s i
+autodeterminato	a u t o d e t e r m i n a t o
+autodeterminazione	a u t o d e t e r m i n a t t͡s j o n e
+autodiagnosi	a u t o d i a ɲ ɲ o z i
+autodiagnostica	a u t o d j a ɲ ɲ ɔ s t i k a
+autodichiarare	a u t o d i k j a r a r e
+autodichiararsi	a u t o d i k j a r a r s i
+autodichiarato	a u t o d i k j a r a t o
+autodichiarazione	a u t o d i k j a r a t t͡s j o n e
+autodidatta	a u t o d i d a t t a
+autodidattico	a u t o d i d a t t i k o
+autodidattismo	a u t o d i d a t t i s m o
+autodifesa	a u t o d i f e z a
+autodigestione	a u t o d i d͡ʒ e s t j o n e
+autodina	a u t o d i n a
+autodirezionale	a u t o d i r e t t͡s j o n a l e
+autodistribuito	a u t o d i s t r i b u i t o
+autodistruggersi	a u t o d i s t r u d d͡ʒ e r s i
+autodonazione	a u t o d o n a t t͡s j o n e
+autoeccitante	a u t o e t t͡ʃ i t a n t e
+autoeccitarsi	a u t o e t t͡ʃ i t a r s i
+autoeccitazione	a u t o e t t͡ʃ i t a t t͡s j o n e
+autoecologia	a u t o e k o l o d͡ʒ i a
+autoeditore	a u t o e d i t o r e
+autoeditoria	a u t o e d i t o r i a
+autoeducazione	a u t o e d u k a t t͡s j o n e
+autoefficacia	a u t o e f f i k a t͡ʃ a
+autoemarginazione	a u t o e m a r d͡ʒ i n a t t͡s j o n e
+autoemoteca	a u t o e m o t ɛ k a
+autoemoterapia	a u t o e m o t e r a p i a
+autoemotrasfusione	a u t o e m o t r a s f u z j o n e
+autoerotico	a u t o e r ɔ t i k o
+autoerotismo	a u t o e r o t i s m o
+autoesaltazione	a u t o e z a l t a t t͡s j o n e
+autoesame	a u t o e z a m e
+autoescludersi	a u t o e s k l u d e r s i
+autoestinguente	a u t o e s t i n ɡ w ɛ n t e
+autoeterodina	a u t o e t e r o d i n a
+autofagocitosi	a u t o f a ɡ o t͡ʃ i t ɔ z i
+autofagosoma	a u t o f a ɡ o s ɔ m a
+autofattura	a u t o f a t t u r a
+autofecondazione	a u t o f e k o n d a t t͡s j o n e
+autoferrotranviario	a u t o f ɛ r r o t r a n v j a r j o
+autoferrotranviere	a u t o f ɛ r r o t r a n v j ɛ r e
+autofertile	a u t o f ɛ r t i l e
+autofertilizzante	a u t o f e r t i l i d d͡z a n t e
+autofficina	a u t o f f i t͡ʃ i n a
+autofilettante	a u t o f i l e t t a n t e
+autofilotranviario	a u t o f i l o t r a n v j a r j o
+autofinanziamento	a u t o f i n a n t͡s j a m e n t o
+autofinanziarsi	a u t o f i n a n t͡s j a r s i
+autoflagellazione	a u t o f l a d͡ʒ e l l a t t͡s j o n e
+autofocus	a u t o f ɔ k u s
+autofunebre	a u t o f u n e b r e
+autointrospezione	a u t o i n t r o s p e t t͡s j o n e
+autoistoradiografia	a u t o i s t o r a d j o ɡ r a f i a
 automatica	a u t o m a t i k a
 automatiche	a u t o m a t i k e
 automatici	a u t o m a t i t͡ʃ i
@@ -1701,15 +1701,15 @@ automatico	a u t o m a t i k o
 automato	a u t o m a t o
 automobile	a u t o m ɔ b i l e
 automorfismo	a u t o m o r f i z m o
-autoplastica	a u̯ t o p l a s t i k a
-autoplastico	a u̯ t o p l a s t i k o
+autoplastica	a u t o p l a s t i k a
+autoplastico	a u t o p l a s t i k o
 autore	a u t o r e
 autorevole	a u t o r e v o l e
-autorità	a u̯ t o r i t a
-autoschediastico	a u̯ t o s k e d j a s t i k o
+autorità	a u t o r i t a
+autoschediastico	a u t o s k e d j a s t i k o
 autovelox	a u t o v ɛ l o k s
 autrice	a u t r i t͡ʃ e
-autunno	a u̯ t u n n o
+autunno	a u t u n n o
 avaccio	a v a t t͡ʃ o
 avallo	a v a l l o
 avana	a v a n a
@@ -2360,7 +2360,7 @@ bottone	b o t t o n e
 bovaro	b o v a r o
 bovino	b o v i n o
 boy	b ɔ i
-boyscout	b o i̯ s k a u̯ t
+boyscout	b o i s k a u t
 bozza	b ɔ t t s a
 bracare	b r a k a r e
 bracchetto	b r a k k e t t o
@@ -3020,7 +3020,7 @@ catena	k a t e n a
 catenaccio	k a t e n a t t ʃ o
 catenare	k a t e n a r e
 catenato	k a t e n a t o
-catenoide	k a t e n ɔ i̯ d e
+catenoide	k a t e n ɔ i d e
 catilina	k a t i l i n a
 catilinaria	k a t i l i n a r j a
 catilinario	k a t i l i n a r j o
@@ -3036,20 +3036,20 @@ cattolica	k a t t o l i k a
 cattoliche	k a t t o l i k e
 cattolici	k a t t o l i t͡ʃ i
 cattolico	k a t t o l i k o
-caudio	k a u̯ d j o
-caudium	k a u̯ d j u m
-caulerpa	k a u̯ l ɛ r p a
-causale	k a u̯ z a l e
-causalismo	k a u̯ z a l i s m o
-causalista	k a u̯ z a l i s t a
-causalistico	k a u̯ z a l i s t i k o
-causatore	k a u̯ z a t o r e
-causatrice	k a u̯ z a t r i t͡ʃ e
-causazione	k a u̯ z a t t͡s j o n e
-cautamente	k a u̯ t a m e n t e
-cauterio	k a u̯ t ɛ r j o
-cauto	k a u̯ t o
-cauzione	k a u̯ t t͡s j o n e
+caudio	k a u d j o
+caudium	k a u d j u m
+caulerpa	k a u l ɛ r p a
+causale	k a u z a l e
+causalismo	k a u z a l i s m o
+causalista	k a u z a l i s t a
+causalistico	k a u z a l i s t i k o
+causatore	k a u z a t o r e
+causatrice	k a u z a t r i t͡ʃ e
+causazione	k a u z a t t͡s j o n e
+cautamente	k a u t a m e n t e
+cauterio	k a u t ɛ r j o
+cauto	k a u t o
+cauzione	k a u t t͡s j o n e
 cavafango	k a v a f a n ɡ o
 cavalleresco	k a v a l l e r e s k o
 cavallo	k a v a lː o
@@ -3461,13 +3461,13 @@ clarino	k l a r i n o
 classe	k l a s s e
 classicistico	k l a s s i t͡ʃ i s t i k o
 classico	k l a s s i k o
-claudicante	k l a u̯ d i k a n t e
-claudicare	k l a u̯ d i k a r e
-claustro	k l a u̯ s t r o
-claustrofilia	k l a u̯ s t r o f i l i a̯
-claustrofilo	k l a u̯ s t r ɔ f i l o
-claustrofobia	k l a u̯ s t r o f o b i a̯
-claustrofobico	k l a u̯ s t r o f ɔ b i k o
+claudicante	k l a u d i k a n t e
+claudicare	k l a u d i k a r e
+claustro	k l a u s t r o
+claustrofilia	k l a u s t r o f i l i a̯
+claustrofilo	k l a u s t r ɔ f i l o
+claustrofobia	k l a u s t r o f o b i a̯
+claustrofobico	k l a u s t r o f ɔ b i k o
 clausura	k l a u z u r a
 clemente	k l e m ɛ n t e
 clementina	k l e m e n t i n a
@@ -3478,7 +3478,7 @@ cliente	k l i ɛ n t e
 clientela	k l j e n t ɛ l a
 clima	k l i m a
 climatico	k l i m a t i k o
-climb	k l a i̯ m b
+climb	k l a i m b
 clinica	k l i n i k a
 clinico	k l i n i k o
 clivo	k l i v o
@@ -3487,7 +3487,7 @@ clonazione	k l o n a t͡s j o n e
 clone	k l o n e
 cloro	k l ɔ r o
 cloroprene	k l o r o p r ɛ n e
-clotoide	k l o t ɔ i̯ d e
+clotoide	k l o t ɔ i d e
 club	k l a b
 club	k l ɛ b
 clune	k l u n e
@@ -4190,7 +4190,7 @@ cuna	k u n a
 cuneense	k u n e ɛ n s e
 cuneese	k u n e e s e
 cuneese	k u n e e z e
-cuneiforme	k u n e i̯ f o r m e
+cuneiforme	k u n e i f o r m e
 cuneo	k u n e o
 cunicolo	k u n i k o l o
 cunta	k u n t a
@@ -4265,7 +4265,7 @@ danzica	d a n t s i k a
 dape	d a p e
 dappertutto	d a p p e r t u t t o
 dappoco	d a p p ɔ k o
-dappoiché	d a p p o i̯ k e
+dappoiché	d a p p o i k e
 dappresso	d a pː r e sː o
 darabukka	d a r a b u k k a
 dardano	d a r d a n o
@@ -4354,8 +4354,8 @@ deh	d ɛ
 dei	d e i
 dei	d ɛ i
 deianira	d e j a n i r a
-deicida	d e i̯ t͡ʃ i d a
-deiforme	d e i̯ f o r m e
+deicida	d e i t͡ʃ i d a
+deiforme	d e i f o r m e
 deimos	d e i m o s
 deitade	d e i t a d e
 deitate	d e i t a t e
@@ -4489,7 +4489,7 @@ dettagliato	d e t t a ʎ ʎ a t o
 dettaglio	d e t t a ʎ ʎ o
 dettare	d e t t a r e
 deturperemo	d e t u r p e r e m o
-deuteragonista	d e u̯ t e r a ɡ o n i s t a
+deuteragonista	d e u t e r a ɡ o n i s t a
 devanagari	d e v a n a ɡ a r i
 devastazione	d e v a s t a t t͡s j o n e
 deve	d ɛ v e
@@ -5004,7 +5004,7 @@ ebro	ɛ b r o
 ebulliometro	e b u l l j ɔ m e t r o
 ecatombe	e k a t o m b e
 ecatostilo	e k a t ɔ s t i l o
-ecceità	e t t͡ʃ e i̯ t a
+ecceità	e t t͡ʃ e i t a
 eccellente	e t t͡ʃ e l l ɛ n t e
 eccellenza	e t t͡ʃ e l l ɛ n t͡s a
 eccellere	e t t͡ʃ ɛ l l e r e
@@ -5105,9 +5105,9 @@ egualità	e ɡ w a l i t a
 egualizzare	e ɡ w a l i d d͡z a r e
 ehi	e i
 ehilà	e i l ä
-ei	e i̯
+ei	e i
 einsteiniano	a i n s t a i n j a n o
-einsteinio	a i̯ n s t a i̯ n j o
+einsteinio	a i n s t a i n j o
 einstenio	a i n s t ɛ n j o
 el	e l
 elaborare	e l a b o r a r e
@@ -5145,7 +5145,7 @@ elevato	e l e v a t o
 elfo	ɛ l f o
 elica	ɛ l i k a
 eliche	ɛ l i k e
-elicoide	e l i k ɔ i̯ d e
+elicoide	e l i k ɔ i d e
 elicotteristico	e l i k o t t e r i s t i k o
 elicottero	e l i k ɔ t t e r o
 eliminazione	e l i m i n a t t͡s j o n e
@@ -5185,7 +5185,7 @@ emanare	e m a n a r e
 emanatistico	e m a n a t i s t i k o
 emanazione	e m a n a t t͡s j o n e
 emancipazione	e m a n t͡ʃ i p a t t͡s j o n e
-ematoide	e m a t ɔ i̯ d e
+ematoide	e m a t ɔ i d e
 ematologia	e m a t o l o d͡ʒ i a
 emberiza	e m b e r i d d͡z a
 emblematico	e m b l e m a t i k o
@@ -5383,10 +5383,10 @@ esattezza	e z a t t e t t͡s a
 esatto	e z a t t o
 esauriente	e z a u r j ɛ n t e
 esaurimento	e z a u r i m e n t o
-esaurire	e z a u̯ r i r e
-esaurirsi	e z a u̯ r i r s i
+esaurire	e z a u r i r e
+esaurirsi	e z a u r i r s i
 esaurito	e z a u r i t o
-esautorare	e z a u̯ t o r a r e
+esautorare	e z a u t o r a r e
 esaù	e s a u
 esaù	e z a u
 esborso	e s b o r s o
@@ -5550,15 +5550,15 @@ etterno	e t t ɛ r n o
 età	e t a
 euclideo	e u k l i d ɛ o
 euforia	e u f o r i a
-euglena	e u̯ ɡ l ɛ n a
-eureka	ɛ u̯ r e k a
-euro	ɛ u̯ r o
+euglena	e u ɡ l ɛ n a
+eureka	ɛ u r e k a
+euro	ɛ u r o
 europa	e u r ɔ p a
 europea	e u r o p ɛ a
 europeo	e u r o p ɛ o
 europio	e u r ɔ p j o
-eurozona	ɛ u̯ r o d͡z ɔ n a
-euterpe	e u̯ t ɛ r p e
+eurozona	ɛ u r o d͡z ɔ n a
+euterpe	e u t ɛ r p e
 evadere	e v a d e r e
 evangelico	e v a n d͡ʒ ɛ l i k o
 evangelista	e v a n d͡ʒ e l i s t a
@@ -5742,7 +5742,7 @@ feci	f ɛ t͡ʃ i
 fecondità	f e k o n d i t a
 fecondo	f e k o n d o
 feda	f ɛ d a
-fedai	f e d a i̯
+fedai	f e d a i
 fedammo	f e d a m m o
 fedano	f ɛ d a n o
 fedare	f e d a r e
@@ -5766,7 +5766,7 @@ fededegno	f e d e d e ɲ ɲ o
 fedele	f e d e l e
 fedelmente	f e d e l m e n t e
 fedeltà	f e d e l t a
-federai	f e d e r a i̯
+federai	f e d e r a i
 federale	f e d e r a l e
 federalismo	f e d e r a l i s m o
 federalista	f e d e r a l i s t a
@@ -5780,7 +5780,7 @@ federato	f e d e r a t o
 federazione	f e d e r a t t͡s j o n e
 federebbe	f e d e r e b b e
 federebbero	f e d e r e b b e r o
-federei	f e d e r ɛ i̯
+federei	f e d e r ɛ i
 federemmo	f e d e r e m m o
 federemo	f e d e r e m o
 federeste	f e d e r e s t e
@@ -5837,7 +5837,7 @@ fero	f ɛ r o
 feroce	f e r o t͡ʃ e
 ferocissimo	f e r o t͡ʃ i s s i m o
 feroese	f e r o e z e
-feroico	f e r ɔ i̯ k o
+feroico	f e r ɔ i k o
 ferramenta	f e r r a m e n t a
 ferrara	f e r r a r a
 ferreo	f ɛ rː e o
@@ -6157,7 +6157,7 @@ fragno	f r a ɲ ɲ o
 fragola	f r a ɡ o l a
 fragore	f r a ɡ o r e
 fragrante	f r a ɡ r a n t e
-fraile	f r a i̯ l e
+fraile	f r a i l e
 fraintendere	f r a i n t ɛ n d e r e
 frale	f r a l e
 francesca	f r a n t ʃ e s k a
@@ -6228,7 +6228,7 @@ frusta	f r u s t a
 frustare	f r u s t a r e
 frusto	f r u s t o
 frustra	f r u s t r a
-frustraneità	f r u s t r a n e i̯ t a
+frustraneità	f r u s t r a n e i t a
 frustraneo	f r u s t r a n e̯ o
 frustrante	f r u s t r a n t e
 frustrare	f r u s t r a r e
@@ -6387,7 +6387,7 @@ gattinara	ɡ a t t i n a r a
 gattinarese	ɡ a t t i n a r e s e
 gatto	ɡ a t t o
 gattuccio	ɡ a t t u t t͡ʃ o
-gaulo	ɡ a u̯ l o
+gaulo	ɡ a u l o
 gavazzare	ɡ a v a t t͡s a r e
 gavetta	ɡ a v e t t a
 gavigliano	ɡ a v i ʎ a n o
@@ -6435,7 +6435,7 @@ gente	d ʒ ɛ n t e
 genti	d͡ʒ ɛ n t i
 gentileschi	d͡ʒ e n t i l e s k i
 geografia	d ʒ e o ɡ r a f i a
-geoide	d͡ʒ e ɔ i̯ d e
+geoide	d͡ʒ e ɔ i d e
 georgia	d͡ʒ e ɔ r d͡ʒ a
 geppetto	d͡ʒ e p p e t t o
 gerarca	d͡ʒ e r a r k a
@@ -6513,7 +6513,7 @@ giallognolo	d ʒ a l l ɔ ɲ ɲ o l o
 giallone	d͡ʒ a l l o n e
 giamaicano	d͡ʒ a m a i k a n o
 giambo	d͡ʒ a m b o
-giammai	d͡ʒ a m m a i̯
+giammai	d͡ʒ a m m a i
 gian	d͡ʒ a n
 gianduia	d ʒ a n d u j a
 gianduiotto	d ʒ a n d u j ɔ t t o
@@ -6938,7 +6938,7 @@ guantato	ɡ w a n t a t o
 guanto	ɡ w a n t o
 guardabarriere	ɡ w a r d a b a r r j ɛ r e
 guardaboschi	ɡ w a r d a b ɔ s k i
-guardabuoi	ɡ w a r d a b w ɔ i̯
+guardabuoi	ɡ w a r d a b w ɔ i
 guardacaccia	ɡ w a r d a k a t t͡ʃ a
 guardalinee	ɡ w a r d a l i n e e̯
 guardapecore	ɡ w a r d a p ɛ k o r e
@@ -6952,7 +6952,7 @@ guardiano	ɡ w a r d j a n o
 guardiola	ɡ w a r d j o l a
 guardo	ɡ w a r d o
 guardolo	ɡ w a r d o l o
-guardrail	ɡ a r d r ɛ i̯ l
+guardrail	ɡ a r d r ɛ i l
 guargango	ɡ w a r ɡ a n ɡ o
 guarigione	ɡ w a r i d͡ʒ o n e
 guarnigione	ɡ w a r n i d͡ʒ o n e
@@ -7002,7 +7002,7 @@ göteborg	ɡ ø t e b ɔ r ɡ
 h	a k k a
 ha	a
 hackerare	a k e r a r e
-hai	a i̯
+hai	a i
 hallalì	a l l a l i
 halloween	a l l o w i n
 hamburger	a m b u r ɡ e r
@@ -7110,7 +7110,7 @@ imbelle	i m b ɛ l l e
 imberbe	i m b ɛ r b e
 imbevere	i m b e v e r e
 imbianchino	i m b j a n k i n o
-imbottatoi	i m b o t t a t o i̯
+imbottatoi	i m b o t t a t o i
 imbottatoia	i m b o t t a t o j a
 imbottatoie	i m b o t t a t o j e
 imbottatoio	i m b o t t a t o j o
@@ -7941,7 +7941,7 @@ lattugaccio	l a t t u ɡ a t t͡ʃ o
 lattughella	l a t t u ɡ ɛ l l a
 lattughetta	l a t t u ɡ e t t a
 lattughina	l a t t u ɡ i n a
-lauda	l a u̯ d a
+lauda	l a u d a
 laurea	l a u r e a
 laurenzio	l a u r ɛ n t s j o
 lauroceraso	l a u r o t͡ʃ e r a z o
@@ -8039,7 +8039,7 @@ lettere	l ɛ t t e r e
 lettone	l e t t o n e
 lettone	l ɛ t t o n e
 lettore	l e t t o r e
-leucoblastico	l e u̯ k o b l a s t i k o
+leucoblastico	l e u k o b l a s t i k o
 levante	l e v a n t e
 levatura	l e v a t u r a
 levigatura	l e v i ɡ a t u r a
@@ -8109,7 +8109,7 @@ linguine	l i n ɡ w i n e
 linguistica	l i n ɡ w i s t i k a
 linguolabiale	l i n ɡ w o l a b j a l e
 lino	l i n o
-linoleum	l i n ɔ l e u̯ m
+linoleum	l i n ɔ l e u m
 liocorno	l j o k ɔ r n o
 lione	l j o n e
 lipedema	l i p e d ɛ m a
@@ -8610,7 +8610,7 @@ melodia	m e l o d i a
 melodiare	m e l o d j a r e
 melodico	m e l ɔ d i k o
 melofo	m e l ɔ f o
-meloide	m e l ɔ i̯ d e
+meloide	m e l ɔ i d e
 melos	m ɛ l o s
 mem	m e m
 membro	m ɛ m b r o
@@ -8969,8 +8969,8 @@ motorino	m o t o r i n o
 motrice	m o t r i t͡ʃ e
 motta	m ɔ t t a
 motto	m ɔ t t o
-mouse	m a u̯ s
-mouse	m a u̯ z
+mouse	m a u s
+mouse	m a u z
 movida	m o v i d a
 mozza	m o t t͡s a
 mozzare	m o t t͡s a r e
@@ -9108,8 +9108,8 @@ naturale	n a t u r a l e
 naturalista	n a t u r a l i s t a
 naturalità	n a t u r a l i t a
 naturista	n a t u r i s t a
-naufragio	n a u̯ f r a d͡ʒ o
-nautico	n a u̯ t i k o
+naufragio	n a u f r a d͡ʒ o
+nautico	n a u t i k o
 nautilo	n ɔ t i l o
 navale	n a v a l e
 navalestro	n a v a l ɛ s t r o
@@ -9173,7 +9173,7 @@ necrotrofia	n e k r o t r o f i a̯
 necrotrofismo	n e k r o t r o f i s m o
 necrotrofo	n e k r ɔ t r o f o
 nectocalice	n e k t o k a l i t͡ʃ e
-nectozoide	n e k t o d͡z ɔ i̯ d e
+nectozoide	n e k t o d͡z ɔ i d e
 ned	n e d
 negare	n e ɡ a r e
 negarit	n e ɡ a r i t
@@ -9232,12 +9232,12 @@ nettarofago	n e t t a r ɔ f a ɡ o
 nettaroteca	n e t t a r o t ɛ k a
 nettarovia	n e t t a r o v i a̯
 netto	n e t t o
-nettozoide	n e t t o d͡z ɔ i̯ d e
+nettozoide	n e t t o d͡z ɔ i d e
 nettunia	n e t t u n j a
 nettunio	n e t t u n j o
 nettuno	n e t t u n o
 neuno	n e u n o
-neuroscheletro	n ɛ u̯ r o s k ɛ l e t r o
+neuroscheletro	n ɛ u r o s k ɛ l e t r o
 neutro	n ɛ u t r o
 nevada	n e v a d a
 nevaio	n e v a j o
@@ -9272,7 +9272,7 @@ nietzschiano	n i t t ʃ a n o
 nievo	n j ɛ v o
 nigeria	n i d͡ʒ ɛ r j a
 nigeriano	n i d͡ʒ e r j a n o
-night	n a i̯ t
+night	n a i t
 nilde	n i l d e
 nilo	n i l o
 nilota	n i l ɔ t a
@@ -9487,7 +9487,7 @@ odiosamente	o d j o z a m e n t e
 odiosità	o d j o z i t a
 odioso	o d j o z o
 odocelo	o d o t͡ʃ ɛ l o
-odocoileo	o d o k o i̯ l ɛ o
+odocoileo	o d o k o i l ɛ o
 odontoblastico	o d o n t o b l a s t i k o
 odor	o d o r
 odorante	o d o r a n t e
@@ -9519,7 +9519,7 @@ offrì	o f f r i
 ofide	o f i d e
 oggetto	o d d ʒ ɛ t t o
 oggi	ɔ d d͡ʒ i
-oggimai	o d d͡ʒ i m a i̯
+oggimai	o d d͡ʒ i m a i
 ogne	o ɲ e
 ogni	o ɲ i
 ogni	ɔ ɲ i
@@ -9530,7 +9530,7 @@ ognuno	o ɲ ɲ u n o
 ohilà	o i l a
 ohimè	o i m ɛ
 ohio	o a j o
-oinochoe	o i̯ n o k ɔ e
+oinochoe	o i n o k ɔ e
 oklahoma	o k l a ɔ m a
 olanda	o l a n d a
 oleandolo	o l e a n d o l o
@@ -9705,7 +9705,7 @@ organizzare	o r ɡ a n i d d͡z a r e
 organizzarsi	o r ɡ a n i d͡ː z a r s i
 organizzazione	o r ɡ a n i d d͡z a t t͡s j o n e
 organo	ɔ r ɡ a n o
-organoide	o r ɡ a n ɔ i̯ d e
+organoide	o r ɡ a n ɔ i d e
 orgia	ɔ r d͡ʒ a
 orgiastico	o r d͡ʒ a s t i k o
 orgoglio	o r ɡ o ʎ ʎ o
@@ -9882,7 +9882,7 @@ pagliaccio	p a ʎ ʎ a t t ʃ o
 pagliata	p a ʎ ʎ a t a
 pago	p a ɡ o
 pagoda	p a ɡ ɔ d a
-paidire	p a i̯ d i r e
+paidire	p a i d i r e
 paio	p a j o
 paiolo	p a j ɔ l o
 paladina	p a l a d i n a
@@ -9940,7 +9940,7 @@ pandispagna	p a n d i s p a ɲ ɲ a
 pandolo	p a n d o l o
 pandoro	p a n d ɔ r o
 pane	p a n e
-panenteismo	p a n e n t e i̯ s m o
+panenteismo	p a n e n t e i s m o
 panettiere	p a n e t t j ɛ r e
 panettone	p a n e t t o n e
 pania	p a n j a
@@ -10488,7 +10488,7 @@ plasticità	p l a s t i t͡ʃ i t a
 plastico	p l a s t i k o
 platina	p l a t i n a
 platino	p l a t i n o
-plausibile	p l a u̯ z i b i l e
+plausibile	p l a u z i b i l e
 playback	p l ɛ i b e k
 playback	p l ɛ i b ɛ k
 plebaglia	p l e b a ʎ a
@@ -10834,7 +10834,7 @@ principio	p r i n t͡ʃ i p j o
 principî	p r i n t͡ʃ i p i
 priscione	p r i ʃ o n e
 prisco	p r i s k o
-prismoide	p r i s m ɔ i̯ d e
+prismoide	p r i s m ɔ i d e
 privacy	p r a i v a s i
 privato	p r i v a t o
 privilegio	p r i v i l ɛ d͡ʒ o
@@ -10939,7 +10939,7 @@ protoclasi	p r ɔ t o k l a z i
 protoclastico	p r o t o k l a s t i k o
 protocollare	p r o t o k o l l a r e
 protocollo	p r o t o k ɔ l l o
-protocuneiforme	p r ɔ t o k u n e i̯ f o r m e
+protocuneiforme	p r ɔ t o k u n e i f o r m e
 protrarre	p r o t r a r r e
 protrudere	p r o t r u d e r e
 proustiano	p r u s t j a n o
@@ -10957,14 +10957,14 @@ provocazione	p r o v o k a t͡s j o n e
 prudere	p r u d e r e
 prugna	p r u ɲ ɲ a
 prugnola	p r u ɲ ɲ o l a
-prulaurasina	p r u l a u̯ r a z i n a
+prulaurasina	p r u l a u r a z i n a
 prunasina	p r u n a z i n a
 pruova	p r w ɔ v a
 prurito	p r u r i t o
 pseudoanglicismo	p s e u d o a n ɡ l i t͡ʃ i z m o
-pseudocupola	p s ɛ u̯ d o k u p o l a
-pseudopecora	p s ɛ u̯ d o p ɛ k o r a
-pseudopecore	p s ɛ u̯ d o p ɛ k o r e
+pseudocupola	p s ɛ u d o k u p o l a
+pseudopecora	p s ɛ u d o p ɛ k o r a
+pseudopecore	p s ɛ u d o p ɛ k o r e
 psiche	p s i k e
 psichedelia	p s i k e d e l i a
 psichedelico	p s i k e d ɛ l i k o
@@ -11199,12 +11199,12 @@ raggiungere	r a d d͡ʒ u n d͡ʒ e r e
 ragione	r a d͡ʒ o n e
 ragnatela	r a ɲ ɲ a t e l a
 ragno	r a ɲ ɲ o
-ragoideo	r a ɡ o i̯ d ɛ o
+ragoideo	r a ɡ o i d ɛ o
 ragutiera	r a ɡ u t j ɛ r a
 ragù	r a ɡ u
-rai	r a i̯
-raiba	r a i̯ b a
-raimondo	r a i̯ m o n d o
+rai	r a i
+raiba	r a i b a
+raimondo	r a i m o n d o
 rais	r a i s
 ramaia	r a m a j a
 rame	r a m e
@@ -11381,7 +11381,7 @@ respiro	r e s p i r o
 responsabile	r e s p o n s a b i l e
 responsabilità	r e s p o n s a b i l i t a
 restare	r e s t a r e
-restaurare	r e s t a u̯ r a r e
+restaurare	r e s t a u r a r e
 resto	r ɛ s t o
 resurgere	r e s u r d͡ʒ e r e
 retaggio	r e t a d d͡ʒ o
@@ -11412,7 +11412,7 @@ retto	r ɛ tː o
 rettore	r e tː o r e
 rettoressa	r e t t o r e s s a
 rettovescicale	r e tː o v e ʃ i k a l e
-reuma	r ɛ u̯ m a
+reuma	r ɛ u m a
 revanscismo	r e v a n ʃ i z m o
 revisionista	r e v i z j o n i s t a
 revoca	r ɛ v o k a
@@ -11901,7 +11901,7 @@ sarcofago	s a r k ɔ f a ɡ o
 sardegna	s a r d e ɲ ɲ a
 sardesco	s a r d e s k o
 sardina	s a r d i n a
-sarei	s a r ɛ i̯
+sarei	s a r ɛ i
 sargasso	s a r ɡ a s s o
 sargia	s a r d͡ʒ a
 sargo	s a r ɡ o
@@ -12101,7 +12101,7 @@ schivata	s k i v a t a
 schivezza	s k i v e t t͡s a
 schivo	s k i v o
 schizzo	s k i t t͡s o
-schoenbekooievaar	s x u n b ɛ k oː i̯ ə v aː r
+schoenbekooievaar	s x u n b ɛ k oː i ə v aː r
 schopenhaueriano	ʃ o p e n a w e r j a n o
 sci	ʃ i
 scia	ʃ i a
@@ -12235,7 +12235,7 @@ scottadito	s k ɔ t t a d i t o
 scottare	s k o t t a r e
 scottarsi	s k o t t a r s i
 scotto	s k ɔ t t o
-scout	s k a u̯ t
+scout	s k a u t
 scozia	s k ɔ t t s j a
 scozzese	s k o t t͡s e z e
 screda	s k r e d a
@@ -12886,14 +12886,14 @@ sparto	s p a r t o
 spaso	s p a z o
 spatola	s p a t o l a
 spatolare	s p a t o l a r e
-spauracchio	s p a u̯ r a k k j o
-spaurare	s p a u̯ r a r e
-spaurarsi	s p a u̯ r a r s i
-spaurato	s p a u̯ r a t o
-spaurevole	s p a u̯ r e v o l e
-spaurimento	s p a u̯ r i m e n t o
-spaurire	s p a u̯ r i r e
-spaurito	s p a u̯ r i t o
+spauracchio	s p a u r a k k j o
+spaurare	s p a u r a r e
+spaurarsi	s p a u r a r s i
+spaurato	s p a u r a t o
+spaurevole	s p a u r e v o l e
+spaurimento	s p a u r i m e n t o
+spaurire	s p a u r i r e
+spaurito	s p a u r i t o
 spaventapasseri	s p a v ɛ n t a p a s s e r i
 spaventare	s p a v e n t a r e
 spazializzare	s p a t t͡s j a l i d d͡z a r e
@@ -13460,9 +13460,9 @@ tassobarbasso	t a s s o b a r b a s s o
 tassì	t a s s i
 tasto	t a s t o
 tattica	t a t t i k a
-tauro	t a u̯ r o
-tautocronismo	t a u̯ t o k r o n i s m o
-tautocrono	t a u̯ t ɔ k r o n o
+tauro	t a u r o
+tautocronismo	t a u t o k r o n i s m o
+tautocrono	t a u t ɔ k r o n o
 taverna	t a v ɛ r n a
 tavernaia	t a v e r n a j a
 taxi	t a k s i
@@ -13761,7 +13761,7 @@ tossicologo	t o sː i k ɔ l o ɡ o
 tossire	t o s s i r e
 tossitore	t o s s i t o r e
 tossizeismo	t o s s i d͡z e̯ i s m o
-tossoide	t o s s ɔ i̯ d e
+tossoide	t o s s ɔ i d e
 tosto	t ɔ s t o
 totale	t o t a l e
 totalitario	t o t a l i t a r j o
@@ -14072,7 +14072,7 @@ tundra	t u n d r a
 tungsteno	t u n s t ɛ n o
 tungsteno	t u ŋ ɡ s t ɛ n o
 tunnel	t u n n e l
-tuono	t u̯ ɔ n o
+tuono	t u ɔ n o
 turbare	t u r b a r e
 turbazione	t u r b a t t͡s j o n e
 turchia	t u r k i a
@@ -14383,7 +14383,7 @@ vastissimo	v a s t i s s i m o
 vastità	v a s t i t a
 vasto	v a s t o
 vate	v a t e
-vau	v a u̯
+vau	v a u
 ve	v e
 vecchi	v e k k i
 vecchi	v ɛ k k i
@@ -14609,7 +14609,7 @@ vicissitudine	v i t͡ʃ i s s i t u d i n e
 vico	v i k o
 vicolo	v i k o l o
 video	v i d e o
-videogame	v i d e̯ o ɡ e i̯ m
+videogame	v i d e̯ o ɡ e i m
 videotelefona	v i d e̯ o t e l ɛ f o n a
 videotelefonano	v i d e̯ o t e l ɛ f o n a n o
 videotelefonare	v i d e̯ o t e l e f o n a r e
@@ -14802,7 +14802,7 @@ vostro	v ɔ s t r o
 votante	v o t a n t e
 votare	v o t a r e
 votiaco	v o t j a k o
-voucher	v a u̯ t͡ʃ e r
+voucher	v a u t͡ʃ e r
 vu	v u
 vudu	v u d u
 vuduismo	v u d u i s m o
@@ -14930,7 +14930,7 @@ zeppa	t s e p p a
 zeppola	t s e p p o l a
 zero	d͡z ɛ r o
 zeta	d͡z ɛ t a
-zeugma	d͡z ɛ u̯ ɡ m a
+zeugma	d͡z ɛ u ɡ m a
 zia	t͡s i a
 zibaldone	d z i b a l d o n e
 zigaia	d͡z i ɡ a j a

--- a/data/scrape/tsv/ita_latn_broad_filtered.tsv
+++ b/data/scrape/tsv/ita_latn_broad_filtered.tsv
@@ -240,7 +240,7 @@ abusare	a b u z a r e
 abuso	a b u z o
 acacia	a k a t͡ʃ a
 acagiù	a k a d͡ʒ u
-acaico	a k a i̯ k o
+acaico	a k a i k o
 acalefa	a k a l ɛ f a
 acalefe	a k a l ɛ f e
 acalifa	a k a l i f a
@@ -568,7 +568,7 @@ ai	a i
 aiere	a j e r e
 ailuride	a i l u r i d e
 ailuridi	a i l u r i d i
-ailuro	a i̯ l u r o
+ailuro	a i l u r o
 ailurofobia	a i l u r o f o b i a
 ain	a j n
 aire	a i r e
@@ -632,7 +632,7 @@ alfa	a l f a
 alfabeti	a l f a b ɛ t i
 alfabetico	a l f a b ɛ t i k o
 alfabeto	a l f a b ɛ t o
-alfeide	a l f ɛ i̯ d e
+alfeide	a l f ɛ i d e
 alfiere	a l f j ɛ r e
 alga	a l ɡ a
 algarello	a l ɡ a r ɛ l l o
@@ -930,7 +930,7 @@ andreottiana	a n d r e o t t j a n a
 andreottiano	a n d r e o t t j a n o
 androceo	a n d r o t ʃ ɛ o
 androconio	a n d r o k ɔ n j o
-androide	a n d r ɔ i̯ d e
+androide	a n d r ɔ i d e
 androne	a n d r o n e
 anelante	a n e l a n t e
 anello	a n ɛ l l o
@@ -1053,7 +1053,7 @@ aosta	a o s t a
 aosta	a ɔ s t a
 aostano	a o s t a n o
 apar	a p a r
-apartheid	a p a r t a i̯ d
+apartheid	a p a r t a i d
 apartitico	a p a r t i t i k o
 apatia	a p a t i a
 apatico	a p a t i k o
@@ -1457,201 +1457,201 @@ attualità	a t t u a l i t a
 attualizzare	a t t w a l i d d͡z a r e
 audience	ɔ d j e n s
 auffa	a u f f a
-auge	a u̯ d͡ʒ e
-augello	a u̯ d͡ʒ ɛ l l o
-augurare	a u̯ ɡ u r a r e
-augure	a u̯ ɡ u r e
-auguri	a u̯ ɡ u r i
-auledo	a u̯ l ɛ d o
-aulente	a u̯ l ɛ n t e
-aulentissimo	a u̯ l e n t i s s i m o
+auge	a u d͡ʒ e
+augello	a u d͡ʒ ɛ l l o
+augurare	a u ɡ u r a r e
+augure	a u ɡ u r e
+auguri	a u ɡ u r i
+auledo	a u l ɛ d o
+aulente	a u l ɛ n t e
+aulentissimo	a u l e n t i s s i m o
 aulico	a u l i k o
-aulire	a u̯ l i r e
-aulore	a u̯ l o r e
-auloroso	a u̯ l o r o z o
+aulire	a u l i r e
+aulore	a u l o r e
+auloroso	a u l o r o z o
 aureo	a u r e o
 aureola	a u r ɛ o l a
 auriga	a u r i ɡ a
-aurignaciano	a u̯ r i ɲ ɲ a t͡ʃ a n o
-aurignaziano	a u̯ r i ɲ ɲ a t t͡s j a n o
-aurora	a u̯ r ɔ r a
-ausilio	a u̯ z i l j o
+aurignaciano	a u r i ɲ ɲ a t͡ʃ a n o
+aurignaziano	a u r i ɲ ɲ a t t͡s j a n o
+aurora	a u r ɔ r a
+ausilio	a u z i l j o
 auspicio	a u s p i t͡ʃ o
 austero	a u s t ɛ r o
-australopitechi	a u̯ s t r a l o p i t ɛ k i
+australopitechi	a u s t r a l o p i t ɛ k i
 austria	a u s t r j a
-autarchia	a u̯ t a r k i a
+autarchia	a u t a r k i a
 autenticità	a u t e n t i t͡ʃ i t a
-auto	a u̯ t o
-autoabbronzante	a u̯ t o a b b r o n d͡z a n t e
-autoabbronzatura	a u̯ t o a b b r o n d͡z a t u r a
-autoaccelerazione	a u̯ t o a t t͡ʃ e l e r a t t͡s j o n e
-autoaccensione	a u̯ t o a t t͡ʃ e n s j o n e
-autoaccessorio	a u̯ t o a t t͡ʃ e s s ɔ r j o
-autoaccusa	a u̯ t o a k k u z a
-autoaccusarsi	a u̯ t o a k k u z a r s i
-autoadattante	a u̯ t o a d a t t a n t e
-autoadescante	a u̯ t o a d e s k a n t e
-autoadesivo	a u̯ t o a d e z i v o
-autoaffermazione	a u̯ t o a f f e r m a t t͡s j o n e
-autoaffondamento	a u̯ t o a f f o n d a m e n t o
-autoaffondarsi	a u̯ t o a f f o n d a r s i
-autoaggiornamento	a u̯ t o a d d͡ʒ o r n a m e n t o
-autoaggiunto	a u̯ t o a d d͡ʒ u n t o
-autoaggressivo	a u̯ t o a ɡ ɡ r e s s i v o
-autoaiuto	a u̯ t o a j u t o
-autoalienazione	a u̯ t o a l j e n a t t͡s j o n e
-autoalimentarsi	a u̯ t o a l i m e n t a r s i
-autoallergia	a u̯ t o a l l e r d͡ʒ i a
-autoambulanza	a u̯ t o a m b u l a n t͡s a
-autoanalisi	a u̯ t o a n a l i z i
-autoanticorpo	a u̯ t o a n t i k ɔ r p o
-autoantigene	a u̯ t o a n t i d͡ʒ e n e
-autoapprendimento	a u̯ t o a p p r e n d i m e n t o
-autoapprovvigionamento	a u̯ t o a p p r o v v i d͡ʒ o n a m e n t o
-autoarticolato	a u̯ t o a r t i k o l a t o
-autoassoluzione	a u̯ t o a s s o l u t t͡s j o n e
-autoassolversi	a u̯ t o a s s ɔ l v e r s i
-autobetoniera	a u̯ t o b e t o n j ɛ r a
-autobiblioteca	a u̯ t o b i b l j o t ɛ k a
-autobilanciato	a u̯ t o b i l a n t͡ʃ a t o
-autobiografismo	a u̯ t o b j o ɡ r a f i s m o
-autobiografo	a u̯ t o b i ɔ ɡ r a f o
-autoblinda	a u̯ t o b l i n d a
-autoblindato	a u̯ t o b l i n d a t o
-autoblindomitragliatrice	a u̯ t o b l i n d o m i t r a ʎ ʎ a t r i t͡ʃ e
-autobloccante	a u̯ t o b l o k k a n t e
-autobomba	a u̯ t o b o m b a
-autobotte	a u̯ t o b o t t e
-autobruco	a u̯ t o b r u k o
-autocalmiere	a u̯ t o k a l m j ɛ r e
-autocalunnia	a u̯ t o k a l u n n j a
-autocamionale	a u̯ t o k a m j o n a l e
-autocampeggio	a u̯ t o k a m p e d d͡ʒ o
-autocampionatore	a u̯ t o k a m p j o n a t o r e
-autocancellazione	a u̯ t o k a n t͡ʃ e l l a t t͡s j o n e
-autocaravan	a u̯ t o k a r a v a n
-autocaricamento	a u̯ t o k a r i k a m e n t o
-autocaricatura	a u̯ t o k a r i k a t u r a
-autocasa	a u̯ t o k a z a
-autocatalisi	a u̯ t o k a t a l i z i
-autocateterismo	a u̯ t o k a t e t e r i s m o
-autocelebrativo	a u̯ t o t͡ʃ e l e b r a t i v o
-autocensura	a u̯ t o t͡ʃ e n s u r a
-autocentrante	a u̯ t o t͡ʃ e n t r a n t e
-autocentro	a u̯ t o t͡ʃ ɛ n t r o
-autocercante	a u̯ t o t͡ʃ e r k a n t e
-autocertificare	a u̯ t o t͡ʃ e r t i f i k a r e
-autocertificativo	a u̯ t o t͡ʃ e r t i f i k a t i v o
-autocertificato	a u̯ t o t͡ʃ e r t i f i k a t o
-autocertificazione	a u̯ t o t͡ʃ e r t i f i k a t t͡s j o n e
-autocestello	a u̯ t o t͡ʃ e s t ɛ l l o
-autochiusura	a u̯ t o k j u z u r a
-autocinema	a u̯ t o t͡ʃ i n e m a
-autocingolato	a u̯ t o t͡ʃ i n ɡ o l a t o
-autocisterna	a u̯ t o t͡ʃ i s t ɛ r n a
-autocitarsi	a u̯ t o t͡ʃ i t a r s i
-autocitazione	a u̯ t o t͡ʃ i t a t t͡s j o n e
-autocivetta	a u̯ t o t͡ʃ i v e t t a
-autoclastico	a u̯ t o k l a s t i k o
-autocolonna	a u̯ t o k o l o n n a
-autocombustione	a u̯ t o k o m b u s t j o n e
-autocommento	a u̯ t o k o m m e n t o
-autocommiserarsi	a u̯ t o k o m m i z e r a r s i
-autocommiserazione	a u̯ t o k o m m i z e r a t t͡s j o n e
-autocommutatore	a u̯ t o k o m m u t a t o r e
-autocompattatore	a u̯ t o k o m p a t t a t o r e
-autocompiacimento	a u̯ t o k o m p j a t͡ʃ i m e n t o
-autoconcessionaria	a u̯ t o k o n t͡ʃ e s s j o n a r j a
-autoconcessionario	a u̯ t o k o n t͡ʃ e s s j o n a r j o
-autocondanna	a u̯ t o k o n d a n n a
-autoconoscenza	a u̯ t o k o n o ʃ ʃ ɛ n t͡s a
-autoconsapevolezza	a u̯ t o k o n s a p e v o l e t t͡s a
-autoconservazione	a u̯ t o k o n s e r v a t t͡s j o n e
-autoconsistente	a u̯ t o k o n s i s t ɛ n t e
-autoconsistenza	a u̯ t o k o n s i s t ɛ n t͡s a
-autoconsumo	a u̯ t o k o n s u m o
-autocontrarre	a u̯ t o k o n t r a r r e
-autocontrarsi	a u̯ t o k o n t r a r s i
-autocontratto	a u̯ t o k o n t r a t t o
-autocontrollo	a u̯ t o k o n t r ɔ l l o
-autoconvincersi	a u̯ t o k o n v i n t͡ʃ e r s i
-autoconvincimento	a u̯ t o k o n v i n t͡ʃ i m e n t o
-autoconvoglio	a u̯ t o k o n v ɔ ʎ ʎ o
-autocopiante	a u̯ t o k o p j a n t e
-autocorrela	a u̯ t o k o r r ɛ l a
-autocorrelare	a u̯ t o k o r r e l a r e
-autocorrelazione	a u̯ t o k o r r e l a t t͡s j o n e
-autocorrezione	a u̯ t o k o r r e t t͡s j o n e
-autocorriera	a u̯ t o k o r r j ɛ r a
-autocosciente	a u̯ t o k o ʃ ʃ ɛ n t e
-autocoscienza	a u̯ t o k o ʃ ʃ ɛ n t͡s a
-autocritica	a u̯ t o k r i t i k a
-autocritico	a u̯ t o k r i t i k o
-autocross	a u̯ t o k r ɔ s
-autocura	a u̯ t o k u r a
-autodafé	a u̯ t o d a f e
-autodecisione	a u̯ t o d e t͡ʃ i z j o n e
-autodefinizione	a u̯ t o d e f i n i t t͡s j o n e
-autodemolitore	a u̯ t o d e m o l i t o r e
-autodemolizione	a u̯ t o d e m o l i t t͡s j o n e
-autodenuncia	a u̯ t o d e n u n t͡ʃ a
-autodenunciarsi	a u̯ t o d e n u n t͡ʃ a r s i
-autodeterminato	a u̯ t o d e t e r m i n a t o
-autodeterminazione	a u̯ t o d e t e r m i n a t t͡s j o n e
-autodiagnosi	a u̯ t o d i a ɲ ɲ o z i
-autodiagnostica	a u̯ t o d j a ɲ ɲ ɔ s t i k a
-autodichiarare	a u̯ t o d i k j a r a r e
-autodichiararsi	a u̯ t o d i k j a r a r s i
-autodichiarato	a u̯ t o d i k j a r a t o
-autodichiarazione	a u̯ t o d i k j a r a t t͡s j o n e
-autodidatta	a u̯ t o d i d a t t a
-autodidattico	a u̯ t o d i d a t t i k o
-autodidattismo	a u̯ t o d i d a t t i s m o
-autodifesa	a u̯ t o d i f e z a
-autodigestione	a u̯ t o d i d͡ʒ e s t j o n e
-autodina	a u̯ t o d i n a
-autodirezionale	a u̯ t o d i r e t t͡s j o n a l e
-autodistribuito	a u̯ t o d i s t r i b u i t o
-autodistruggersi	a u̯ t o d i s t r u d d͡ʒ e r s i
-autodonazione	a u̯ t o d o n a t t͡s j o n e
-autoeccitante	a u̯ t o e t t͡ʃ i t a n t e
-autoeccitarsi	a u̯ t o e t t͡ʃ i t a r s i
-autoeccitazione	a u̯ t o e t t͡ʃ i t a t t͡s j o n e
-autoecologia	a u̯ t o e k o l o d͡ʒ i a
-autoeditore	a u̯ t o e d i t o r e
-autoeditoria	a u̯ t o e d i t o r i a
-autoeducazione	a u̯ t o e d u k a t t͡s j o n e
-autoefficacia	a u̯ t o e f f i k a t͡ʃ a
-autoemarginazione	a u̯ t o e m a r d͡ʒ i n a t t͡s j o n e
-autoemoteca	a u̯ t o e m o t ɛ k a
-autoemoterapia	a u̯ t o e m o t e r a p i a
-autoemotrasfusione	a u̯ t o e m o t r a s f u z j o n e
-autoerotico	a u̯ t o e r ɔ t i k o
-autoerotismo	a u̯ t o e r o t i s m o
-autoesaltazione	a u̯ t o e z a l t a t t͡s j o n e
-autoesame	a u̯ t o e z a m e
-autoescludersi	a u̯ t o e s k l u d e r s i
-autoestinguente	a u̯ t o e s t i n ɡ w ɛ n t e
-autoeterodina	a u̯ t o e t e r o d i n a
-autofagocitosi	a u̯ t o f a ɡ o t͡ʃ i t ɔ z i
-autofagosoma	a u̯ t o f a ɡ o s ɔ m a
-autofattura	a u̯ t o f a t t u r a
-autofecondazione	a u̯ t o f e k o n d a t t͡s j o n e
-autoferrotranviario	a u̯ t o f ɛ r r o t r a n v j a r j o
-autoferrotranviere	a u̯ t o f ɛ r r o t r a n v j ɛ r e
-autofertile	a u̯ t o f ɛ r t i l e
-autofertilizzante	a u̯ t o f e r t i l i d d͡z a n t e
-autofficina	a u̯ t o f f i t͡ʃ i n a
-autofilettante	a u̯ t o f i l e t t a n t e
-autofilotranviario	a u̯ t o f i l o t r a n v j a r j o
-autofinanziamento	a u̯ t o f i n a n t͡s j a m e n t o
-autofinanziarsi	a u̯ t o f i n a n t͡s j a r s i
-autoflagellazione	a u̯ t o f l a d͡ʒ e l l a t t͡s j o n e
-autofocus	a u̯ t o f ɔ k u s
-autofunebre	a u̯ t o f u n e b r e
-autointrospezione	a u̯ t o i n t r o s p e t t͡s j o n e
-autoistoradiografia	a u̯ t o i s t o r a d j o ɡ r a f i a
+auto	a u t o
+autoabbronzante	a u t o a b b r o n d͡z a n t e
+autoabbronzatura	a u t o a b b r o n d͡z a t u r a
+autoaccelerazione	a u t o a t t͡ʃ e l e r a t t͡s j o n e
+autoaccensione	a u t o a t t͡ʃ e n s j o n e
+autoaccessorio	a u t o a t t͡ʃ e s s ɔ r j o
+autoaccusa	a u t o a k k u z a
+autoaccusarsi	a u t o a k k u z a r s i
+autoadattante	a u t o a d a t t a n t e
+autoadescante	a u t o a d e s k a n t e
+autoadesivo	a u t o a d e z i v o
+autoaffermazione	a u t o a f f e r m a t t͡s j o n e
+autoaffondamento	a u t o a f f o n d a m e n t o
+autoaffondarsi	a u t o a f f o n d a r s i
+autoaggiornamento	a u t o a d d͡ʒ o r n a m e n t o
+autoaggiunto	a u t o a d d͡ʒ u n t o
+autoaggressivo	a u t o a ɡ ɡ r e s s i v o
+autoaiuto	a u t o a j u t o
+autoalienazione	a u t o a l j e n a t t͡s j o n e
+autoalimentarsi	a u t o a l i m e n t a r s i
+autoallergia	a u t o a l l e r d͡ʒ i a
+autoambulanza	a u t o a m b u l a n t͡s a
+autoanalisi	a u t o a n a l i z i
+autoanticorpo	a u t o a n t i k ɔ r p o
+autoantigene	a u t o a n t i d͡ʒ e n e
+autoapprendimento	a u t o a p p r e n d i m e n t o
+autoapprovvigionamento	a u t o a p p r o v v i d͡ʒ o n a m e n t o
+autoarticolato	a u t o a r t i k o l a t o
+autoassoluzione	a u t o a s s o l u t t͡s j o n e
+autoassolversi	a u t o a s s ɔ l v e r s i
+autobetoniera	a u t o b e t o n j ɛ r a
+autobiblioteca	a u t o b i b l j o t ɛ k a
+autobilanciato	a u t o b i l a n t͡ʃ a t o
+autobiografismo	a u t o b j o ɡ r a f i s m o
+autobiografo	a u t o b i ɔ ɡ r a f o
+autoblinda	a u t o b l i n d a
+autoblindato	a u t o b l i n d a t o
+autoblindomitragliatrice	a u t o b l i n d o m i t r a ʎ ʎ a t r i t͡ʃ e
+autobloccante	a u t o b l o k k a n t e
+autobomba	a u t o b o m b a
+autobotte	a u t o b o t t e
+autobruco	a u t o b r u k o
+autocalmiere	a u t o k a l m j ɛ r e
+autocalunnia	a u t o k a l u n n j a
+autocamionale	a u t o k a m j o n a l e
+autocampeggio	a u t o k a m p e d d͡ʒ o
+autocampionatore	a u t o k a m p j o n a t o r e
+autocancellazione	a u t o k a n t͡ʃ e l l a t t͡s j o n e
+autocaravan	a u t o k a r a v a n
+autocaricamento	a u t o k a r i k a m e n t o
+autocaricatura	a u t o k a r i k a t u r a
+autocasa	a u t o k a z a
+autocatalisi	a u t o k a t a l i z i
+autocateterismo	a u t o k a t e t e r i s m o
+autocelebrativo	a u t o t͡ʃ e l e b r a t i v o
+autocensura	a u t o t͡ʃ e n s u r a
+autocentrante	a u t o t͡ʃ e n t r a n t e
+autocentro	a u t o t͡ʃ ɛ n t r o
+autocercante	a u t o t͡ʃ e r k a n t e
+autocertificare	a u t o t͡ʃ e r t i f i k a r e
+autocertificativo	a u t o t͡ʃ e r t i f i k a t i v o
+autocertificato	a u t o t͡ʃ e r t i f i k a t o
+autocertificazione	a u t o t͡ʃ e r t i f i k a t t͡s j o n e
+autocestello	a u t o t͡ʃ e s t ɛ l l o
+autochiusura	a u t o k j u z u r a
+autocinema	a u t o t͡ʃ i n e m a
+autocingolato	a u t o t͡ʃ i n ɡ o l a t o
+autocisterna	a u t o t͡ʃ i s t ɛ r n a
+autocitarsi	a u t o t͡ʃ i t a r s i
+autocitazione	a u t o t͡ʃ i t a t t͡s j o n e
+autocivetta	a u t o t͡ʃ i v e t t a
+autoclastico	a u t o k l a s t i k o
+autocolonna	a u t o k o l o n n a
+autocombustione	a u t o k o m b u s t j o n e
+autocommento	a u t o k o m m e n t o
+autocommiserarsi	a u t o k o m m i z e r a r s i
+autocommiserazione	a u t o k o m m i z e r a t t͡s j o n e
+autocommutatore	a u t o k o m m u t a t o r e
+autocompattatore	a u t o k o m p a t t a t o r e
+autocompiacimento	a u t o k o m p j a t͡ʃ i m e n t o
+autoconcessionaria	a u t o k o n t͡ʃ e s s j o n a r j a
+autoconcessionario	a u t o k o n t͡ʃ e s s j o n a r j o
+autocondanna	a u t o k o n d a n n a
+autoconoscenza	a u t o k o n o ʃ ʃ ɛ n t͡s a
+autoconsapevolezza	a u t o k o n s a p e v o l e t t͡s a
+autoconservazione	a u t o k o n s e r v a t t͡s j o n e
+autoconsistente	a u t o k o n s i s t ɛ n t e
+autoconsistenza	a u t o k o n s i s t ɛ n t͡s a
+autoconsumo	a u t o k o n s u m o
+autocontrarre	a u t o k o n t r a r r e
+autocontrarsi	a u t o k o n t r a r s i
+autocontratto	a u t o k o n t r a t t o
+autocontrollo	a u t o k o n t r ɔ l l o
+autoconvincersi	a u t o k o n v i n t͡ʃ e r s i
+autoconvincimento	a u t o k o n v i n t͡ʃ i m e n t o
+autoconvoglio	a u t o k o n v ɔ ʎ ʎ o
+autocopiante	a u t o k o p j a n t e
+autocorrela	a u t o k o r r ɛ l a
+autocorrelare	a u t o k o r r e l a r e
+autocorrelazione	a u t o k o r r e l a t t͡s j o n e
+autocorrezione	a u t o k o r r e t t͡s j o n e
+autocorriera	a u t o k o r r j ɛ r a
+autocosciente	a u t o k o ʃ ʃ ɛ n t e
+autocoscienza	a u t o k o ʃ ʃ ɛ n t͡s a
+autocritica	a u t o k r i t i k a
+autocritico	a u t o k r i t i k o
+autocross	a u t o k r ɔ s
+autocura	a u t o k u r a
+autodafé	a u t o d a f e
+autodecisione	a u t o d e t͡ʃ i z j o n e
+autodefinizione	a u t o d e f i n i t t͡s j o n e
+autodemolitore	a u t o d e m o l i t o r e
+autodemolizione	a u t o d e m o l i t t͡s j o n e
+autodenuncia	a u t o d e n u n t͡ʃ a
+autodenunciarsi	a u t o d e n u n t͡ʃ a r s i
+autodeterminato	a u t o d e t e r m i n a t o
+autodeterminazione	a u t o d e t e r m i n a t t͡s j o n e
+autodiagnosi	a u t o d i a ɲ ɲ o z i
+autodiagnostica	a u t o d j a ɲ ɲ ɔ s t i k a
+autodichiarare	a u t o d i k j a r a r e
+autodichiararsi	a u t o d i k j a r a r s i
+autodichiarato	a u t o d i k j a r a t o
+autodichiarazione	a u t o d i k j a r a t t͡s j o n e
+autodidatta	a u t o d i d a t t a
+autodidattico	a u t o d i d a t t i k o
+autodidattismo	a u t o d i d a t t i s m o
+autodifesa	a u t o d i f e z a
+autodigestione	a u t o d i d͡ʒ e s t j o n e
+autodina	a u t o d i n a
+autodirezionale	a u t o d i r e t t͡s j o n a l e
+autodistribuito	a u t o d i s t r i b u i t o
+autodistruggersi	a u t o d i s t r u d d͡ʒ e r s i
+autodonazione	a u t o d o n a t t͡s j o n e
+autoeccitante	a u t o e t t͡ʃ i t a n t e
+autoeccitarsi	a u t o e t t͡ʃ i t a r s i
+autoeccitazione	a u t o e t t͡ʃ i t a t t͡s j o n e
+autoecologia	a u t o e k o l o d͡ʒ i a
+autoeditore	a u t o e d i t o r e
+autoeditoria	a u t o e d i t o r i a
+autoeducazione	a u t o e d u k a t t͡s j o n e
+autoefficacia	a u t o e f f i k a t͡ʃ a
+autoemarginazione	a u t o e m a r d͡ʒ i n a t t͡s j o n e
+autoemoteca	a u t o e m o t ɛ k a
+autoemoterapia	a u t o e m o t e r a p i a
+autoemotrasfusione	a u t o e m o t r a s f u z j o n e
+autoerotico	a u t o e r ɔ t i k o
+autoerotismo	a u t o e r o t i s m o
+autoesaltazione	a u t o e z a l t a t t͡s j o n e
+autoesame	a u t o e z a m e
+autoescludersi	a u t o e s k l u d e r s i
+autoestinguente	a u t o e s t i n ɡ w ɛ n t e
+autoeterodina	a u t o e t e r o d i n a
+autofagocitosi	a u t o f a ɡ o t͡ʃ i t ɔ z i
+autofagosoma	a u t o f a ɡ o s ɔ m a
+autofattura	a u t o f a t t u r a
+autofecondazione	a u t o f e k o n d a t t͡s j o n e
+autoferrotranviario	a u t o f ɛ r r o t r a n v j a r j o
+autoferrotranviere	a u t o f ɛ r r o t r a n v j ɛ r e
+autofertile	a u t o f ɛ r t i l e
+autofertilizzante	a u t o f e r t i l i d d͡z a n t e
+autofficina	a u t o f f i t͡ʃ i n a
+autofilettante	a u t o f i l e t t a n t e
+autofilotranviario	a u t o f i l o t r a n v j a r j o
+autofinanziamento	a u t o f i n a n t͡s j a m e n t o
+autofinanziarsi	a u t o f i n a n t͡s j a r s i
+autoflagellazione	a u t o f l a d͡ʒ e l l a t t͡s j o n e
+autofocus	a u t o f ɔ k u s
+autofunebre	a u t o f u n e b r e
+autointrospezione	a u t o i n t r o s p e t t͡s j o n e
+autoistoradiografia	a u t o i s t o r a d j o ɡ r a f i a
 automatica	a u t o m a t i k a
 automatiche	a u t o m a t i k e
 automatici	a u t o m a t i t͡ʃ i
@@ -1659,15 +1659,15 @@ automatico	a u t o m a t i k o
 automato	a u t o m a t o
 automobile	a u t o m ɔ b i l e
 automorfismo	a u t o m o r f i z m o
-autoplastica	a u̯ t o p l a s t i k a
-autoplastico	a u̯ t o p l a s t i k o
+autoplastica	a u t o p l a s t i k a
+autoplastico	a u t o p l a s t i k o
 autore	a u t o r e
 autorevole	a u t o r e v o l e
-autorità	a u̯ t o r i t a
-autoschediastico	a u̯ t o s k e d j a s t i k o
+autorità	a u t o r i t a
+autoschediastico	a u t o s k e d j a s t i k o
 autovelox	a u t o v ɛ l o k s
 autrice	a u t r i t͡ʃ e
-autunno	a u̯ t u n n o
+autunno	a u t u n n o
 avaccio	a v a t t͡ʃ o
 avallo	a v a l l o
 avana	a v a n a
@@ -2288,7 +2288,7 @@ bottone	b o t t o n e
 bovaro	b o v a r o
 bovino	b o v i n o
 boy	b ɔ i
-boyscout	b o i̯ s k a u̯ t
+boyscout	b o i s k a u t
 bozza	b ɔ t t s a
 bracare	b r a k a r e
 bracchetto	b r a k k e t t o
@@ -2925,7 +2925,7 @@ catena	k a t e n a
 catenaccio	k a t e n a t t ʃ o
 catenare	k a t e n a r e
 catenato	k a t e n a t o
-catenoide	k a t e n ɔ i̯ d e
+catenoide	k a t e n ɔ i d e
 catilina	k a t i l i n a
 catilinaria	k a t i l i n a r j a
 catilinario	k a t i l i n a r j o
@@ -2940,20 +2940,20 @@ cattolica	k a t t o l i k a
 cattoliche	k a t t o l i k e
 cattolici	k a t t o l i t͡ʃ i
 cattolico	k a t t o l i k o
-caudio	k a u̯ d j o
-caudium	k a u̯ d j u m
-caulerpa	k a u̯ l ɛ r p a
-causale	k a u̯ z a l e
-causalismo	k a u̯ z a l i s m o
-causalista	k a u̯ z a l i s t a
-causalistico	k a u̯ z a l i s t i k o
-causatore	k a u̯ z a t o r e
-causatrice	k a u̯ z a t r i t͡ʃ e
-causazione	k a u̯ z a t t͡s j o n e
-cautamente	k a u̯ t a m e n t e
-cauterio	k a u̯ t ɛ r j o
-cauto	k a u̯ t o
-cauzione	k a u̯ t t͡s j o n e
+caudio	k a u d j o
+caudium	k a u d j u m
+caulerpa	k a u l ɛ r p a
+causale	k a u z a l e
+causalismo	k a u z a l i s m o
+causalista	k a u z a l i s t a
+causalistico	k a u z a l i s t i k o
+causatore	k a u z a t o r e
+causatrice	k a u z a t r i t͡ʃ e
+causazione	k a u z a t t͡s j o n e
+cautamente	k a u t a m e n t e
+cauterio	k a u t ɛ r j o
+cauto	k a u t o
+cauzione	k a u t t͡s j o n e
 cavafango	k a v a f a n ɡ o
 cavalleresco	k a v a l l e r e s k o
 cavea	k a v e a
@@ -3354,11 +3354,11 @@ clarino	k l a r i n o
 classe	k l a s s e
 classicistico	k l a s s i t͡ʃ i s t i k o
 classico	k l a s s i k o
-claudicante	k l a u̯ d i k a n t e
-claudicare	k l a u̯ d i k a r e
-claustro	k l a u̯ s t r o
-claustrofilo	k l a u̯ s t r ɔ f i l o
-claustrofobico	k l a u̯ s t r o f ɔ b i k o
+claudicante	k l a u d i k a n t e
+claudicare	k l a u d i k a r e
+claustro	k l a u s t r o
+claustrofilo	k l a u s t r ɔ f i l o
+claustrofobico	k l a u s t r o f ɔ b i k o
 clausura	k l a u z u r a
 clemente	k l e m ɛ n t e
 clementina	k l e m e n t i n a
@@ -3369,7 +3369,7 @@ cliente	k l i ɛ n t e
 clientela	k l j e n t ɛ l a
 clima	k l i m a
 climatico	k l i m a t i k o
-climb	k l a i̯ m b
+climb	k l a i m b
 clinica	k l i n i k a
 clinico	k l i n i k o
 clivo	k l i v o
@@ -3378,7 +3378,7 @@ clonazione	k l o n a t͡s j o n e
 clone	k l o n e
 cloro	k l ɔ r o
 cloroprene	k l o r o p r ɛ n e
-clotoide	k l o t ɔ i̯ d e
+clotoide	k l o t ɔ i d e
 club	k l a b
 club	k l ɛ b
 clune	k l u n e
@@ -4060,7 +4060,7 @@ cuna	k u n a
 cuneense	k u n e ɛ n s e
 cuneese	k u n e e s e
 cuneese	k u n e e z e
-cuneiforme	k u n e i̯ f o r m e
+cuneiforme	k u n e i f o r m e
 cuneo	k u n e o
 cunicolo	k u n i k o l o
 cunta	k u n t a
@@ -4132,7 +4132,7 @@ danzica	d a n t s i k a
 dape	d a p e
 dappertutto	d a p p e r t u t t o
 dappoco	d a p p ɔ k o
-dappoiché	d a p p o i̯ k e
+dappoiché	d a p p o i k e
 darabukka	d a r a b u k k a
 dardano	d a r d a n o
 dare	d a r e
@@ -4220,8 +4220,8 @@ deh	d ɛ
 dei	d e i
 dei	d ɛ i
 deianira	d e j a n i r a
-deicida	d e i̯ t͡ʃ i d a
-deiforme	d e i̯ f o r m e
+deicida	d e i t͡ʃ i d a
+deiforme	d e i f o r m e
 deimos	d e i m o s
 deitade	d e i t a d e
 deitate	d e i t a t e
@@ -4354,7 +4354,7 @@ dettagliato	d e t t a ʎ ʎ a t o
 dettaglio	d e t t a ʎ ʎ o
 dettare	d e t t a r e
 deturperemo	d e t u r p e r e m o
-deuteragonista	d e u̯ t e r a ɡ o n i s t a
+deuteragonista	d e u t e r a ɡ o n i s t a
 devanagari	d e v a n a ɡ a r i
 devastazione	d e v a s t a t t͡s j o n e
 deve	d ɛ v e
@@ -4853,7 +4853,7 @@ ebro	ɛ b r o
 ebulliometro	e b u l l j ɔ m e t r o
 ecatombe	e k a t o m b e
 ecatostilo	e k a t ɔ s t i l o
-ecceità	e t t͡ʃ e i̯ t a
+ecceità	e t t͡ʃ e i t a
 eccellente	e t t͡ʃ e l l ɛ n t e
 eccellenza	e t t͡ʃ e l l ɛ n t͡s a
 eccellere	e t t͡ʃ ɛ l l e r e
@@ -4949,9 +4949,9 @@ egualitarismo	e ɡ w a l i t a r i s m o
 egualità	e ɡ w a l i t a
 egualizzare	e ɡ w a l i d d͡z a r e
 ehi	e i
-ei	e i̯
+ei	e i
 einsteiniano	a i n s t a i n j a n o
-einsteinio	a i̯ n s t a i̯ n j o
+einsteinio	a i n s t a i n j o
 einstenio	a i n s t ɛ n j o
 el	e l
 elaborare	e l a b o r a r e
@@ -4988,7 +4988,7 @@ elevato	e l e v a t o
 elfo	ɛ l f o
 elica	ɛ l i k a
 eliche	ɛ l i k e
-elicoide	e l i k ɔ i̯ d e
+elicoide	e l i k ɔ i d e
 elicotteristico	e l i k o t t e r i s t i k o
 elicottero	e l i k ɔ t t e r o
 eliminazione	e l i m i n a t t͡s j o n e
@@ -5026,7 +5026,7 @@ emanare	e m a n a r e
 emanatistico	e m a n a t i s t i k o
 emanazione	e m a n a t t͡s j o n e
 emancipazione	e m a n t͡ʃ i p a t t͡s j o n e
-ematoide	e m a t ɔ i̯ d e
+ematoide	e m a t ɔ i d e
 ematologia	e m a t o l o d͡ʒ i a
 emberiza	e m b e r i d d͡z a
 emblematico	e m b l e m a t i k o
@@ -5217,10 +5217,10 @@ esattezza	e z a t t e t t͡s a
 esatto	e z a t t o
 esauriente	e z a u r j ɛ n t e
 esaurimento	e z a u r i m e n t o
-esaurire	e z a u̯ r i r e
-esaurirsi	e z a u̯ r i r s i
+esaurire	e z a u r i r e
+esaurirsi	e z a u r i r s i
 esaurito	e z a u r i t o
-esautorare	e z a u̯ t o r a r e
+esautorare	e z a u t o r a r e
 esaù	e s a u
 esaù	e z a u
 esborso	e s b o r s o
@@ -5383,15 +5383,15 @@ etterno	e t t ɛ r n o
 età	e t a
 euclideo	e u k l i d ɛ o
 euforia	e u f o r i a
-euglena	e u̯ ɡ l ɛ n a
-eureka	ɛ u̯ r e k a
-euro	ɛ u̯ r o
+euglena	e u ɡ l ɛ n a
+eureka	ɛ u r e k a
+euro	ɛ u r o
 europa	e u r ɔ p a
 europea	e u r o p ɛ a
 europeo	e u r o p ɛ o
 europio	e u r ɔ p j o
-eurozona	ɛ u̯ r o d͡z ɔ n a
-euterpe	e u̯ t ɛ r p e
+eurozona	ɛ u r o d͡z ɔ n a
+euterpe	e u t ɛ r p e
 evadere	e v a d e r e
 evangelico	e v a n d͡ʒ ɛ l i k o
 evangelista	e v a n d͡ʒ e l i s t a
@@ -5570,7 +5570,7 @@ feci	f ɛ t͡ʃ i
 fecondità	f e k o n d i t a
 fecondo	f e k o n d o
 feda	f ɛ d a
-fedai	f e d a i̯
+fedai	f e d a i
 fedammo	f e d a m m o
 fedano	f ɛ d a n o
 fedare	f e d a r e
@@ -5594,7 +5594,7 @@ fededegno	f e d e d e ɲ ɲ o
 fedele	f e d e l e
 fedelmente	f e d e l m e n t e
 fedeltà	f e d e l t a
-federai	f e d e r a i̯
+federai	f e d e r a i
 federale	f e d e r a l e
 federalismo	f e d e r a l i s m o
 federalista	f e d e r a l i s t a
@@ -5608,7 +5608,7 @@ federato	f e d e r a t o
 federazione	f e d e r a t t͡s j o n e
 federebbe	f e d e r e b b e
 federebbero	f e d e r e b b e r o
-federei	f e d e r ɛ i̯
+federei	f e d e r ɛ i
 federemmo	f e d e r e m m o
 federemo	f e d e r e m o
 federeste	f e d e r e s t e
@@ -5664,7 +5664,7 @@ fero	f ɛ r o
 feroce	f e r o t͡ʃ e
 ferocissimo	f e r o t͡ʃ i s s i m o
 feroese	f e r o e z e
-feroico	f e r ɔ i̯ k o
+feroico	f e r ɔ i k o
 ferramenta	f e r r a m e n t a
 ferrara	f e r r a r a
 ferrico	f ɛ r r i k a
@@ -5964,7 +5964,7 @@ fragno	f r a ɲ ɲ o
 fragola	f r a ɡ o l a
 fragore	f r a ɡ o r e
 fragrante	f r a ɡ r a n t e
-fraile	f r a i̯ l e
+fraile	f r a i l e
 fraintendere	f r a i n t ɛ n d e r e
 frale	f r a l e
 francesca	f r a n t ʃ e s k a
@@ -6033,7 +6033,7 @@ frusta	f r u s t a
 frustare	f r u s t a r e
 frusto	f r u s t o
 frustra	f r u s t r a
-frustraneità	f r u s t r a n e i̯ t a
+frustraneità	f r u s t r a n e i t a
 frustrante	f r u s t r a n t e
 frustrare	f r u s t r a r e
 frustrato	f r u s t r a t o
@@ -6182,7 +6182,7 @@ gattinara	ɡ a t t i n a r a
 gattinarese	ɡ a t t i n a r e s e
 gatto	ɡ a t t o
 gattuccio	ɡ a t t u t t͡ʃ o
-gaulo	ɡ a u̯ l o
+gaulo	ɡ a u l o
 gavazzare	ɡ a v a t t͡s a r e
 gavetta	ɡ a v e t t a
 gavigliano	ɡ a v i ʎ a n o
@@ -6215,7 +6215,7 @@ genitrice	d͡ʒ e n i t r i t͡ʃ e
 genocidio	d͡ʒ e n o t͡ʃ i d j o
 genti	d͡ʒ ɛ n t i
 gentileschi	d͡ʒ e n t i l e s k i
-geoide	d͡ʒ e ɔ i̯ d e
+geoide	d͡ʒ e ɔ i d e
 georgia	d͡ʒ e ɔ r d͡ʒ a
 geppetto	d͡ʒ e p p e t t o
 gerarca	d͡ʒ e r a r k a
@@ -6280,7 +6280,7 @@ giaguaro	d͡ʒ a ɡ w a r o
 giallone	d͡ʒ a l l o n e
 giamaicano	d͡ʒ a m a i k a n o
 giambo	d͡ʒ a m b o
-giammai	d͡ʒ a m m a i̯
+giammai	d͡ʒ a m m a i
 gian	d͡ʒ a n
 gianicolense	d͡ʒ a n i k o l ɛ n s e
 gianicolo	d͡ʒ a n i k o l o
@@ -6663,7 +6663,7 @@ guantato	ɡ w a n t a t o
 guanto	ɡ w a n t o
 guardabarriere	ɡ w a r d a b a r r j ɛ r e
 guardaboschi	ɡ w a r d a b ɔ s k i
-guardabuoi	ɡ w a r d a b w ɔ i̯
+guardabuoi	ɡ w a r d a b w ɔ i
 guardacaccia	ɡ w a r d a k a t t͡ʃ a
 guardapecore	ɡ w a r d a p ɛ k o r e
 guardare	ɡ w a r d a r e
@@ -6675,7 +6675,7 @@ guardiano	ɡ w a r d j a n o
 guardiola	ɡ w a r d j o l a
 guardo	ɡ w a r d o
 guardolo	ɡ w a r d o l o
-guardrail	ɡ a r d r ɛ i̯ l
+guardrail	ɡ a r d r ɛ i l
 guargango	ɡ w a r ɡ a n ɡ o
 guarigione	ɡ w a r i d͡ʒ o n e
 guarnigione	ɡ w a r n i d͡ʒ o n e
@@ -6723,7 +6723,7 @@ gutturale	ɡ u t t u r a l e
 h	a k k a
 ha	a
 hackerare	a k e r a r e
-hai	a i̯
+hai	a i
 hallalì	a l l a l i
 halloween	a l l o w i n
 hamburger	a m b u r ɡ e r
@@ -6828,7 +6828,7 @@ imbelle	i m b ɛ l l e
 imberbe	i m b ɛ r b e
 imbevere	i m b e v e r e
 imbianchino	i m b j a n k i n o
-imbottatoi	i m b o t t a t o i̯
+imbottatoi	i m b o t t a t o i
 imbottatoia	i m b o t t a t o j a
 imbottatoie	i m b o t t a t o j e
 imbottatoio	i m b o t t a t o j o
@@ -7633,7 +7633,7 @@ lattugaccio	l a t t u ɡ a t t͡ʃ o
 lattughella	l a t t u ɡ ɛ l l a
 lattughetta	l a t t u ɡ e t t a
 lattughina	l a t t u ɡ i n a
-lauda	l a u̯ d a
+lauda	l a u d a
 laurea	l a u r e a
 laurenzio	l a u r ɛ n t s j o
 lauroceraso	l a u r o t͡ʃ e r a z o
@@ -7723,7 +7723,7 @@ lettere	l ɛ t t e r e
 lettone	l e t t o n e
 lettone	l ɛ t t o n e
 lettore	l e t t o r e
-leucoblastico	l e u̯ k o b l a s t i k o
+leucoblastico	l e u k o b l a s t i k o
 levante	l e v a n t e
 levatura	l e v a t u r a
 levigatura	l e v i ɡ a t u r a
@@ -7793,7 +7793,7 @@ linguine	l i n ɡ w i n e
 linguistica	l i n ɡ w i s t i k a
 linguolabiale	l i n ɡ w o l a b j a l e
 lino	l i n o
-linoleum	l i n ɔ l e u̯ m
+linoleum	l i n ɔ l e u m
 liocorno	l j o k ɔ r n o
 lione	l j o n e
 lipedema	l i p e d ɛ m a
@@ -8276,7 +8276,7 @@ melodia	m e l o d i a
 melodiare	m e l o d j a r e
 melodico	m e l ɔ d i k o
 melofo	m e l ɔ f o
-meloide	m e l ɔ i̯ d e
+meloide	m e l ɔ i d e
 melos	m ɛ l o s
 mem	m e m
 membro	m ɛ m b r o
@@ -8617,8 +8617,8 @@ motorino	m o t o r i n o
 motrice	m o t r i t͡ʃ e
 motta	m ɔ t t a
 motto	m ɔ t t o
-mouse	m a u̯ s
-mouse	m a u̯ z
+mouse	m a u s
+mouse	m a u z
 movida	m o v i d a
 mozza	m o t t͡s a
 mozzare	m o t t͡s a r e
@@ -8754,8 +8754,8 @@ naturale	n a t u r a l e
 naturalista	n a t u r a l i s t a
 naturalità	n a t u r a l i t a
 naturista	n a t u r i s t a
-naufragio	n a u̯ f r a d͡ʒ o
-nautico	n a u̯ t i k o
+naufragio	n a u f r a d͡ʒ o
+nautico	n a u t i k o
 nautilo	n ɔ t i l o
 navale	n a v a l e
 navalestro	n a v a l ɛ s t r o
@@ -8810,7 +8810,7 @@ necrotomia	n e k r o t o m i a
 necrotrofismo	n e k r o t r o f i s m o
 necrotrofo	n e k r ɔ t r o f o
 nectocalice	n e k t o k a l i t͡ʃ e
-nectozoide	n e k t o d͡z ɔ i̯ d e
+nectozoide	n e k t o d͡z ɔ i d e
 ned	n e d
 negare	n e ɡ a r e
 negarit	n e ɡ a r i t
@@ -8864,12 +8864,12 @@ nettaroconca	n e t t a r o k o n k a
 nettarofago	n e t t a r ɔ f a ɡ o
 nettaroteca	n e t t a r o t ɛ k a
 netto	n e t t o
-nettozoide	n e t t o d͡z ɔ i̯ d e
+nettozoide	n e t t o d͡z ɔ i d e
 nettunia	n e t t u n j a
 nettunio	n e t t u n j o
 nettuno	n e t t u n o
 neuno	n e u n o
-neuroscheletro	n ɛ u̯ r o s k ɛ l e t r o
+neuroscheletro	n ɛ u r o s k ɛ l e t r o
 neutro	n ɛ u t r o
 nevada	n e v a d a
 nevaio	n e v a j o
@@ -8904,7 +8904,7 @@ nietzschiano	n i t t ʃ a n o
 nievo	n j ɛ v o
 nigeria	n i d͡ʒ ɛ r j a
 nigeriano	n i d͡ʒ e r j a n o
-night	n a i̯ t
+night	n a i t
 nilde	n i l d e
 nilo	n i l o
 nilota	n i l ɔ t a
@@ -9109,7 +9109,7 @@ odiosamente	o d j o z a m e n t e
 odiosità	o d j o z i t a
 odioso	o d j o z o
 odocelo	o d o t͡ʃ ɛ l o
-odocoileo	o d o k o i̯ l ɛ o
+odocoileo	o d o k o i l ɛ o
 odontoblastico	o d o n t o b l a s t i k o
 odor	o d o r
 odorante	o d o r a n t e
@@ -9140,7 +9140,7 @@ offrire	o f f r i r e
 offrì	o f f r i
 ofide	o f i d e
 oggi	ɔ d d͡ʒ i
-oggimai	o d d͡ʒ i m a i̯
+oggimai	o d d͡ʒ i m a i
 ogne	o ɲ e
 ogni	o ɲ i
 ogni	ɔ ɲ i
@@ -9151,7 +9151,7 @@ ognuno	o ɲ ɲ u n o
 ohilà	o i l a
 ohimè	o i m ɛ
 ohio	o a j o
-oinochoe	o i̯ n o k ɔ e
+oinochoe	o i n o k ɔ e
 oklahoma	o k l a ɔ m a
 olanda	o l a n d a
 oleandolo	o l e a n d o l o
@@ -9320,7 +9320,7 @@ orezzo	o r e d d͡z o
 organizzare	o r ɡ a n i d d͡z a r e
 organizzazione	o r ɡ a n i d d͡z a t t͡s j o n e
 organo	ɔ r ɡ a n o
-organoide	o r ɡ a n ɔ i̯ d e
+organoide	o r ɡ a n ɔ i d e
 orgia	ɔ r d͡ʒ a
 orgiastico	o r d͡ʒ a s t i k o
 orgoglio	o r ɡ o ʎ ʎ o
@@ -9493,7 +9493,7 @@ pagliaccio	p a ʎ ʎ a t t ʃ o
 pagliata	p a ʎ ʎ a t a
 pago	p a ɡ o
 pagoda	p a ɡ ɔ d a
-paidire	p a i̯ d i r e
+paidire	p a i d i r e
 paio	p a j o
 paiolo	p a j ɔ l o
 paladina	p a l a d i n a
@@ -9551,7 +9551,7 @@ pandispagna	p a n d i s p a ɲ ɲ a
 pandolo	p a n d o l o
 pandoro	p a n d ɔ r o
 pane	p a n e
-panenteismo	p a n e n t e i̯ s m o
+panenteismo	p a n e n t e i s m o
 panettiere	p a n e t t j ɛ r e
 panettone	p a n e t t o n e
 pania	p a n j a
@@ -10081,7 +10081,7 @@ plasticità	p l a s t i t͡ʃ i t a
 plastico	p l a s t i k o
 platina	p l a t i n a
 platino	p l a t i n o
-plausibile	p l a u̯ z i b i l e
+plausibile	p l a u z i b i l e
 playback	p l ɛ i b e k
 playback	p l ɛ i b ɛ k
 plebaglia	p l e b a ʎ a
@@ -10422,7 +10422,7 @@ principio	p r i n t͡ʃ i p j o
 principî	p r i n t͡ʃ i p i
 priscione	p r i ʃ o n e
 prisco	p r i s k o
-prismoide	p r i s m ɔ i̯ d e
+prismoide	p r i s m ɔ i d e
 privacy	p r a i v a s i
 privato	p r i v a t o
 privilegio	p r i v i l ɛ d͡ʒ o
@@ -10525,7 +10525,7 @@ protoclasi	p r ɔ t o k l a z i
 protoclastico	p r o t o k l a s t i k o
 protocollare	p r o t o k o l l a r e
 protocollo	p r o t o k ɔ l l o
-protocuneiforme	p r ɔ t o k u n e i̯ f o r m e
+protocuneiforme	p r ɔ t o k u n e i f o r m e
 protrarre	p r o t r a r r e
 protrudere	p r o t r u d e r e
 proustiano	p r u s t j a n o
@@ -10543,14 +10543,14 @@ provocazione	p r o v o k a t͡s j o n e
 prudere	p r u d e r e
 prugna	p r u ɲ ɲ a
 prugnola	p r u ɲ ɲ o l a
-prulaurasina	p r u l a u̯ r a z i n a
+prulaurasina	p r u l a u r a z i n a
 prunasina	p r u n a z i n a
 pruova	p r w ɔ v a
 prurito	p r u r i t o
 pseudoanglicismo	p s e u d o a n ɡ l i t͡ʃ i z m o
-pseudocupola	p s ɛ u̯ d o k u p o l a
-pseudopecora	p s ɛ u̯ d o p ɛ k o r a
-pseudopecore	p s ɛ u̯ d o p ɛ k o r e
+pseudocupola	p s ɛ u d o k u p o l a
+pseudopecora	p s ɛ u d o p ɛ k o r a
+pseudopecore	p s ɛ u d o p ɛ k o r e
 psiche	p s i k e
 psichedelia	p s i k e d e l i a
 psichedelico	p s i k e d ɛ l i k o
@@ -10782,12 +10782,12 @@ raggiungere	r a d d͡ʒ u n d͡ʒ e r e
 ragione	r a d͡ʒ o n e
 ragnatela	r a ɲ ɲ a t e l a
 ragno	r a ɲ ɲ o
-ragoideo	r a ɡ o i̯ d ɛ o
+ragoideo	r a ɡ o i d ɛ o
 ragutiera	r a ɡ u t j ɛ r a
 ragù	r a ɡ u
-rai	r a i̯
-raiba	r a i̯ b a
-raimondo	r a i̯ m o n d o
+rai	r a i
+raiba	r a i b a
+raimondo	r a i m o n d o
 rais	r a i s
 ramaia	r a m a j a
 rame	r a m e
@@ -10957,7 +10957,7 @@ respiro	r e s p i r o
 responsabile	r e s p o n s a b i l e
 responsabilità	r e s p o n s a b i l i t a
 restare	r e s t a r e
-restaurare	r e s t a u̯ r a r e
+restaurare	r e s t a u r a r e
 resto	r ɛ s t o
 resurgere	r e s u r d͡ʒ e r e
 retaggio	r e t a d d͡ʒ o
@@ -10980,7 +10980,7 @@ rettangolo	r e t t a n ɡ o l o
 rettificabile	r e t t i f i k a b i l e
 rettile	r ɛ t t i l e
 rettoressa	r e t t o r e s s a
-reuma	r ɛ u̯ m a
+reuma	r ɛ u m a
 revanscismo	r e v a n ʃ i z m o
 revisionista	r e v i z j o n i s t a
 revoca	r ɛ v o k a
@@ -11462,7 +11462,7 @@ sarcofago	s a r k ɔ f a ɡ o
 sardegna	s a r d e ɲ ɲ a
 sardesco	s a r d e s k o
 sardina	s a r d i n a
-sarei	s a r ɛ i̯
+sarei	s a r ɛ i
 sargasso	s a r ɡ a s s o
 sargia	s a r d͡ʒ a
 sargo	s a r ɡ o
@@ -11783,7 +11783,7 @@ scottadito	s k ɔ t t a d i t o
 scottare	s k o t t a r e
 scottarsi	s k o t t a r s i
 scotto	s k ɔ t t o
-scout	s k a u̯ t
+scout	s k a u t
 scozia	s k ɔ t t s j a
 scozzese	s k o t t͡s e z e
 screda	s k r e d a
@@ -12416,14 +12416,14 @@ sparto	s p a r t o
 spaso	s p a z o
 spatola	s p a t o l a
 spatolare	s p a t o l a r e
-spauracchio	s p a u̯ r a k k j o
-spaurare	s p a u̯ r a r e
-spaurarsi	s p a u̯ r a r s i
-spaurato	s p a u̯ r a t o
-spaurevole	s p a u̯ r e v o l e
-spaurimento	s p a u̯ r i m e n t o
-spaurire	s p a u̯ r i r e
-spaurito	s p a u̯ r i t o
+spauracchio	s p a u r a k k j o
+spaurare	s p a u r a r e
+spaurarsi	s p a u r a r s i
+spaurato	s p a u r a t o
+spaurevole	s p a u r e v o l e
+spaurimento	s p a u r i m e n t o
+spaurire	s p a u r i r e
+spaurito	s p a u r i t o
 spaventapasseri	s p a v ɛ n t a p a s s e r i
 spaventare	s p a v e n t a r e
 spazializzare	s p a t t͡s j a l i d d͡z a r e
@@ -12974,9 +12974,9 @@ tassobarbasso	t a s s o b a r b a s s o
 tassì	t a s s i
 tasto	t a s t o
 tattica	t a t t i k a
-tauro	t a u̯ r o
-tautocronismo	t a u̯ t o k r o n i s m o
-tautocrono	t a u̯ t ɔ k r o n o
+tauro	t a u r o
+tautocronismo	t a u t o k r o n i s m o
+tautocrono	t a u t ɔ k r o n o
 taverna	t a v ɛ r n a
 tavernaia	t a v e r n a j a
 taxi	t a k s i
@@ -13263,7 +13263,7 @@ tossico	t ɔ s s i k o
 tossicofarmacologia	t o s s i k o f a r m a k o l o d͡ʒ i a
 tossire	t o s s i r e
 tossitore	t o s s i t o r e
-tossoide	t o s s ɔ i̯ d e
+tossoide	t o s s ɔ i d e
 tosto	t ɔ s t o
 totale	t o t a l e
 totalitario	t o t a l i t a r j o
@@ -13569,7 +13569,7 @@ tumulo	t u m u l o
 tundra	t u n d r a
 tungsteno	t u n s t ɛ n o
 tunnel	t u n n e l
-tuono	t u̯ ɔ n o
+tuono	t u ɔ n o
 turbare	t u r b a r e
 turbazione	t u r b a t t͡s j o n e
 turchia	t u r k i a
@@ -13870,7 +13870,7 @@ vastissimo	v a s t i s s i m o
 vastità	v a s t i t a
 vasto	v a s t o
 vate	v a t e
-vau	v a u̯
+vau	v a u
 ve	v e
 vecchi	v e k k i
 vecchi	v ɛ k k i
@@ -14273,7 +14273,7 @@ vostro	v ɔ s t r o
 votante	v o t a n t e
 votare	v o t a r e
 votiaco	v o t j a k o
-voucher	v a u̯ t͡ʃ e r
+voucher	v a u t͡ʃ e r
 vu	v u
 vudu	v u d u
 vuduismo	v u d u i s m o
@@ -14396,7 +14396,7 @@ zeppa	t s e p p a
 zeppola	t s e p p o l a
 zero	d͡z ɛ r o
 zeta	d͡z ɛ t a
-zeugma	d͡z ɛ u̯ ɡ m a
+zeugma	d͡z ɛ u ɡ m a
 zia	t͡s i a
 zibaldone	d z i b a l d o n e
 zigaia	d͡z i ɡ a j a


### PR DESCRIPTION
I noted an incoherence in the italian transcriptions. The broad version of the transcriptions correctly contains the phonemic representations of sounds based on the sources cited in _ita_broad.phones_. Such broad transcription correctly ignore allophones of some phonemes but **[u̯]** and **[i̯]**.

The point is, why were these phones included? They are not phonemes (differently from **/j/=[j]** and **/w/=[w]**), because no italian would ever recognize the difference between **[i] - [i̯]** and **[u]=[u̯]** unless he studied phonetic (and hardly recognize it even if he did). These should only be included in the narrow transcription.

Another point in support of this. If you were to include **[i̯]** and **[u̯]** then you would have to include also all the possible allophones of **/n/** (**[n̺], [n̪], [ŋ], [ɱ]**) which are not in the broad transcription but there are in the narrow one.

If you have any questions I will gladly answer them.