### PR TITLE
Drop support for Python 3.6 and add 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.2.0
+  # https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.5.0
 
 
 jobs:
@@ -13,7 +14,9 @@ jobs:
       command-run:
         type: string
     docker:
-      - image: cimg/python:3.9
+      # Use the latest Python 3.x image from CircleCI that WikiPron supports.
+      # See: https://circleci.com/developer/images/image/cimg/python
+      - image: cimg/python:3.10
         #auth:
         #  username: $DOCKERHUB_USERNAME
         #  password: $DOCKERHUB_PASSWORD
@@ -87,5 +90,4 @@ workflows:
             - mypy
           matrix:
             parameters:
-              python-version: ["3.6", "3.7", "3.8", "3.9"]
-
+              python-version: ["3.7", "3.8", "3.9", "3.10"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,15 @@ Unreleased
 
 #### Added
 
+-  Added support for Python 3.10. (\#462)
 -  Added test of phones list generation in `test_data/test_summary.py` (\#363)
 -  Added Min Nan extraction function. (\#397)
 -  Added Tai Dam extraction function, configuration and initial scrape. (\#435)
 -  Added test of `casefold` value for languages in `data/scrape/lib/languages.json` (\#442)
+
+#### Removed
+
+-  Dropped support for Python 3.6. (\#462)
 
 [1.2.0] - 2021-01-30
 --------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ requests-html==0.10.0
 requests==2.24.0
 segments==2.2.0
 setuptools==50.3.1
-unicodedataplus==13.0.0.post2
+unicodedataplus==14.0.0.post2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==21.12b0
 flake8==3.8.4
 iso639==0.1.4
 mypy==0.790
-pytest==6.1.1
+pytest==7.0.0
 requests-html==0.10.0
 requests==2.24.0
 segments==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def main():
         ],
         license="Apache 2.0",
         packages=setuptools.find_packages(),
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         zip_safe=False,
         setup_requires=["setuptools>=39"],
         install_requires=[
@@ -46,10 +46,10 @@ def main():
         classifiers=[
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Development Status :: 3 - Alpha",
             "Environment :: Console",
             "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ def main():
             "requests-html",
             "segments>=2.2.0,<3",
             "setuptools",
-            "unicodedataplus",
         ],
         entry_points={"console_scripts": ["wikipron = wikipron.cli:main"]},
         classifiers=[


### PR DESCRIPTION
This PR drops support for Python 3.6 and adds 3.10.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
