### PR TITLE
remove default casefolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Unreleased
 
 #### Changed
 
--   Switched to ISO 639-3 language codes. (\#468)
+-   Removed `casefold:true` from langauges.json and rescraped `hye` and `apw` (\#469)
 -   Updated scraped data in preparation for the SIGMORPHON 2022 shared task:
     `swe nno ger dut ita rum ukr bel tgl ceb ben asm per pus tha lwl`. (\#461)
 -   Made scripts under `data/frequencies/` and `data/morphology/` more flexible,

--- a/data/scrape/lib/languages.json
+++ b/data/scrape/lib/languages.json
@@ -1,55 +1,33 @@
 {
-    "aar": {
-        "iso639_name": "Afar",
-        "wiktionary_name": "Afar",
-        "wiktionary_code": "aa",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "abk": {
         "iso639_name": "Abkhazian",
         "wiktionary_name": "Abkhaz",
         "wiktionary_code": "ab",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "cyrl": "Cyrillic"
         }
     },
-    "acw": {
-        "iso639_name": "Hijazi Arabic",
-        "wiktionary_name": "Hijazi Arabic",
-        "wiktionary_code": "acw",
-        "casefold": false,
-        "script": {
-            "arab": "Arabic"
-        }
-    },
     "ady": {
-        "iso639_name": "Adygei; Adyghe",
+        "iso639_name": "Adyghe",
         "wiktionary_name": "Adyghe",
         "wiktionary_code": "ady",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
         }
     },
-    "afb": {
-        "iso639_name": "Gulf Arabic",
-        "wiktionary_name": "Gulf Arabic",
-        "wiktionary_code": "afb",
-        "casefold": false,
+    "aar": {
+        "iso639_name": "Afar",
+        "wiktionary_name": "Afar",
+        "wiktionary_code": "aa",
         "script": {
-            "arab": "Arabic"
+            "latn": "Latin"
         }
     },
     "afr": {
         "iso639_name": "Afrikaans",
         "wiktionary_name": "Afrikaans",
         "wiktionary_code": "af",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -58,37 +36,42 @@
         "iso639_name": "Ainu (Japan)",
         "wiktionary_name": "Ainu",
         "wiktionary_code": "ain",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "kana": "Katakana",
             "cyrl": "Cyrillic"
         }
     },
-    "ajp": {
-        "iso639_name": "South Levantine Arabic",
-        "wiktionary_name": "South Levantine Arabic",
-        "wiktionary_code": "ajp",
-        "casefold": false,
-        "script": {
-            "arab": "Arabic"
-        }
-    },
     "akk": {
         "iso639_name": "Akkadian",
         "wiktionary_name": "Akkadian",
         "wiktionary_code": "akk",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "xsux": "Cuneiform"
+        }
+    },
+    "sqi": {
+        "iso639_name": "Albanian",
+        "wiktionary_name": "Albanian",
+        "wiktionary_code": "sq",
+        "script": {
+            "latn": "Latin",
+            "grek": "Greek"
+        }
+    },
+    "gsw": {
+        "iso639_name": "Swiss German",
+        "wiktionary_name": "Alemannic German",
+        "wiktionary_code": "gsw",
+        "script": {
+            "latn": "Latin"
         }
     },
     "ale": {
         "iso639_name": "Aleut",
         "wiktionary_name": "Aleut",
         "wiktionary_code": "ale",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -97,7 +80,6 @@
         "iso639_name": "Alutor",
         "wiktionary_name": "Alutor",
         "wiktionary_code": "alr",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
         }
@@ -111,32 +93,12 @@
             "ethi": "Ethiopic"
         }
     },
-    "ang": {
-        "iso639_name": "Old English (ca. 450-1100)",
-        "wiktionary_name": "Old English",
-        "wiktionary_code": "ang",
-        "casefold": true,
+    "grc": {
+        "iso639_name": "Ancient Greek (to 1453)",
+        "wiktionary_name": "Ancient Greek",
+        "wiktionary_code": "grc",
         "script": {
-            "latn": "Latin"
-        }
-    },
-    "aot": {
-        "iso639_name": "Atong (India)",
-        "wiktionary_name": "Atong (India)",
-        "wiktionary_code": "aot",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "beng": "Bengali"
-        }
-    },
-    "apw": {
-        "iso639_name": "Western Apache",
-        "wiktionary_name": "Western Apache",
-        "wiktionary_code": "apw",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
+            "grek": "Greek"
         }
     },
     "ara": {
@@ -150,7 +112,7 @@
         }
     },
     "arc": {
-        "iso639_name": "Imperial Aramaic (700-300 BCE); Official Aramaic (700-300 BCE)",
+        "iso639_name": "Official Aramaic (700-300 BCE)",
         "wiktionary_name": "Aramaic",
         "wiktionary_code": "arc",
         "casefold": false,
@@ -160,22 +122,24 @@
             "syrc": "Syriac"
         }
     },
-    "ary": {
-        "iso639_name": "Moroccan Arabic",
-        "wiktionary_name": "Moroccan Arabic",
-        "wiktionary_code": "ary",
-        "casefold": false,
+    "hye": {
+        "iso639_name": "Armenian",
+        "wiktionary_name": "Armenian",
+        "wiktionary_code": "hy",
+        "dialect": {
+            "w": "Western Armenian, standard",
+            "e": "Eastern Armenian, standard"
+        },
         "script": {
-            "arab": "Arabic"
+            "armn": "Armenian"
         }
     },
-    "arz": {
-        "iso639_name": "Egyptian Arabic",
-        "wiktionary_name": "Egyptian Arabic",
-        "wiktionary_code": "arz",
-        "casefold": false,
+    "rup": {
+        "iso639_name": "Macedo-Romanian",
+        "wiktionary_name": "Aromanian",
+        "wiktionary_code": "rup",
         "script": {
-            "arab": "Arabic"
+            "latn": "Latin"
         }
     },
     "asm": {
@@ -188,51 +152,44 @@
             "ahom": "Ahom"
         }
     },
+    "aii": {
+        "iso639_name": "Assyrian Neo-Aramaic",
+        "wiktionary_name": "Assyrian Neo-Aramaic",
+        "wiktionary_code": "aii",
+        "casefold": null
+    },
     "ast": {
         "iso639_name": "Asturian",
         "wiktionary_name": "Asturian",
         "wiktionary_code": "ast",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "ayl": {
-        "iso639_name": "Libyan Arabic",
-        "wiktionary_name": "Libyan Arabic",
-        "wiktionary_code": "ayl",
-        "casefold": false,
+    "aot": {
+        "iso639_name": "Atong (India)",
+        "wiktionary_name": "Atong (India)",
+        "wiktionary_code": "aot",
         "script": {
-            "arab": "Arabic"
+            "latn": "Latin",
+            "beng": "Bengali"
         }
     },
     "aze": {
         "iso639_name": "Azerbaijani",
         "wiktionary_name": "Azerbaijani",
         "wiktionary_code": "az",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "cyrl": "Cyrillic",
             "arab": "Arabic"
         }
     },
-    "azg": {
-        "iso639_name": "San Pedro Amuzgos Amuzgo",
-        "wiktionary_name": "San Pedro Amuzgos Amuzgo",
-        "wiktionary_code": "azg",
-        "casefold": true,
+    "bdq": {
+        "iso639_name": "Bahnar",
+        "wiktionary_name": "Bahnar",
+        "wiktionary_code": "bdq",
         "script": {
-            "latn": "Latin"
-        }
-    },
-    "bak": {
-        "iso639_name": "Bashkir",
-        "wiktionary_name": "Bashkir",
-        "wiktionary_code": "ba",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic",
             "latn": "Latin"
         }
     },
@@ -240,35 +197,44 @@
         "iso639_name": "Balinese",
         "wiktionary_name": "Balinese",
         "wiktionary_code": "ban",
-        "casefold": true,
         "script": {
             "bali": "Balinese",
             "latn": "Latin"
         }
     },
-    "bcl": {
-        "iso639_name": "Central Bikol",
-        "wiktionary_name": "Bikol Central",
-        "wiktionary_code": "bcl",
-        "casefold": true,
+    "bjb": {
+        "iso639_name": "Banggarla",
+        "wiktionary_name": "Barngarla",
+        "wiktionary_code": "bjb",
+        "casefold": null
+    },
+    "bak": {
+        "iso639_name": "Bashkir",
+        "wiktionary_name": "Bashkir",
+        "wiktionary_code": "ba",
+        "script": {
+            "cyrl": "Cyrillic",
+            "latn": "Latin"
+        }
+    },
+    "eus": {
+        "iso639_name": "Basque",
+        "wiktionary_name": "Basque",
+        "wiktionary_code": "eu",
         "script": {
             "latn": "Latin"
         }
     },
-    "bdq": {
-        "iso639_name": "Bahnar",
-        "wiktionary_name": "Bahnar",
-        "wiktionary_code": "bdq",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
+    "bar": {
+        "iso639_name": "Bavarian",
+        "wiktionary_name": "Bavarian",
+        "wiktionary_code": "bar",
+        "casefold": null
     },
     "bel": {
         "iso639_name": "Belarusian",
         "wiktionary_name": "Belarusian",
         "wiktionary_code": "be",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
         }
@@ -282,30 +248,34 @@
             "beng": "Bengali"
         }
     },
-    "blt": {
-        "iso639_name": "Tai Dam",
-        "wiktionary_name": "Tai Dam",
-        "wiktionary_code": "blt",
-        "casefold": false,
+    "bcl": {
+        "iso639_name": "Central Bikol",
+        "wiktionary_name": "Bikol Central",
+        "wiktionary_code": "bcl",
         "script": {
-            "tavt": "Tai Viet"
+            "latn": "Latin"
         }
     },
-    "bod": {
-        "iso639_name": "Tibetan",
-        "wiktionary_name": "Tibetan",
-        "wiktionary_code": "bo",
-        "casefold": false,
-        "skip_spaces_pron": false,
+    "pcc": {
+        "iso639_name": "Bouyei",
+        "wiktionary_name": "Bouyei",
+        "wiktionary_code": "pcc",
         "script": {
-            "tibt": "Tibetan"
+            "latn": "Latin"
         }
     },
     "bre": {
         "iso639_name": "Breton",
         "wiktionary_name": "Breton",
         "wiktionary_code": "br",
-        "casefold": true,
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "kxd": {
+        "iso639_name": "Brunei",
+        "wiktionary_name": "Brunei Malay",
+        "wiktionary_code": "kxd",
         "script": {
             "latn": "Latin"
         }
@@ -314,75 +284,71 @@
         "iso639_name": "Bulgarian",
         "wiktionary_name": "Bulgarian",
         "wiktionary_code": "bg",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
         }
     },
-    "cat": {
-        "iso639_name": "Catalan; Valencian",
-        "wiktionary_name": "Catalan",
-        "wiktionary_code": "ca",
-        "casefold": true,
+    "mya": {
+        "iso639_name": "Burmese",
+        "wiktionary_name": "Burmese",
+        "wiktionary_code": "my",
+        "casefold": false,
         "script": {
+            "mymr": "Myanmar",
             "latn": "Latin"
         }
     },
-    "cbn": {
-        "iso639_name": "Nyahkur",
-        "wiktionary_name": "Nyah Kur",
-        "wiktionary_code": "cbn",
+    "bua": {
+        "iso639_name": "Buriat",
+        "wiktionary_name": "Buryat",
+        "wiktionary_code": "bua",
+        "casefold": null
+    },
+    "yue": {
+        "iso639_name": "Yue Chinese",
+        "wiktionary_name": "Cantonese",
+        "wiktionary_code": "yue",
+        "skip_spaces_pron": false,
         "casefold": false,
         "script": {
-            "thai": "Thai",
-            "mymr": "Myanmar"
+            "latn": "Latin",
+            "hira": "Hiragana",
+            "bopo": "Bopomofo",
+            "hani": "Han"
+        }
+    },
+    "crx": {
+        "iso639_name": "Carrier",
+        "wiktionary_name": "Carrier",
+        "wiktionary_code": "crx",
+        "casefold": false,
+        "script": {
+            "cans": "Canadian Aboriginal"
+        }
+    },
+    "cat": {
+        "iso639_name": "Catalan",
+        "wiktionary_name": "Catalan",
+        "wiktionary_code": "ca",
+        "script": {
+            "latn": "Latin"
         }
     },
     "ceb": {
         "iso639_name": "Cebuano",
         "wiktionary_name": "Cebuano",
         "wiktionary_code": "ceb",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "ces": {
-        "iso639_name": "Czech",
-        "wiktionary_name": "Czech",
-        "wiktionary_code": "cs",
-        "casefold": true,
+    "tzm": {
+        "iso639_name": "Central Atlas Tamazight",
+        "wiktionary_name": "Central Atlas Tamazight",
+        "wiktionary_code": "tzm",
+        "casefold": false,
         "script": {
-            "latn": "Latin"
-        }
-    },
-    "chb": {
-        "iso639_name": "Chibcha",
-        "wiktionary_name": "Chibcha",
-        "wiktionary_code": "chb",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "che": {
-        "iso639_name": "Chechen",
-        "wiktionary_name": "Chechen",
-        "wiktionary_code": "ce",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
-        }
-    },
-    "cho": {
-        "iso639_name": "Choctaw",
-        "wiktionary_name": "Choctaw",
-        "wiktionary_code": "cho",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
+            "tfng": "Tifinagh"
         }
     },
     "ckb": {
@@ -395,30 +361,76 @@
             "latn": "Latin"
         }
     },
-    "cmn": {
-        "iso639_name": "Mandarin Chinese",
-        "wiktionary_name": "Chinese",
-        "wiktionary_code": "zh",
-        "casefold": false,
-        "skip_spaces_pron": false,
-        "script": {
-            "hani": "Han"
-        }
-    },
-    "cnk": {
-        "iso639_name": "Khumi Chin",
-        "wiktionary_name": "Khumi Chin",
-        "wiktionary_code": "cnk",
-        "casefold": true,
+    "nhn": {
+        "iso639_name": "Central Nahuatl",
+        "wiktionary_name": "Central Nahuatl",
+        "wiktionary_code": "nhn",
         "script": {
             "latn": "Latin"
+        }
+    },
+    "che": {
+        "iso639_name": "Chechen",
+        "wiktionary_name": "Chechen",
+        "wiktionary_code": "ce",
+        "script": {
+            "latn": "Latin",
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
+        }
+    },
+    "chb": {
+        "iso639_name": "Chibcha",
+        "wiktionary_name": "Chibcha",
+        "wiktionary_code": "chb",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "nya": {
+        "iso639_name": "Nyanja",
+        "wiktionary_name": "Chichewa",
+        "wiktionary_code": "ny",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "zho": {
+        "iso639_name": "Chinese",
+        "wiktionary_name": "Chinese",
+        "wiktionary_code": "zh",
+        "casefold": null
+    },
+    "cho": {
+        "iso639_name": "Choctaw",
+        "wiktionary_name": "Choctaw",
+        "wiktionary_code": "cho",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "nci": {
+        "iso639_name": "Classical Nahuatl",
+        "wiktionary_name": "Classical Nahuatl",
+        "wiktionary_code": "nci",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "syc": {
+        "iso639_name": "Classical Syriac",
+        "wiktionary_name": "Classical Syriac",
+        "wiktionary_code": "syc",
+        "casefold": false,
+        "script": {
+            "syrc": "Syriac",
+            "hebr": "Hebrew"
         }
     },
     "cop": {
         "iso639_name": "Coptic",
         "wiktionary_name": "Coptic",
         "wiktionary_code": "cop",
-        "casefold": true,
         "script": {
             "copt": "Coptic"
         }
@@ -427,7 +439,6 @@
         "iso639_name": "Cornish",
         "wiktionary_name": "Cornish",
         "wiktionary_code": "kw",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -436,48 +447,22 @@
         "iso639_name": "Corsican",
         "wiktionary_name": "Corsican",
         "wiktionary_code": "co",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "crk": {
-        "iso639_name": "Plains Cree",
-        "wiktionary_name": "Plains Cree",
-        "wiktionary_code": "crk",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "cans": "Canadian Aboriginal"
-        }
-    },
-    "crx": {
-        "iso639_name": "Carrier",
-        "wiktionary_name": "Carrier",
-        "wiktionary_code": "crx",
-        "casefold": false,
-        "script": {
-            "cans": "Canadian Aboriginal"
-        }
-    },
-    "csb": {
-        "iso639_name": "Kashubian",
-        "wiktionary_name": "Kashubian",
-        "wiktionary_code": "csb",
-        "casefold": true,
+    "ces": {
+        "iso639_name": "Czech",
+        "wiktionary_name": "Czech",
+        "wiktionary_code": "cs",
         "script": {
             "latn": "Latin"
         }
     },
-    "cym": {
-        "iso639_name": "Welsh",
-        "wiktionary_name": "Welsh",
-        "wiktionary_code": "cy",
-        "casefold": true,
-        "dialect": {
-            "nw": "North Wales",
-            "sw": "South Wales"
-        },
+    "dlm": {
+        "iso639_name": "Dalmatian",
+        "wiktionary_name": "Dalmatian",
+        "wiktionary_code": "dlm",
         "script": {
             "latn": "Latin"
         }
@@ -486,24 +471,12 @@
         "iso639_name": "Danish",
         "wiktionary_name": "Danish",
         "wiktionary_code": "da",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "deu": {
-        "iso639_name": "German",
-        "wiktionary_name": "German",
-        "wiktionary_code": "de",
-        "casefold": true,
-        "script": {
-            "zyyy": "Common",
-            "latn": "Latin",
-            "hebr": "Hebrew"
-        }
-    },
     "div": {
-        "iso639_name": "Dhivehi, Divehi, Maldivian",
+        "iso639_name": "Dhivehi",
         "wiktionary_name": "Dhivehi",
         "wiktionary_code": "dv",
         "casefold": false,
@@ -513,11 +486,10 @@
             "arab": "Arabic"
         }
     },
-    "dlm": {
-        "iso639_name": "Dalmatian",
-        "wiktionary_name": "Dalmatian",
-        "wiktionary_code": "dlm",
-        "casefold": true,
+    "sce": {
+        "iso639_name": "Dongxiang",
+        "wiktionary_name": "Dongxiang",
+        "wiktionary_code": "sce",
         "script": {
             "latn": "Latin"
         }
@@ -527,25 +499,14 @@
         "wiktionary_name": "Dungan",
         "wiktionary_code": "dng",
         "skip_spaces_pron": false,
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
         }
     },
-    "dsb": {
-        "iso639_name": "Lower Sorbian",
-        "wiktionary_name": "Lower Sorbian",
-        "wiktionary_code": "dsb",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "dum": {
-        "iso639_name": "Middle Dutch (ca. 1050-1350)",
-        "wiktionary_name": "Middle Dutch",
-        "wiktionary_code": "dum",
-        "casefold": true,
+    "nld": {
+        "iso639_name": "Dutch",
+        "wiktionary_name": "Dutch",
+        "wiktionary_code": "nl",
         "script": {
             "latn": "Latin"
         }
@@ -559,13 +520,22 @@
             "tibt": "Tibetan"
         }
     },
-    "egl": {
-        "iso639_name": "Emilian",
-        "wiktionary_name": "Emilian",
-        "wiktionary_code": "egl",
-        "casefold": true,
+    "lwl": {
+        "iso639_name": "Eastern Lawa",
+        "wiktionary_name": "Eastern Lawa",
+        "wiktionary_code": "lwl",
+        "casefold": false,
         "script": {
-            "latn": "Latin"
+            "thai": "Thai"
+        }
+    },
+    "arz": {
+        "iso639_name": "Egyptian Arabic",
+        "wiktionary_name": "Egyptian Arabic",
+        "wiktionary_code": "arz",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
         }
     },
     "egy": {
@@ -577,20 +547,18 @@
             "latn": "Latin"
         }
     },
-    "ell": {
-        "iso639_name": "Modern Greek (1453-)",
-        "wiktionary_name": "Greek",
-        "wiktionary_code": "el",
-        "casefold": true,
+    "egl": {
+        "iso639_name": "Emilian",
+        "wiktionary_name": "Emilian",
+        "wiktionary_code": "egl",
         "script": {
-            "grek": "Greek"
+            "latn": "Latin"
         }
     },
     "eng": {
         "iso639_name": "English",
         "wiktionary_name": "English",
         "wiktionary_code": "en",
-        "casefold": true,
         "dialect": {
             "us": "US | General American",
             "uk": "UK | Received Pronunciation"
@@ -601,20 +569,10 @@
             "grek": "Greek"
         }
     },
-    "enm": {
-        "iso639_name": "Middle English (1100-1500)",
-        "wiktionary_name": "Middle English",
-        "wiktionary_code": "enm",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "epo": {
         "iso639_name": "Esperanto",
         "wiktionary_name": "Esperanto",
         "wiktionary_code": "eo",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -623,7 +581,6 @@
         "iso639_name": "Estonian",
         "wiktionary_name": "Estonian",
         "wiktionary_code": "et",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -637,49 +594,38 @@
             "ital": "Old Italic"
         }
     },
-    "eus": {
-        "iso639_name": "Basque",
-        "wiktionary_name": "Basque",
-        "wiktionary_code": "eu",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
+    "evn": {
+        "iso639_name": "Evenki",
+        "wiktionary_name": "Evenki",
+        "wiktionary_code": "evn",
+        "casefold": null
     },
     "ewe": {
         "iso639_name": "Ewe",
         "wiktionary_name": "Ewe",
         "wiktionary_code": "ee",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
+    },
+    "gur": {
+        "iso639_name": "Farefare",
+        "wiktionary_name": "Farefare",
+        "wiktionary_code": "gur",
+        "casefold": null
     },
     "fao": {
         "iso639_name": "Faroese",
         "wiktionary_name": "Faroese",
         "wiktionary_code": "fo",
-        "casefold": true,
         "script": {
             "latn": "Latin"
-        }
-    },
-    "fas": {
-        "iso639_name": "Persian",
-        "wiktionary_name": "Persian",
-        "wiktionary_code": "fa",
-        "casefold": false,
-        "skip_spaces_pron": false,
-        "script": {
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
         }
     },
     "fin": {
         "iso639_name": "Finnish",
         "wiktionary_name": "Finnish",
         "wiktionary_code": "fi",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -688,52 +634,6 @@
         "iso639_name": "French",
         "wiktionary_name": "French",
         "wiktionary_code": "fr",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "fro": {
-        "iso639_name": "Old French (842-ca. 1400)",
-        "wiktionary_name": "Old French",
-        "wiktionary_code": "fro",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "frr": {
-        "iso639_name": "Northern Frisian",
-        "wiktionary_name": "North Frisian",
-        "wiktionary_code": "frr",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "fry": {
-        "iso639_name": "Western Frisian",
-        "wiktionary_name": "West Frisian",
-        "wiktionary_code": "fy",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "gla": {
-        "iso639_name": "Gaelic; Scottish Gaelic",
-        "wiktionary_name": "Scottish Gaelic",
-        "wiktionary_code": "gd",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "gle": {
-        "iso639_name": "Irish",
-        "wiktionary_name": "Irish",
-        "wiktionary_code": "ga",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -742,64 +642,66 @@
         "iso639_name": "Galician",
         "wiktionary_name": "Galician",
         "wiktionary_code": "gl",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "glv": {
-        "iso639_name": "Manx",
-        "wiktionary_name": "Manx",
-        "wiktionary_code": "gv",
-        "casefold": true,
+    "kld": {
+        "iso639_name": "Gamilaraay",
+        "wiktionary_name": "Gamilaraay",
+        "wiktionary_code": "kld",
         "script": {
             "latn": "Latin"
         }
     },
-    "gml": {
-        "iso639_name": "Middle Low German",
-        "wiktionary_name": "Middle Low German",
-        "wiktionary_code": "gml",
-        "casefold": true,
+    "kat": {
+        "iso639_name": "Georgian",
+        "wiktionary_name": "Georgian",
+        "wiktionary_code": "ka",
+        "casefold": false,
         "script": {
-            "latn": "Latin"
+            "geor": "Georgian"
         }
     },
-    "goh": {
-        "iso639_name": "Old High German (ca. 750-1050)",
-        "wiktionary_name": "Old High German",
-        "wiktionary_code": "goh",
-        "casefold": true,
+    "deu": {
+        "iso639_name": "German",
+        "wiktionary_name": "German",
+        "wiktionary_code": "de",
         "script": {
-            "latn": "Latin"
+            "zyyy": "Common",
+            "latn": "Latin",
+            "hebr": "Hebrew"
         }
     },
     "got": {
         "iso639_name": "Gothic",
         "wiktionary_name": "Gothic",
         "wiktionary_code": "got",
-        "casefold": true,
         "script": {
             "goth": "Gothic"
         }
     },
-    "grc": {
-        "iso639_name": "Ancient Greek (to 1453)",
-        "wiktionary_name": "Ancient Greek",
-        "wiktionary_code": "grc",
-        "casefold": true,
+    "ell": {
+        "iso639_name": "Modern Greek (1453-)",
+        "wiktionary_name": "Greek",
+        "wiktionary_code": "el",
         "script": {
             "grek": "Greek"
         }
     },
-    "gsw": {
-        "iso639_name": "Swiss German",
-        "wiktionary_name": "Alemannic German",
-        "wiktionary_code": "gsw",
-        "casefold": true,
+    "kal": {
+        "iso639_name": "Kalaallisut",
+        "wiktionary_name": "Greenlandic",
+        "wiktionary_code": "kl",
         "script": {
             "latn": "Latin"
         }
+    },
+    "grn": {
+        "iso639_name": "Guarani",
+        "wiktionary_name": "Guaraní",
+        "wiktionary_code": "gn",
+        "casefold": null
     },
     "guj": {
         "iso639_name": "Gujarati",
@@ -812,11 +714,39 @@
             "arab": "Arabic"
         }
     },
+    "afb": {
+        "iso639_name": "Gulf Arabic",
+        "wiktionary_name": "Gulf Arabic",
+        "wiktionary_code": "afb",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
+        }
+    },
+    "guw": {
+        "iso639_name": "Gun",
+        "wiktionary_name": "Gun",
+        "wiktionary_code": "guw",
+        "casefold": null
+    },
+    "hts": {
+        "iso639_name": "Hadza",
+        "wiktionary_name": "Hadza",
+        "wiktionary_code": "hts",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "hat": {
+        "iso639_name": "Haitian",
+        "wiktionary_name": "Haitian Creole",
+        "wiktionary_code": "ht",
+        "casefold": null
+    },
     "hau": {
         "iso639_name": "Hausa",
         "wiktionary_name": "Hausa",
         "wiktionary_code": "ha",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "arab": "Arabic"
@@ -826,21 +756,9 @@
         "iso639_name": "Hawaiian",
         "wiktionary_name": "Hawaiian",
         "wiktionary_code": "haw",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "zyyy": "Common"
-        }
-    },
-    "hbs": {
-        "iso639_name": "Serbo-Croatian",
-        "wiktionary_name": "Serbo-Croatian",
-        "wiktionary_code": "sh",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
         }
     },
     "heb": {
@@ -852,6 +770,15 @@
             "hebr": "Hebrew"
         }
     },
+    "acw": {
+        "iso639_name": "Hijazi Arabic",
+        "wiktionary_name": "Hijazi Arabic",
+        "wiktionary_code": "acw",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
+        }
+    },
     "hin": {
         "iso639_name": "Hindi",
         "wiktionary_name": "Hindi",
@@ -861,60 +788,40 @@
             "deva": "Devanagari"
         }
     },
-    "hrx": {
-        "iso639_name": "Hunsrik",
-        "wiktionary_name": "Hunsrik",
-        "wiktionary_code": "hrx",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "hts": {
-        "iso639_name": "Hadza",
-        "wiktionary_name": "Hadza",
-        "wiktionary_code": "hts",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "hun": {
         "iso639_name": "Hungarian",
         "wiktionary_name": "Hungarian",
         "wiktionary_code": "hu",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "huu": {
-        "iso639_name": "Murui Huitoto",
-        "wiktionary_name": "Murui Huitoto",
-        "wiktionary_code": "huu",
-        "casefold": true,
+    "hrx": {
+        "iso639_name": "Hunsrik",
+        "wiktionary_name": "Hunsrik",
+        "wiktionary_code": "hrx",
         "script": {
             "latn": "Latin"
         }
     },
-    "hye": {
-        "iso639_name": "Armenian",
-        "wiktionary_name": "Armenian",
-        "wiktionary_code": "hy",
-        "casefold": true,
-        "dialect": {
-            "w": "Western Armenian, standard",
-            "e": "Eastern Armenian, standard"
-        },
+    "iba": {
+        "iso639_name": "Iban",
+        "wiktionary_name": "Iban",
+        "wiktionary_code": "iba",
+        "casefold": null
+    },
+    "isl": {
+        "iso639_name": "Icelandic",
+        "wiktionary_name": "Icelandic",
+        "wiktionary_code": "is",
         "script": {
-            "armn": "Armenian"
+            "latn": "Latin"
         }
     },
     "ido": {
         "iso639_name": "Ido",
         "wiktionary_name": "Ido",
         "wiktionary_code": "io",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -923,16 +830,6 @@
         "iso639_name": "Iloko",
         "wiktionary_name": "Ilocano",
         "wiktionary_code": "ilo",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ina": {
-        "iso639_name": "Interlingua (International Auxiliary Language Association)",
-        "wiktionary_name": "Interlingua",
-        "wiktionary_code": "ia",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -941,18 +838,32 @@
         "iso639_name": "Indonesian",
         "wiktionary_name": "Indonesian",
         "wiktionary_code": "id",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "bali": "Balinese",
             "java": "Javanese"
         }
     },
-    "isl": {
-        "iso639_name": "Icelandic",
-        "wiktionary_name": "Icelandic",
-        "wiktionary_code": "is",
-        "casefold": true,
+    "izh": {
+        "iso639_name": "Ingrian",
+        "wiktionary_name": "Ingrian",
+        "wiktionary_code": "izh",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ina": {
+        "iso639_name": "Interlingua (International Auxiliary Language Association)",
+        "wiktionary_name": "Interlingua",
+        "wiktionary_code": "ia",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "gle": {
+        "iso639_name": "Irish",
+        "wiktionary_name": "Irish",
+        "wiktionary_code": "ga",
         "script": {
             "latn": "Latin"
         }
@@ -961,16 +872,6 @@
         "iso639_name": "Italian",
         "wiktionary_name": "Italian",
         "wiktionary_code": "it",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "izh": {
-        "iso639_name": "Ingrian",
-        "wiktionary_name": "Ingrian",
-        "wiktionary_code": "izh",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -979,18 +880,8 @@
         "iso639_name": "Jamaican Creole English",
         "wiktionary_name": "Jamaican Creole",
         "wiktionary_code": "jam",
-        "casefold": true,
         "script": {
             "latn": "Latin"
-        }
-    },
-    "jje": {
-        "iso639_name": "Jejueo",
-        "wiktionary_name": "Jeju",
-        "wiktionary_code": "jje",
-        "casefold": false,
-        "script": {
-            "hang": "Hangul"
         }
     },
     "jpn": {
@@ -1004,14 +895,42 @@
             "hani": "Han"
         }
     },
-    "kal": {
-        "iso639_name": "Kalaallisut",
-        "wiktionary_name": "Greenlandic",
-        "wiktionary_code": "kl",
-        "casefold": true,
+    "jje": {
+        "iso639_name": "Jejueo",
+        "wiktionary_name": "Jeju",
+        "wiktionary_code": "jje",
+        "casefold": false,
+        "script": {
+            "hang": "Hangul"
+        }
+    },
+    "quc": {
+        "iso639_name": "K'iche'",
+        "wiktionary_name": "K'iche'",
+        "wiktionary_code": "quc",
         "script": {
             "latn": "Latin"
         }
+    },
+    "kbd": {
+        "iso639_name": "Kabardian",
+        "wiktionary_name": "Kabardian",
+        "wiktionary_code": "kbd",
+        "script": {
+            "cyrl": "Cyrillic"
+        }
+    },
+    "kgp": {
+        "iso639_name": "Kaingang",
+        "wiktionary_name": "Kaingang",
+        "wiktionary_code": "kgp",
+        "casefold": null
+    },
+    "xal": {
+        "iso639_name": "Kalmyk",
+        "wiktionary_name": "Kalmyk",
+        "wiktionary_code": "xal",
+        "casefold": null
     },
     "kan": {
         "iso639_name": "Kannada",
@@ -1020,6 +939,20 @@
         "casefold": false,
         "script": {
             "knda": "Kannada"
+        }
+    },
+    "pam": {
+        "iso639_name": "Pampanga",
+        "wiktionary_name": "Kapampangan",
+        "wiktionary_code": "pam",
+        "casefold": null
+    },
+    "krl": {
+        "iso639_name": "Karelian",
+        "wiktionary_name": "Karelian",
+        "wiktionary_code": "krl",
+        "script": {
+            "latn": "Latin"
         }
     },
     "kas": {
@@ -1034,43 +967,22 @@
             "shrd": "Sharada"
         }
     },
-    "kat": {
-        "iso639_name": "Georgian",
-        "wiktionary_name": "Georgian",
-        "wiktionary_code": "ka",
-        "casefold": false,
+    "csb": {
+        "iso639_name": "Kashubian",
+        "wiktionary_name": "Kashubian",
+        "wiktionary_code": "csb",
         "script": {
-            "geor": "Georgian"
+            "latn": "Latin"
         }
     },
     "kaz": {
         "iso639_name": "Kazakh",
         "wiktionary_name": "Kazakh",
         "wiktionary_code": "kk",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "cyrl": "Cyrillic",
             "arab": "Arabic"
-        }
-    },
-    "kbd": {
-        "iso639_name": "Kabardian",
-        "wiktionary_name": "Kabardian",
-        "wiktionary_code": "kbd",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic"
-        }
-    },
-    "khb": {
-        "iso639_name": "L\u00fc",
-        "wiktionary_name": "L\u00fc",
-        "wiktionary_code": "khb",
-        "casefold": false,
-        "script": {
-            "talu": "New Tai Lue",
-            "lana": "Tai Tham"
         }
     },
     "khm": {
@@ -1083,43 +995,29 @@
             "mymr": "Myanmar"
         }
     },
+    "cnk": {
+        "iso639_name": "Khumi Chin",
+        "wiktionary_name": "Khumi Chin",
+        "wiktionary_code": "cnk",
+        "script": {
+            "latn": "Latin"
+        }
+    },
     "kik": {
         "iso639_name": "Kikuyu",
         "wiktionary_name": "Kikuyu",
         "wiktionary_code": "ki",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "kir": {
-        "iso639_name": "Kirghiz",
-        "wiktionary_name": "Kyrgyz",
-        "wiktionary_code": "ky",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
-        }
-    },
-    "kld": {
-        "iso639_name": "Gamilaraay",
-        "wiktionary_name": "Gamilaraay",
-        "wiktionary_code": "kld",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "kmr": {
-        "iso639_name": "Northern Kurdish",
-        "wiktionary_name": "Northern Kurdish",
-        "wiktionary_code": "kmr",
-        "casefold": false,
+    "kpv": {
+        "iso639_name": "Komi-Zyrian",
+        "wiktionary_name": "Komi-Zyrian",
+        "wiktionary_code": "kpv",
         "script": {
             "latn": "Latin",
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
+            "cyrl": "Cyrillic"
         }
     },
     "kok": {
@@ -1141,30 +1039,19 @@
             "hang": "Hangul"
         }
     },
-    "kpv": {
-        "iso639_name": "Komi-Zyrian",
-        "wiktionary_name": "Komi-Zyrian",
-        "wiktionary_code": "kpv",
-        "casefold": true,
+    "kir": {
+        "iso639_name": "Kirghiz",
+        "wiktionary_name": "Kyrgyz",
+        "wiktionary_code": "ky",
         "script": {
-            "latn": "Latin",
-            "cyrl": "Cyrillic"
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
         }
     },
-    "krl": {
-        "iso639_name": "Karelian",
-        "wiktionary_name": "Karelian",
-        "wiktionary_code": "krl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "kxd": {
-        "iso639_name": "Brunei",
-        "wiktionary_name": "Brunei Malay",
-        "wiktionary_code": "kxd",
-        "casefold": true,
+    "lmy": {
+        "iso639_name": "Lamboya",
+        "wiktionary_name": "Laboya",
+        "wiktionary_code": "lmy",
         "script": {
             "latn": "Latin"
         }
@@ -1173,7 +1060,6 @@
         "iso639_name": "Ladino",
         "wiktionary_name": "Ladino",
         "wiktionary_code": "lad",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "hebr": "Hebrew"
@@ -1188,11 +1074,26 @@
             "laoo": "Lao"
         }
     },
+    "lsi": {
+        "iso639_name": "Lashi",
+        "wiktionary_name": "Lashi",
+        "wiktionary_code": "lsi",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ltg": {
+        "iso639_name": "Latgalian",
+        "wiktionary_name": "Latgalian",
+        "wiktionary_code": "ltg",
+        "script": {
+            "latn": "Latin"
+        }
+    },
     "lat": {
         "iso639_name": "Latin",
         "wiktionary_name": "Latin",
         "wiktionary_code": "la",
-        "casefold": true,
         "dialect": {
             "clas": "Classical",
             "eccl": "Ecclesiastical",
@@ -1207,18 +1108,25 @@
         "iso639_name": "Latvian",
         "wiktionary_name": "Latvian",
         "wiktionary_code": "lv",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "lcp": {
-        "iso639_name": "Western Lawa",
-        "wiktionary_name": "Western Lawa",
-        "wiktionary_code": "lcp",
+    "ayl": {
+        "iso639_name": "Libyan Arabic",
+        "wiktionary_name": "Libyan Arabic",
+        "wiktionary_code": "ayl",
         "casefold": false,
         "script": {
-            "thai": "Thai"
+            "arab": "Arabic"
+        }
+    },
+    "lij": {
+        "iso639_name": "Ligurian",
+        "wiktionary_name": "Ligurian",
+        "wiktionary_code": "lij",
+        "script": {
+            "latn": "Latin"
         }
     },
     "lif": {
@@ -1230,20 +1138,10 @@
             "limb": "Limbu"
         }
     },
-    "lij": {
-        "iso639_name": "Ligurian",
-        "wiktionary_name": "Ligurian",
-        "wiktionary_code": "lij",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "lim": {
         "iso639_name": "Limburgan",
         "wiktionary_name": "Limburgish",
         "wiktionary_code": "li",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -1252,7 +1150,6 @@
         "iso639_name": "Lithuanian",
         "wiktionary_name": "Lithuanian",
         "wiktionary_code": "lt",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -1261,7 +1158,22 @@
         "iso639_name": "Liv",
         "wiktionary_name": "Livonian",
         "wiktionary_code": "liv",
-        "casefold": true,
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "olo": {
+        "iso639_name": "Livvi",
+        "wiktionary_name": "Livvi",
+        "wiktionary_code": "olo",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ycl": {
+        "iso639_name": "Lolopo",
+        "wiktionary_name": "Lolopo",
+        "wiktionary_code": "ycl",
         "script": {
             "latn": "Latin"
         }
@@ -1270,72 +1182,81 @@
         "iso639_name": "Lombard",
         "wiktionary_name": "Lombard",
         "wiktionary_code": "lmo",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "lmy": {
-        "iso639_name": "Lamboya",
-        "wiktionary_name": "Laboya",
-        "wiktionary_code": "lmy",
-        "casefold": true,
+    "lou": {
+        "iso639_name": "Louisiana Creole",
+        "wiktionary_name": "Louisiana Creole French",
+        "wiktionary_code": "lou",
+        "casefold": null
+    },
+    "nds": {
+        "iso639_name": "Low German",
+        "wiktionary_name": "Low German",
+        "wiktionary_code": "nds",
         "script": {
             "latn": "Latin"
         }
     },
-    "lsi": {
-        "iso639_name": "Lashi",
-        "wiktionary_name": "Lashi",
-        "wiktionary_code": "lsi",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ltg": {
-        "iso639_name": "Latgalian",
-        "wiktionary_name": "Latgalian",
-        "wiktionary_code": "ltg",
-        "casefold": true,
+    "dsb": {
+        "iso639_name": "Lower Sorbian",
+        "wiktionary_name": "Lower Sorbian",
+        "wiktionary_code": "dsb",
         "script": {
             "latn": "Latin"
         }
     },
     "ltz": {
-        "iso639_name": "Letzeburgesch; Luxembourgish",
+        "iso639_name": "Luxembourgish",
         "wiktionary_name": "Luxembourgish",
         "wiktionary_code": "lb",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "lwl": {
-        "iso639_name": "Eastern Lawa",
-        "wiktionary_name": "Eastern Lawa",
-        "wiktionary_code": "lwl",
+    "khb": {
+        "iso639_name": "Lü",
+        "wiktionary_name": "Lü",
+        "wiktionary_code": "khb",
         "casefold": false,
         "script": {
-            "thai": "Thai"
+            "talu": "New Tai Lue",
+            "lana": "Tai Tham"
         }
     },
-    "mah": {
-        "iso639_name": "Marshallese",
-        "wiktionary_name": "Marshallese",
-        "wiktionary_code": "mh",
-        "casefold": true,
+    "mkd": {
+        "iso639_name": "Macedonian",
+        "wiktionary_name": "Macedonian",
+        "wiktionary_code": "mk",
         "script": {
-            "latn": "Latin"
+            "cyrl": "Cyrillic"
         }
     },
     "mak": {
         "iso639_name": "Makasar",
         "wiktionary_name": "Makasar",
         "wiktionary_code": "mak",
-        "casefold": true,
         "script": {
             "latn": "Latin"
+        }
+    },
+    "mlg": {
+        "iso639_name": "Malagasy",
+        "wiktionary_name": "Malagasy",
+        "wiktionary_code": "mg",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "msa": {
+        "iso639_name": "Malay (macrolanguage)",
+        "wiktionary_name": "Malay",
+        "wiktionary_code": "ms",
+        "script": {
+            "latn": "Latin",
+            "arab": "Arabic"
         }
     },
     "mal": {
@@ -1348,74 +1269,10 @@
             "arab": "Arabic"
         }
     },
-    "mar": {
-        "iso639_name": "Marathi",
-        "wiktionary_name": "Marathi",
-        "wiktionary_code": "mr",
-        "casefold": false,
-        "script": {
-            "deva": "Devanagari"
-        }
-    },
-    "mdf": {
-        "iso639_name": "Moksha",
-        "wiktionary_name": "Moksha",
-        "wiktionary_code": "mdf",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic"
-        }
-    },
-    "mfe": {
-        "iso639_name": "Morisyen",
-        "wiktionary_name": "Mauritian Creole",
-        "wiktionary_code": "mfe",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "mga": {
-        "iso639_name": "Middle Irish (900-1200)",
-        "wiktionary_name": "Middle Irish",
-        "wiktionary_code": "mga",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "mic": {
-        "iso639_name": "Mi'kmaq",
-        "wiktionary_name": "Mi'kmaq",
-        "wiktionary_code": "mic",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "mkd": {
-        "iso639_name": "Macedonian",
-        "wiktionary_name": "Macedonian",
-        "wiktionary_code": "mk",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic"
-        }
-    },
-    "mlg": {
-        "iso639_name": "Malagasy",
-        "wiktionary_name": "Malagasy",
-        "wiktionary_code": "mg",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "mlt": {
         "iso639_name": "Maltese",
         "wiktionary_name": "Maltese",
         "wiktionary_code": "mt",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -1427,6 +1284,150 @@
         "casefold": false,
         "script": {
             "mong": "Mongolian"
+        }
+    },
+    "glv": {
+        "iso639_name": "Manx",
+        "wiktionary_name": "Manx",
+        "wiktionary_code": "gv",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "mri": {
+        "iso639_name": "Maori",
+        "wiktionary_name": "Maori",
+        "wiktionary_code": "mi",
+        "casefold": null
+    },
+    "mch": {
+        "iso639_name": "Maquiritari",
+        "wiktionary_name": "Maquiritari",
+        "wiktionary_code": "mch",
+        "casefold": null
+    },
+    "mar": {
+        "iso639_name": "Marathi",
+        "wiktionary_name": "Marathi",
+        "wiktionary_code": "mr",
+        "casefold": false,
+        "script": {
+            "deva": "Devanagari"
+        }
+    },
+    "mah": {
+        "iso639_name": "Marshallese",
+        "wiktionary_name": "Marshallese",
+        "wiktionary_code": "mh",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "mfe": {
+        "iso639_name": "Morisyen",
+        "wiktionary_name": "Mauritian Creole",
+        "wiktionary_code": "mfe",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "nhx": {
+        "iso639_name": "Isthmus-Mecayapan Nahuatl",
+        "wiktionary_name": "Mecayapan Nahuatl",
+        "wiktionary_code": "nhx",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "mic": {
+        "iso639_name": "Mi'kmaq",
+        "wiktionary_name": "Mi'kmaq",
+        "wiktionary_code": "mic",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "dum": {
+        "iso639_name": "Middle Dutch (ca. 1050-1350)",
+        "wiktionary_name": "Middle Dutch",
+        "wiktionary_code": "dum",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "enm": {
+        "iso639_name": "Middle English (1100-1500)",
+        "wiktionary_name": "Middle English",
+        "wiktionary_code": "enm",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "mga": {
+        "iso639_name": "Middle Irish (900-1200)",
+        "wiktionary_name": "Middle Irish",
+        "wiktionary_code": "mga",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "okm": {
+        "iso639_name": "Middle Korean (10th-16th cent.)",
+        "wiktionary_name": "Middle Korean",
+        "wiktionary_code": "okm",
+        "casefold": false,
+        "script": {
+            "hang": "Hangul"
+        }
+    },
+    "gml": {
+        "iso639_name": "Middle Low German",
+        "wiktionary_name": "Middle Low German",
+        "wiktionary_code": "gml",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "wlm": {
+        "iso639_name": "Middle Welsh",
+        "wiktionary_name": "Middle Welsh",
+        "wiktionary_code": "wlm",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "nan": {
+        "iso639_name": "Min Nan Chinese",
+        "wiktionary_name": "Min Nan",
+        "wiktionary_code": "nan",
+        "skip_spaces_pron": false,
+        "dialect": {
+            "xi": "Xiamen"
+        },
+        "script": {
+            "zyyy": "Common",
+            "latn": "Latin",
+            "hira": "Hiragana",
+            "hani": "Han"
+        }
+    },
+    "mvi": {
+        "iso639_name": "Miyako",
+        "wiktionary_name": "Miyako",
+        "wiktionary_code": "mvi",
+        "casefold": false,
+        "script": {
+            "hira": "Hiragana",
+            "kana": "Katakana",
+            "hani": "Han"
+        }
+    },
+    "mdf": {
+        "iso639_name": "Moksha",
+        "wiktionary_name": "Moksha",
+        "wiktionary_code": "mdf",
+        "script": {
+            "cyrl": "Cyrillic"
         }
     },
     "mnw": {
@@ -1442,83 +1443,39 @@
         "iso639_name": "Mongolian",
         "wiktionary_name": "Mongolian",
         "wiktionary_code": "mn",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic",
             "latn": "Latin",
             "mong": "Mongolian"
         }
     },
-    "mqs": {
-        "iso639_name": "West Makian",
-        "wiktionary_name": "West Makian",
-        "wiktionary_code": "mqs",
-        "casefold": true,
+    "ary": {
+        "iso639_name": "Moroccan Arabic",
+        "wiktionary_name": "Moroccan Arabic",
+        "wiktionary_code": "ary",
+        "casefold": false,
         "script": {
-            "latn": "Latin"
-        }
-    },
-    "msa": {
-        "iso639_name": "Malay (macrolanguage)",
-        "wiktionary_name": "Malay",
-        "wiktionary_code": "ms",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
             "arab": "Arabic"
         }
     },
-    "mvi": {
-        "iso639_name": "Miyako",
-        "wiktionary_name": "Miyako",
-        "wiktionary_code": "mvi",
-        "casefold": false,
-        "script": {
-            "hira": "Hiragana",
-            "kana": "Katakana",
-            "hani": "Han"
-        }
+    "mtq": {
+        "iso639_name": "Muong",
+        "wiktionary_name": "Muong",
+        "wiktionary_code": "mtq",
+        "casefold": null
     },
-    "mww": {
-        "iso639_name": "Hmong Daw",
-        "wiktionary_name": "White Hmong",
-        "wiktionary_code": "mww",
-        "casefold": true,
+    "huu": {
+        "iso639_name": "Murui Huitoto",
+        "wiktionary_name": "Murui Huitoto",
+        "wiktionary_code": "huu",
         "script": {
             "latn": "Latin"
         }
     },
-    "mya": {
-        "iso639_name": "Burmese",
-        "wiktionary_name": "Burmese",
-        "wiktionary_code": "my",
-        "casefold": false,
-        "script": {
-            "mymr": "Myanmar",
-            "latn": "Latin"
-        }
-    },
-    "nan": {
-        "iso639_name": "Min Nan Chinese",
-        "wiktionary_name": "Min Nan",
-        "wiktionary_code": "nan",
-        "casefold": true,
-        "skip_spaces_pron": false,
-        "dialect": {
-            "xi": "Xiamen"
-        },
-        "script": {
-            "zyyy": "Common",
-            "latn": "Latin",
-            "hira": "Hiragana",
-            "hani": "Han"
-        }
-    },
-    "nap": {
-        "iso639_name": "Neapolitan",
-        "wiktionary_name": "Neapolitan",
-        "wiktionary_code": "nap",
-        "casefold": true,
+    "nmy": {
+        "iso639_name": "Namuyi",
+        "wiktionary_name": "Namuyi",
+        "wiktionary_code": "nmy",
         "script": {
             "latn": "Latin"
         }
@@ -1527,26 +1484,15 @@
         "iso639_name": "Navajo",
         "wiktionary_name": "Navajo",
         "wiktionary_code": "nv",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "zyyy": "Common"
         }
     },
-    "nci": {
-        "iso639_name": "Classical Nahuatl",
-        "wiktionary_name": "Classical Nahuatl",
-        "wiktionary_code": "nci",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "nds": {
-        "iso639_name": "Low German",
-        "wiktionary_name": "Low German",
-        "wiktionary_code": "nds",
-        "casefold": true,
+    "nap": {
+        "iso639_name": "Neapolitan",
+        "wiktionary_name": "Neapolitan",
+        "wiktionary_code": "nap",
         "script": {
             "latn": "Latin"
         }
@@ -1569,74 +1515,43 @@
             "deva": "Devanagari"
         }
     },
-    "nhg": {
-        "iso639_name": "Tetelcingo Nahuatl",
-        "wiktionary_name": "Tetelcingo Nahuatl",
-        "wiktionary_code": "nhg",
-        "casefold": true,
+    "niv": {
+        "iso639_name": "Gilyak",
+        "wiktionary_name": "Nivkh",
+        "wiktionary_code": "niv",
+        "casefold": null
+    },
+    "nrf": {
+        "iso639_name": "Jèrriais",
+        "wiktionary_name": "Norman",
+        "wiktionary_code": "nrf",
         "script": {
             "latn": "Latin"
         }
     },
-    "nhn": {
-        "iso639_name": "Central Nahuatl",
-        "wiktionary_name": "Central Nahuatl",
-        "wiktionary_code": "nhn",
-        "casefold": true,
+    "frr": {
+        "iso639_name": "Northern Frisian",
+        "wiktionary_name": "North Frisian",
+        "wiktionary_code": "frr",
         "script": {
             "latn": "Latin"
         }
     },
-    "nhx": {
-        "iso639_name": "Isthmus-Mecayapan Nahuatl",
-        "wiktionary_name": "Mecayapan Nahuatl",
-        "wiktionary_code": "nhx",
-        "casefold": true,
+    "kmr": {
+        "iso639_name": "Northern Kurdish",
+        "wiktionary_name": "Northern Kurdish",
+        "wiktionary_code": "kmr",
+        "casefold": false,
         "script": {
-            "latn": "Latin"
+            "latn": "Latin",
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
         }
     },
-    "nld": {
-        "iso639_name": "Dutch; Flemish",
-        "wiktionary_name": "Dutch",
-        "wiktionary_code": "nl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "nmy": {
-        "iso639_name": "Namuyi",
-        "wiktionary_name": "Namuyi",
-        "wiktionary_code": "nmy",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "nno": {
-        "iso639_name": "Norwegian Nynorsk",
-        "wiktionary_name": "Norwegian Nynorsk",
-        "wiktionary_code": "nn",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "nob": {
-        "iso639_name": "Norwegian Bokm\u00e5l",
-        "wiktionary_name": "Norwegian Bokm\u00e5l",
-        "wiktionary_code": "nb",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "non": {
-        "iso639_name": "Old Norse",
-        "wiktionary_name": "Old Norse",
-        "wiktionary_code": "non",
-        "casefold": true,
+    "sme": {
+        "iso639_name": "Northern Sami",
+        "wiktionary_name": "Northern Sami",
+        "wiktionary_code": "se",
         "script": {
             "latn": "Latin"
         }
@@ -1645,259 +1560,48 @@
         "iso639_name": "Norwegian",
         "wiktionary_name": "Norwegian",
         "wiktionary_code": "no",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "nrf": {
-        "iso639_name": "J\u00e8rriais",
-        "wiktionary_name": "Norman",
-        "wiktionary_code": "nrf",
-        "casefold": true,
+    "nob": {
+        "iso639_name": "Norwegian Bokmål",
+        "wiktionary_name": "Norwegian Bokmål",
+        "wiktionary_code": "nb",
         "script": {
             "latn": "Latin"
         }
     },
-    "nya": {
-        "iso639_name": "Nyanja",
-        "wiktionary_name": "Chichewa",
-        "wiktionary_code": "ny",
-        "casefold": true,
+    "nno": {
+        "iso639_name": "Norwegian Nynorsk",
+        "wiktionary_name": "Norwegian Nynorsk",
+        "wiktionary_code": "nn",
         "script": {
             "latn": "Latin"
+        }
+    },
+    "nup": {
+        "iso639_name": "Nupe-Nupe-Tako",
+        "wiktionary_name": "Nupe",
+        "wiktionary_code": "nup",
+        "casefold": null
+    },
+    "cbn": {
+        "iso639_name": "Nyahkur",
+        "wiktionary_name": "Nyah Kur",
+        "wiktionary_code": "cbn",
+        "casefold": false,
+        "script": {
+            "thai": "Thai",
+            "mymr": "Myanmar"
         }
     },
     "oci": {
         "iso639_name": "Occitan (post 1500)",
         "wiktionary_name": "Occitan",
         "wiktionary_code": "oc",
-        "casefold": true,
         "script": {
             "latn": "Latin"
-        }
-    },
-    "ofs": {
-        "iso639_name": "Old Frisian",
-        "wiktionary_name": "Old Frisian",
-        "wiktionary_code": "ofs",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "okm": {
-        "iso639_name": "Middle Korean (10th-16th cent.)",
-        "wiktionary_name": "Middle Korean",
-        "wiktionary_code": "okm",
-        "casefold": false,
-        "script": {
-            "hang": "Hangul"
-        }
-    },
-    "olo": {
-        "iso639_name": "Livvi",
-        "wiktionary_name": "Livvi",
-        "wiktionary_code": "olo",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ori": {
-        "iso639_name": "Oriya (macrolanguage)",
-        "wiktionary_name": "Oriya",
-        "wiktionary_code": "or",
-        "casefold": false,
-        "script": {
-            "orya": "Oriya"
-        }
-    },
-    "osp": {
-        "iso639_name": "Old Spanish",
-        "wiktionary_name": "Old Spanish",
-        "wiktionary_code": "osp",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "osx": {
-        "iso639_name": "Old Saxon",
-        "wiktionary_name": "Old Saxon",
-        "wiktionary_code": "osx",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ota": {
-        "iso639_name": "Ottoman Turkish (1500-1928)",
-        "wiktionary_name": "Ottoman Turkish",
-        "wiktionary_code": "ota",
-        "casefold": false,
-        "script": {
-            "arab": "Arabic"
-        }
-    },
-    "pan": {
-        "iso639_name": "Panjabi",
-        "wiktionary_name": "Punjabi",
-        "wiktionary_code": "pa",
-        "casefold": false,
-        "script": {
-            "guru": "Gurmukhi",
-            "arab": "Arabic"
-        }
-    },
-    "pbv": {
-        "iso639_name": "Pnar",
-        "wiktionary_name": "Pnar",
-        "wiktionary_code": "pbv",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pcc": {
-        "iso639_name": "Bouyei",
-        "wiktionary_name": "Bouyei",
-        "wiktionary_code": "pcc",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pdc": {
-        "iso639_name": "Pennsylvania German",
-        "wiktionary_name": "Pennsylvania German",
-        "wiktionary_code": "pdc",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "phl": {
-        "iso639_name": "Phalura",
-        "wiktionary_name": "Phalura",
-        "wiktionary_code": "phl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pjt": {
-        "iso639_name": "Pitjantjatjara",
-        "wiktionary_name": "Pitjantjatjara",
-        "wiktionary_code": "pjt",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pms": {
-        "iso639_name": "Piemontese",
-        "wiktionary_name": "Piedmontese",
-        "wiktionary_code": "pms",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pol": {
-        "iso639_name": "Polish",
-        "wiktionary_name": "Polish",
-        "wiktionary_code": "pl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "por": {
-        "iso639_name": "Portuguese",
-        "wiktionary_name": "Portuguese",
-        "wiktionary_code": "pt",
-        "casefold": true,
-        "dialect": {
-            "bz": "Brazil",
-            "po": "Portugal"
-        },
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pox": {
-        "iso639_name": "Polabian",
-        "wiktionary_name": "Polabian",
-        "wiktionary_code": "pox",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ppl": {
-        "iso639_name": "Pipil",
-        "wiktionary_name": "Pipil",
-        "wiktionary_code": "ppl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "pus": {
-        "iso639_name": "Pushto",
-        "wiktionary_name": "Pashto",
-        "wiktionary_code": "ps",
-        "casefold": false,
-        "script": {
-            "arab": "Arabic"
-        }
-    },
-    "quc": {
-        "iso639_name": "K'iche'",
-        "wiktionary_name": "K'iche'",
-        "wiktionary_code": "quc",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "rgn": {
-        "iso639_name": "Romagnol",
-        "wiktionary_name": "Romagnol",
-        "wiktionary_code": "rgn",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "ron": {
-        "iso639_name": "Romanian; Moldavian; Moldovan",
-        "wiktionary_name": "Romanian",
-        "wiktionary_code": "ro",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "cyrl": "Cyrillic"
-        }
-    },
-    "rup": {
-        "iso639_name": "Macedo-Romanian",
-        "wiktionary_name": "Aromanian",
-        "wiktionary_code": "rup",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "rus": {
-        "iso639_name": "Russian",
-        "wiktionary_name": "Russian",
-        "wiktionary_code": "ru",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic",
-            "zyyy": "Common"
         }
     },
     "ryu": {
@@ -1911,13 +1615,279 @@
             "hani": "Han"
         }
     },
-    "sah": {
-        "iso639_name": "Yakut",
-        "wiktionary_name": "Yakut",
-        "wiktionary_code": "sah",
-        "casefold": true,
+    "orv": {
+        "iso639_name": "Old Russian",
+        "wiktionary_name": "Old East Slavic",
+        "wiktionary_code": "orv",
+        "casefold": null
+    },
+    "ang": {
+        "iso639_name": "Old English (ca. 450-1100)",
+        "wiktionary_name": "Old English",
+        "wiktionary_code": "ang",
         "script": {
+            "latn": "Latin"
+        }
+    },
+    "fro": {
+        "iso639_name": "Old French (842-ca. 1400)",
+        "wiktionary_name": "Old French",
+        "wiktionary_code": "fro",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ofs": {
+        "iso639_name": "Old Frisian",
+        "wiktionary_name": "Old Frisian",
+        "wiktionary_code": "ofs",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "goh": {
+        "iso639_name": "Old High German (ca. 750-1050)",
+        "wiktionary_name": "Old High German",
+        "wiktionary_code": "goh",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "sga": {
+        "iso639_name": "Old Irish (to 900)",
+        "wiktionary_name": "Old Irish",
+        "wiktionary_code": "sga",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "non": {
+        "iso639_name": "Old Norse",
+        "wiktionary_name": "Old Norse",
+        "wiktionary_code": "non",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "osx": {
+        "iso639_name": "Old Saxon",
+        "wiktionary_name": "Old Saxon",
+        "wiktionary_code": "osx",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "osp": {
+        "iso639_name": "Old Spanish",
+        "wiktionary_name": "Old Spanish",
+        "wiktionary_code": "osp",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "tpw": {
+        "iso639_name": "Tupí",
+        "wiktionary_name": "Old Tupi",
+        "wiktionary_code": "tpw",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ori": {
+        "iso639_name": "Oriya (macrolanguage)",
+        "wiktionary_name": "Oriya",
+        "wiktionary_code": "or",
+        "casefold": false,
+        "script": {
+            "orya": "Oriya"
+        }
+    },
+    "ota": {
+        "iso639_name": "Ottoman Turkish (1500-1928)",
+        "wiktionary_name": "Ottoman Turkish",
+        "wiktionary_code": "ota",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
+        }
+    },
+    "pag": {
+        "iso639_name": "Pangasinan",
+        "wiktionary_name": "Pangasinan",
+        "wiktionary_code": "pag",
+        "casefold": null
+    },
+    "pus": {
+        "iso639_name": "Pushto",
+        "wiktionary_name": "Pashto",
+        "wiktionary_code": "ps",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
+        }
+    },
+    "pdc": {
+        "iso639_name": "Pennsylvania German",
+        "wiktionary_name": "Pennsylvania German",
+        "wiktionary_code": "pdc",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "fas": {
+        "iso639_name": "Persian",
+        "wiktionary_name": "Persian",
+        "wiktionary_code": "fa",
+        "casefold": false,
+        "skip_spaces_pron": false,
+        "script": {
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
+        }
+    },
+    "phl": {
+        "iso639_name": "Phalura",
+        "wiktionary_name": "Phalura",
+        "wiktionary_code": "phl",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "pms": {
+        "iso639_name": "Piemontese",
+        "wiktionary_name": "Piedmontese",
+        "wiktionary_code": "pms",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ppl": {
+        "iso639_name": "Pipil",
+        "wiktionary_name": "Pipil",
+        "wiktionary_code": "ppl",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "pjt": {
+        "iso639_name": "Pitjantjatjara",
+        "wiktionary_name": "Pitjantjatjara",
+        "wiktionary_code": "pjt",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "crk": {
+        "iso639_name": "Plains Cree",
+        "wiktionary_name": "Plains Cree",
+        "wiktionary_code": "crk",
+        "script": {
+            "latn": "Latin",
+            "cans": "Canadian Aboriginal"
+        }
+    },
+    "pbv": {
+        "iso639_name": "Pnar",
+        "wiktionary_name": "Pnar",
+        "wiktionary_code": "pbv",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "pox": {
+        "iso639_name": "Polabian",
+        "wiktionary_name": "Polabian",
+        "wiktionary_code": "pox",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "pol": {
+        "iso639_name": "Polish",
+        "wiktionary_name": "Polish",
+        "wiktionary_code": "pl",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "por": {
+        "iso639_name": "Portuguese",
+        "wiktionary_name": "Portuguese",
+        "wiktionary_code": "pt",
+        "dialect": {
+            "bz": "Brazil",
+            "po": "Portugal"
+        },
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "pan": {
+        "iso639_name": "Panjabi",
+        "wiktionary_name": "Punjabi",
+        "wiktionary_code": "pa",
+        "casefold": false,
+        "script": {
+            "guru": "Gurmukhi",
+            "arab": "Arabic"
+        }
+    },
+    "rap": {
+        "iso639_name": "Rapanui",
+        "wiktionary_name": "Rapa Nui",
+        "wiktionary_code": "rap",
+        "casefold": null
+    },
+    "rgn": {
+        "iso639_name": "Romagnol",
+        "wiktionary_name": "Romagnol",
+        "wiktionary_code": "rgn",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "rom": {
+        "iso639_name": "Romany",
+        "wiktionary_name": "Romani",
+        "wiktionary_code": "rom",
+        "casefold": null
+    },
+    "ron": {
+        "iso639_name": "Romanian",
+        "wiktionary_name": "Romanian",
+        "wiktionary_code": "ro",
+        "script": {
+            "latn": "Latin",
             "cyrl": "Cyrillic"
+        }
+    },
+    "rus": {
+        "iso639_name": "Russian",
+        "wiktionary_name": "Russian",
+        "wiktionary_code": "ru",
+        "script": {
+            "cyrl": "Cyrillic",
+            "zyyy": "Common"
+        }
+    },
+    "ksw": {
+        "iso639_name": "S'gaw Karen",
+        "wiktionary_name": "S'gaw Karen",
+        "wiktionary_code": "ksw",
+        "casefold": null
+    },
+    "slr": {
+        "iso639_name": "Salar",
+        "wiktionary_name": "Salar",
+        "wiktionary_code": "slr",
+        "casefold": null
+    },
+    "azg": {
+        "iso639_name": "San Pedro Amuzgos Amuzgo",
+        "wiktionary_name": "San Pedro Amuzgos Amuzgo",
+        "wiktionary_code": "azg",
+        "script": {
+            "latn": "Latin"
         }
     },
     "san": {
@@ -1930,20 +1900,24 @@
             "shrd": "Sharada"
         }
     },
-    "sce": {
-        "iso639_name": "Dongxiang",
-        "wiktionary_name": "Dongxiang",
-        "wiktionary_code": "sce",
-        "casefold": true,
+    "srd": {
+        "iso639_name": "Sardinian",
+        "wiktionary_name": "Sardinian",
+        "wiktionary_code": "sc",
         "script": {
             "latn": "Latin"
         }
     },
-    "scn": {
-        "iso639_name": "Sicilian",
-        "wiktionary_name": "Sicilian",
-        "wiktionary_code": "scn",
-        "casefold": true,
+    "sdc": {
+        "iso639_name": "Sassarese Sardinian",
+        "wiktionary_name": "Sassarese",
+        "wiktionary_code": "sdc",
+        "casefold": null
+    },
+    "stq": {
+        "iso639_name": "Saterfriesisch",
+        "wiktionary_name": "Saterland Frisian",
+        "wiktionary_code": "stq",
         "script": {
             "latn": "Latin"
         }
@@ -1952,18 +1926,26 @@
         "iso639_name": "Scots",
         "wiktionary_name": "Scots",
         "wiktionary_code": "sco",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "sga": {
-        "iso639_name": "Old Irish (to 900)",
-        "wiktionary_name": "Old Irish",
-        "wiktionary_code": "sga",
-        "casefold": true,
+    "gla": {
+        "iso639_name": "Scottish Gaelic",
+        "wiktionary_name": "Scottish Gaelic",
+        "wiktionary_code": "gd",
         "script": {
             "latn": "Latin"
+        }
+    },
+    "hbs": {
+        "iso639_name": "Serbo-Croatian",
+        "wiktionary_name": "Serbo-Croatian",
+        "wiktionary_code": "sh",
+        "script": {
+            "latn": "Latin",
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
         }
     },
     "shn": {
@@ -1975,38 +1957,18 @@
             "mymr": "Myanmar"
         }
     },
+    "scn": {
+        "iso639_name": "Sicilian",
+        "wiktionary_name": "Sicilian",
+        "wiktionary_code": "scn",
+        "script": {
+            "latn": "Latin"
+        }
+    },
     "sid": {
         "iso639_name": "Sidamo",
         "wiktionary_name": "Sidamo",
         "wiktionary_code": "sid",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "slk": {
-        "iso639_name": "Slovak",
-        "wiktionary_name": "Slovak",
-        "wiktionary_code": "sk",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "slv": {
-        "iso639_name": "Slovenian",
-        "wiktionary_name": "Slovene",
-        "wiktionary_code": "sl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "sme": {
-        "iso639_name": "Northern Sami",
-        "wiktionary_name": "Northern Sami",
-        "wiktionary_code": "se",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -2015,16 +1977,53 @@
         "iso639_name": "Skolt Sami",
         "wiktionary_name": "Skolt Sami",
         "wiktionary_code": "sms",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
+    "slk": {
+        "iso639_name": "Slovak",
+        "wiktionary_name": "Slovak",
+        "wiktionary_code": "sk",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "slv": {
+        "iso639_name": "Slovenian",
+        "wiktionary_name": "Slovene",
+        "wiktionary_code": "sl",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "ajp": {
+        "iso639_name": "South Levantine Arabic",
+        "wiktionary_name": "South Levantine Arabic",
+        "wiktionary_code": "ajp",
+        "casefold": false,
+        "script": {
+            "arab": "Arabic"
+        }
+    },
+    "xsl": {
+        "iso639_name": "South Slavey",
+        "wiktionary_name": "South Slavey",
+        "wiktionary_code": "xsl",
+        "casefold": null
+    },
+    "yux": {
+        "iso639_name": "Southern Yukaghir",
+        "wiktionary_name": "Southern Yukaghir",
+        "wiktionary_code": "yux",
+        "script": {
+            "cyrl": "Cyrillic"
+        }
+    },
     "spa": {
-        "iso639_name": "Spanish; Castilian",
+        "iso639_name": "Spanish",
         "wiktionary_name": "Spanish",
         "wiktionary_code": "es",
-        "casefold": true,
         "dialect": {
             "la": "Latin America",
             "ca": "Castilian"
@@ -2033,39 +2032,10 @@
             "latn": "Latin"
         }
     },
-    "sqi": {
-        "iso639_name": "Albanian",
-        "wiktionary_name": "Albanian",
-        "wiktionary_code": "sq",
-        "casefold": true,
-        "script": {
-            "latn": "Latin",
-            "grek": "Greek"
-        }
-    },
-    "srd": {
-        "iso639_name": "Sardinian",
-        "wiktionary_name": "Sardinian",
-        "wiktionary_code": "sc",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
     "srn": {
         "iso639_name": "Sranan Tongo",
         "wiktionary_name": "Sranan Tongo",
         "wiktionary_code": "srn",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "stq": {
-        "iso639_name": "Saterfriesisch",
-        "wiktionary_name": "Saterland Frisian",
-        "wiktionary_code": "stq",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -2074,19 +2044,8 @@
         "iso639_name": "Swedish",
         "wiktionary_name": "Swedish",
         "wiktionary_code": "sv",
-        "casefold": true,
         "script": {
             "latn": "Latin"
-        }
-    },
-    "syc": {
-        "iso639_name": "Classical Syriac",
-        "wiktionary_name": "Classical Syriac",
-        "wiktionary_code": "syc",
-        "casefold": false,
-        "script": {
-            "syrc": "Syriac",
-            "hebr": "Hebrew"
         }
     },
     "syl": {
@@ -2099,6 +2058,40 @@
             "beng": "Bengali"
         }
     },
+    "tby": {
+        "iso639_name": "Tabaru",
+        "wiktionary_name": "Tabaru",
+        "wiktionary_code": "tby",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "tgl": {
+        "iso639_name": "Tagalog",
+        "wiktionary_name": "Tagalog",
+        "wiktionary_code": "tl",
+        "script": {
+            "latn": "Latin",
+            "tglg": "Tagalog"
+        }
+    },
+    "blt": {
+        "iso639_name": "Tai Dam",
+        "wiktionary_name": "Tai Dam",
+        "wiktionary_code": "blt",
+        "casefold": false,
+        "script": {
+            "tavt": "Tai Viet"
+        }
+    },
+    "tgk": {
+        "iso639_name": "Tajik",
+        "wiktionary_name": "Tajik",
+        "wiktionary_code": "tg",
+        "script": {
+            "cyrl": "Cyrillic"
+        }
+    },
     "tam": {
         "iso639_name": "Tamil",
         "wiktionary_name": "Tamil",
@@ -2109,11 +2102,10 @@
             "taml": "Tamil"
         }
     },
-    "tby": {
-        "iso639_name": "Tabaru",
-        "wiktionary_name": "Tabaru",
-        "wiktionary_code": "tby",
-        "casefold": true,
+    "twf": {
+        "iso639_name": "Northern Tiwa",
+        "wiktionary_name": "Taos",
+        "wiktionary_code": "twf",
         "script": {
             "latn": "Latin"
         }
@@ -2128,23 +2120,18 @@
             "knda": "Kannada"
         }
     },
-    "tgk": {
-        "iso639_name": "Tajik",
-        "wiktionary_name": "Tajik",
-        "wiktionary_code": "tg",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic"
-        }
+    "tft": {
+        "iso639_name": "Ternate",
+        "wiktionary_name": "Ternate",
+        "wiktionary_code": "tft",
+        "casefold": null
     },
-    "tgl": {
-        "iso639_name": "Tagalog",
-        "wiktionary_name": "Tagalog",
-        "wiktionary_code": "tl",
-        "casefold": true,
+    "nhg": {
+        "iso639_name": "Tetelcingo Nahuatl",
+        "wiktionary_name": "Tetelcingo Nahuatl",
+        "wiktionary_code": "nhg",
         "script": {
-            "latn": "Latin",
-            "tglg": "Tagalog"
+            "latn": "Latin"
         }
     },
     "tha": {
@@ -2154,6 +2141,16 @@
         "casefold": false,
         "script": {
             "thai": "Thai"
+        }
+    },
+    "bod": {
+        "iso639_name": "Tibetan",
+        "wiktionary_name": "Tibetan",
+        "wiktionary_code": "bo",
+        "casefold": false,
+        "skip_spaces_pron": false,
+        "script": {
+            "tibt": "Tibetan"
         }
     },
     "tkl": {
@@ -2166,25 +2163,6 @@
         "iso639_name": "Tonga (Tonga Islands)",
         "wiktionary_name": "Tongan",
         "wiktionary_code": "to",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "tpw": {
-        "iso639_name": "Tup\u00ed",
-        "wiktionary_name": "Old Tupi",
-        "wiktionary_code": "tpw",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "tuk": {
-        "iso639_name": "Turkmen",
-        "wiktionary_name": "Turkmen",
-        "wiktionary_code": "tk",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -2193,65 +2171,74 @@
         "iso639_name": "Turkish",
         "wiktionary_name": "Turkish",
         "wiktionary_code": "tr",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "arab": "Arabic"
         }
     },
-    "twf": {
-        "iso639_name": "Northern Tiwa",
-        "wiktionary_name": "Taos",
-        "wiktionary_code": "twf",
-        "casefold": true,
+    "tuk": {
+        "iso639_name": "Turkmen",
+        "wiktionary_name": "Turkmen",
+        "wiktionary_code": "tk",
         "script": {
             "latn": "Latin"
         }
+    },
+    "tru": {
+        "iso639_name": "Turoyo",
+        "wiktionary_name": "Turoyo",
+        "wiktionary_code": "tru",
+        "casefold": null
     },
     "tyv": {
         "iso639_name": "Tuvinian",
         "wiktionary_name": "Tuvan",
         "wiktionary_code": "tyv",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
-        }
-    },
-    "tzm": {
-        "iso639_name": "Central Atlas Tamazight",
-        "wiktionary_name": "Central Atlas Tamazight",
-        "wiktionary_code": "tzm",
-        "casefold": false,
-        "script": {
-            "tfng": "Tifinagh"
         }
     },
     "tzo": {
         "iso639_name": "Tzotzil",
         "wiktionary_name": "Tzotzil",
         "wiktionary_code": "tzo",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
-    "uig": {
-        "iso639_name": "Uighur",
-        "wiktionary_name": "Uyghur",
-        "wiktionary_code": "ug",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic",
-            "arab": "Arabic"
-        }
+    "tyz": {
+        "iso639_name": "Tày",
+        "wiktionary_name": "Tày",
+        "wiktionary_code": "tyz",
+        "casefold": null
+    },
+    "uby": {
+        "iso639_name": "Ubykh",
+        "wiktionary_name": "Ubykh",
+        "wiktionary_code": "uby",
+        "casefold": null
     },
     "ukr": {
         "iso639_name": "Ukrainian",
         "wiktionary_name": "Ukrainian",
         "wiktionary_code": "uk",
-        "casefold": true,
         "script": {
             "cyrl": "Cyrillic"
+        }
+    },
+    "bbn": {
+        "iso639_name": "Uneapa",
+        "wiktionary_name": "Uneapa",
+        "wiktionary_code": "bbn",
+        "casefold": null
+    },
+    "urk": {
+        "iso639_name": "Urak Lawoi'",
+        "wiktionary_name": "Urak Lawoi'",
+        "wiktionary_code": "urk",
+        "casefold": false,
+        "script": {
+            "thai": "Thai"
         }
     },
     "urd": {
@@ -2263,47 +2250,115 @@
             "arab": "Arabic"
         }
     },
-    "urk": {
-        "iso639_name": "Urak Lawoi'",
-        "wiktionary_name": "Urak Lawoi'",
-        "wiktionary_code": "urk",
-        "casefold": false,
+    "uig": {
+        "iso639_name": "Uighur",
+        "wiktionary_name": "Uyghur",
+        "wiktionary_code": "ug",
         "script": {
-            "thai": "Thai"
+            "cyrl": "Cyrillic",
+            "arab": "Arabic"
         }
+    },
+    "uzb": {
+        "iso639_name": "Uzbek",
+        "wiktionary_name": "Uzbek",
+        "wiktionary_code": "uz",
+        "casefold": null
     },
     "vie": {
         "iso639_name": "Vietnamese",
         "wiktionary_name": "Vietnamese",
         "wiktionary_code": "vi",
-        "casefold": true,
         "skip_spaces_word": false,
         "skip_spaces_pron": false,
         "dialect": {
-            "hanoi": "H\u00e0 N\u1ed9i",
-            "hcmc": "H\u1ed3 Ch\u00ed Minh City",
-            "hue": "Hu\u1ebf",
-            "tc": "Vinh, Thanh Ch\u01b0\u01a1ng",
-            "ht": "H\u00e0 T\u0129nh"
+            "hanoi": "Hà Nội",
+            "hcmc": "Hồ Chí Minh City",
+            "hue": "Huế",
+            "tc": "Vinh, Thanh Chương",
+            "ht": "Hà Tĩnh"
         },
         "script": {
             "latn": "Latin"
         }
     },
     "vol": {
-        "iso639_name": "Volap\u00fck",
-        "wiktionary_name": "Volap\u00fck",
+        "iso639_name": "Volapük",
+        "wiktionary_name": "Volapük",
         "wiktionary_code": "vo",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
     },
+    "wln": {
+        "iso639_name": "Walloon",
+        "wiktionary_name": "Walloon",
+        "wiktionary_code": "wa",
+        "casefold": null
+    },
     "wau": {
-        "iso639_name": "Waur\u00e1",
+        "iso639_name": "Waurá",
         "wiktionary_name": "Wauja",
         "wiktionary_code": "wau",
-        "casefold": true,
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "cym": {
+        "iso639_name": "Welsh",
+        "wiktionary_name": "Welsh",
+        "wiktionary_code": "cy",
+        "dialect": {
+            "nw": "North Wales",
+            "sw": "South Wales"
+        },
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "fry": {
+        "iso639_name": "Western Frisian",
+        "wiktionary_name": "West Frisian",
+        "wiktionary_code": "fy",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "mqs": {
+        "iso639_name": "West Makian",
+        "wiktionary_name": "West Makian",
+        "wiktionary_code": "mqs",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "apw": {
+        "iso639_name": "Western Apache",
+        "wiktionary_name": "Western Apache",
+        "wiktionary_code": "apw",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "kyu": {
+        "iso639_name": "Western Kayah",
+        "wiktionary_name": "Western Kayah",
+        "wiktionary_code": "kyu",
+        "casefold": null
+    },
+    "lcp": {
+        "iso639_name": "Western Lawa",
+        "wiktionary_name": "Western Lawa",
+        "wiktionary_code": "lcp",
+        "casefold": false,
+        "script": {
+            "thai": "Thai"
+        }
+    },
+    "mww": {
+        "iso639_name": "Hmong Daw",
+        "wiktionary_name": "White Hmong",
+        "wiktionary_code": "mww",
         "script": {
             "latn": "Latin"
         }
@@ -2312,16 +2367,6 @@
         "iso639_name": "Wiyot",
         "wiktionary_name": "Wiyot",
         "wiktionary_code": "wiy",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "wlm": {
-        "iso639_name": "Middle Welsh",
-        "wiktionary_name": "Middle Welsh",
-        "wiktionary_code": "wlm",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -2330,9 +2375,16 @@
         "iso639_name": "Xhosa",
         "wiktionary_name": "Xhosa",
         "wiktionary_code": "xh",
-        "casefold": true,
         "script": {
             "latn": "Latin"
+        }
+    },
+    "sah": {
+        "iso639_name": "Yakut",
+        "wiktionary_name": "Yakut",
+        "wiktionary_code": "sah",
+        "script": {
+            "cyrl": "Cyrillic"
         }
     },
     "ybi": {
@@ -2342,15 +2394,6 @@
         "casefold": false,
         "script": {
             "deva": "Devanagari"
-        }
-    },
-    "ycl": {
-        "iso639_name": "Lolopo",
-        "wiktionary_name": "Lolopo",
-        "wiktionary_code": "ycl",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
         }
     },
     "yid": {
@@ -2366,56 +2409,6 @@
         "iso639_name": "Yoruba",
         "wiktionary_name": "Yoruba",
         "wiktionary_code": "yo",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "yue": {
-        "iso639_name": "Yue Chinese",
-        "wiktionary_name": "Cantonese",
-        "wiktionary_code": "yue",
-        "skip_spaces_pron": false,
-        "casefold": false,
-        "script": {
-            "latn": "Latin",
-            "hira": "Hiragana",
-            "bopo": "Bopomofo",
-            "hani": "Han"
-        }
-    },
-    "yux": {
-        "iso639_name": "Southern Yukaghir",
-        "wiktionary_name": "Southern Yukaghir",
-        "wiktionary_code": "yux",
-        "casefold": true,
-        "script": {
-            "cyrl": "Cyrillic"
-        }
-    },
-    "zha": {
-        "iso639_name": "Zhuang",
-        "wiktionary_name": "Zhuang",
-        "wiktionary_code": "za",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "zom": {
-        "iso639_name": "Zou",
-        "wiktionary_name": "Zou",
-        "wiktionary_code": "zom",
-        "casefold": true,
-        "script": {
-            "latn": "Latin"
-        }
-    },
-    "zul": {
-        "iso639_name": "Zulu",
-        "wiktionary_name": "Zulu",
-        "wiktionary_code": "zu",
-        "casefold": true,
         "script": {
             "latn": "Latin"
         }
@@ -2424,10 +2417,33 @@
         "iso639_name": "Zaza",
         "wiktionary_name": "Zazaki",
         "wiktionary_code": "zza",
-        "casefold": true,
         "script": {
             "latn": "Latin",
             "arab": "Arabic"
+        }
+    },
+    "zha": {
+        "iso639_name": "Zhuang",
+        "wiktionary_name": "Zhuang",
+        "wiktionary_code": "za",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "zom": {
+        "iso639_name": "Zou",
+        "wiktionary_name": "Zou",
+        "wiktionary_code": "zom",
+        "script": {
+            "latn": "Latin"
+        }
+    },
+    "zul": {
+        "iso639_name": "Zulu",
+        "wiktionary_name": "Zulu",
+        "wiktionary_code": "zu",
+        "script": {
+            "latn": "Latin"
         }
     }
 }

--- a/data/scrape/lib/unmatched_languages.json
+++ b/data/scrape/lib/unmatched_languages.json
@@ -5,6 +5,9 @@
     "nds-de": {
         "wiktionary_name": "German Low German"
     },
+    "gmw-jdt": {
+        "wiktionary_name": "Jersey Dutch"
+    },
     "roa-opt": {
         "wiktionary_name": "Old Portuguese"
     },
@@ -17,11 +20,11 @@
     "gem-pro": {
         "wiktionary_name": "Proto-Germanic"
     },
+    "grk-pro": {
+        "wiktionary_name": "Proto-Hellenic"
+    },
     "itc-pro": {
         "wiktionary_name": "Proto-Italic"
-    },
-    "jpx-pro": {
-        "wiktionary_name": "Proto-Japonic"
     },
     "poz-mly-pro": {
         "wiktionary_name": "Proto-Malayic"


### PR DESCRIPTION
Removed the statement `casefold:true` from the languages.json list. I rescraped `hye` and `apw` to confirm that the languages were still scrapped, but now with the original case marking from Wiktionary. 

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
