### PR TITLE
MAINT make requires-python PEP 508 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wikipron"
 version = "1.3.0"
 description = "Scraping grapheme-to-phoneme data from Wiktionary"
 readme = "README.md"
-requires-python = ">= 3.8.*"
+requires-python = ">= 3.8"
 license = { text = "Apache 2.0" }
 authors = [ { name = "WikiPron authors", email = "kylebgorman@gmail.com" } ]
 keywords = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==22.10.0
 build==0.9.0
 flake8==6.0.0
 python-iso639==2022.11.27
-mypy==0.991
+mypy==1.1.1
 pytest==7.2.0
 requests-html==0.10.0
 requests==2.28.1


### PR DESCRIPTION
I've run into the same issue regarding `requires-python` in `pyproject.toml` in various projects very recently. Most likely the most recent versions of `setuptools` are now more stringent about the format of `requires-python`, or something like that.

Resolves #484.
