### PR TITLE
Upstream cleaning wrt English high vowel and schwa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Unreleased
 #### Added
 
 -   Renamed `generate_tsv_summary.py` to `generate_summary.py`. (\#492)
+-   Upstream cleaning wrt English tie bar. (\#491)
+-   Upstream cleaning wrt English high vowel and schwa. (\#493)
 -   Fixed Georgian (`kat`) phones and rescrapes. (\#488)
 -   Big scrape for 2022. (\#464)
 -   Added the `--fresh` flag to `data/scrape/scrape.py` to facilitate running the big scrape in batches. (\#464)
@@ -109,7 +111,6 @@ Unreleased
 -   Fixed Common character collection in `common_characters.py` (\#419)
 -   Scraping test fixed for `blt`. (\#436)
 -   Changed URLs to point at CUNY-CL repo, where applicable. (\#438)
--   Upstream cleaning wrt English tie bar. (\#491)
 
 ### Under `wikipron/` and elsewhere
 

--- a/data/scrape/README.md
+++ b/data/scrape/README.md
@@ -87,12 +87,12 @@
 | [TSV](tsv/ell_grek_broad.tsv) | ell | Modern Greek (1453-) | Greek | Greek |  | False | Broad | True | 11,900 |
 | [TSV](tsv/ell_grek_broad_filtered.tsv) | ell | Modern Greek (1453-) | Greek | Greek |  | True | Broad | True | 11,725 |
 | [TSV](tsv/ell_grek_narrow.tsv) | ell | Modern Greek (1453-) | Greek | Greek |  | False | Narrow | True | 407 |
-| [TSV](tsv/eng_latn_uk_broad.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Broad | True | 71,727 |
-| [TSV](tsv/eng_latn_uk_broad_filtered.tsv) | eng | English | English | Latin | UK, Received Pronunciation | True | Broad | True | 71,021 |
-| [TSV](tsv/eng_latn_uk_narrow.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Narrow | True | 1,557 |
-| [TSV](tsv/eng_latn_us_broad.tsv) | eng | English | English | Latin | US, General American | False | Broad | True | 69,683 |
-| [TSV](tsv/eng_latn_us_broad_filtered.tsv) | eng | English | English | Latin | US, General American | True | Broad | True | 68,874 |
-| [TSV](tsv/eng_latn_us_narrow.tsv) | eng | English | English | Latin | US, General American | False | Narrow | True | 2,035 |
+| [TSV](tsv/eng_latn_uk_broad.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Broad | True | 72,377 |
+| [TSV](tsv/eng_latn_uk_broad_filtered.tsv) | eng | English | English | Latin | UK, Received Pronunciation | True | Broad | True | 71,835 |
+| [TSV](tsv/eng_latn_uk_narrow.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Narrow | True | 1,574 |
+| [TSV](tsv/eng_latn_us_broad.tsv) | eng | English | English | Latin | US, General American | False | Broad | True | 70,280 |
+| [TSV](tsv/eng_latn_us_broad_filtered.tsv) | eng | English | English | Latin | US, General American | True | Broad | True | 69,706 |
+| [TSV](tsv/eng_latn_us_narrow.tsv) | eng | English | English | Latin | US, General American | False | Narrow | True | 2,056 |
 | [TSV](tsv/enm_latn_broad.tsv) | enm | Middle English (1100-1500) | Middle English | Latin |  | False | Broad | True | 8,825 |
 | [TSV](tsv/epo_latn_broad.tsv) | epo | Esperanto | Esperanto | Latin |  | False | Broad | True | 4,889 |
 | [TSV](tsv/epo_latn_narrow.tsv) | epo | Esperanto | Esperanto | Latin |  | False | Narrow | True | 12,218 |

--- a/data/scrape/tsv/eng_latn_uk_broad.tsv
+++ b/data/scrape/tsv/eng_latn_uk_broad.tsv
@@ -253,7 +253,7 @@ abide	ə b a ɪ d
 abided	ə b a ɪ d ə d
 abides	ə b a ɪ d s
 abidest	ə b a ɪ d ɪ s t
-abier	ə b ɪ ə ɹ
+abier	ə b ɪ ɚ
 abigail	a b ɪ ɡ e ɪ l
 abigails	a b ɪ ɡ e ɪ l s
 abigeat	ə b ɪ d͡ʒ i ə t
@@ -286,6 +286,8 @@ ablations	ə b l e ɪ ʃ n̩ s
 ablativity	a b l ə t ɪ v ɪ t i
 ablator	æ b l e ɪ t əː
 ablauting	ɑ b l a ʊ t ɪ ŋ
+able	e ɪ b l̩
+able	e ɪ b ə l
 abligurition	ə b l ɪ ɡ j ʊ ɹ ɪ ʃ ə n
 ablings	e ɪ b l ɪ n z
 ablood	ə b l ʌ d
@@ -582,6 +584,8 @@ accept	ə k s ɛ p t
 acceptable	æ k s ɛ p t ə b ə l
 acceptable	ə k s ɛ p t ə b ə l
 acceptation	æ k s ɛ p t e ɪ ʃ ə n
+accepted	æ k s ɛ p t ɪ d
+accepted	ə k s ɛ p t ɪ d
 accepting	ə k s ɛ p t ɪ ŋ
 accepting	ɪ k s ɛ p t ɪ ŋ
 acceptor	ə k s ɛ p t ə ɹ
@@ -594,6 +598,7 @@ accessed	æ k s ɛ s t
 accessed	ə k s ɛ s t
 accesses	æ k s ɛ s ɪ z
 accesses	ə k s ɛ s ɪ z
+accessibility	ə k s ɛ s ə b ɪ l ɪ t i
 accessing	æ k s ɛ s ɪ ŋ
 accessing	ə k s ɛ s ɪ ŋ
 accession	æ k s ɛ ʃ ə n
@@ -743,7 +748,7 @@ acebutolol	a s ɪ b j uː t ə l ɒ l
 aced	e ɪ s t
 acedia	ə s iː d ɪ ə
 acela	ə s ɛ l ə
-aceldama	ə k e l d ə m ə
+aceldama	ə k ɛ l d ə m ə
 aceldama	ə s ɛ l d ə m ə
 acephali	ɑː s ɛ f æ l ɪ i
 acephalous	ə s ɛ f ə l ə s
@@ -776,7 +781,7 @@ acetal	æ s ɪ t æ l
 acetaminophen	ə s i t ə m ɪ n ə f ə n
 acetary	ə s iː t ə ɹ i
 acetate	æ s ɪ t e ɪ̯ t
-acetator	æ s ɪ t e ɪ t ə ɹ
+acetator	æ s ɪ t e ɪ t ɚ
 acetazolamide	ə s iː t ə z ɒ l ə m ʌ ɪ d
 acetazolamide	ə s iː t ə z ə ʊ l ə m ʌ ɪ d
 acetazolamide	ə s ɛ t ə z ɒ l ə m ʌ ɪ d
@@ -826,7 +831,7 @@ achieved	ə t͡ʃ iː v d
 achievement	ə t͡ʃ iː v m ə n t
 achievement	ə t͡ʃ iː v m ɪ n t
 achievements	ə t͡ʃ iː v m ə n t s
-achiever	ə t͡ʃ iː v ə ɹ
+achiever	ə t͡ʃ iː v ɚ
 achieves	ə t͡ʃ iː v z
 achieving	ə t͡ʃ iː v ɪ ŋ
 achievings	ə t͡ʃ iː v ɪ ŋ z
@@ -913,10 +918,9 @@ acquittal	ə k w ɪ t ə l
 acquittance	ə k w ɪ t ə n s
 acquitted	ə k w ɪ t ɪ d
 acrasia	ə k ɹ e ɪ z i ə
-acre	e ɪ k ə
-acre	e ɪ k ə ɹ
-acre	ɑː k ə
-acre	ɑː k ɹ ə
+acre	e ɪ k ɚ
+acre	ɑː k ɚ
+acre	ɑː k ɹ ɚ
 acreage	e ɪ k ə ɹ ɪ d͡ʒ
 acreocracy	e ɪ k ə ɹ ɒ k ɹ ə s i
 acres	e ɪ k ə z
@@ -942,6 +946,8 @@ acropolises	æ k ɹ ɒ p ɒ l ɪ s ɪ z
 acropolitan	æ k ɹ ə p ɒ l ɪ t ə n
 across	ə k ɹ ɒ s
 acrostic	ə k ɹ ɒ s t ɪ k
+acroter	æ k ɹ ə t ə ɹ
+acroterium	æ k ɹ ə t ɪ ə ɹ i ə m
 acrylamide	ə k ɹ ɪ l ə m a ɪ d
 acrylate	æ k ɹ ɪ l e ɪ t
 acrylic	ə k ɹ ɪ l ɪ k
@@ -1004,6 +1010,7 @@ acushla	ə k ʊ ʃ l ə
 acute	ə k j uː t
 acutely	ə k j uː t l i
 acyclic	e ɪ s a ɪ k l ɪ k
+acyclic	e ɪ s ɪ k l ɪ k
 acyl	æ s ɪ l
 acyltransferase	a s ɪ l t ɹ a n s f ə ɹ e ɪ z
 acyltransferase	e ɪ s ʌ ɪ l t ɹ ɑː n z f ə ɹ e ɪ z
@@ -1074,7 +1081,7 @@ adduce	ə d ʒ uː s
 adduct	æ d ʌ k t
 adduct	ə d ʌ k t
 adduction	ə d ʌ k ʃ n̩
-adductor	ə d ʌ k t ə ɹ
+adductor	ə d ʌ k t ɚ
 ade	e ɪ d
 adela	æ d ə l ə
 adela	ə d ɛ l ə
@@ -1082,6 +1089,7 @@ adelaide	æ d ə l e ɪ d
 adele	ə d ɛ l
 adeling	æ d ə l ɪ ŋ
 adelings	æ d ə l ɪ ŋ z
+adelopod	ə d ɛ l ə p ɒ d
 adenine	æ d ə n iː n
 adenine	æ d ɪ n ɪ n
 adenines	æ d ɪ n ɪ n z
@@ -1098,8 +1106,10 @@ adermatoglyphia	e ɪ d ɜː m ə t ə ʊ ɡ l ɪ f ɪ ə
 adespota	ə d ɛ s p ə t ə
 adhan	ɑː ð ɑː n
 adhan	ə ð ɑː n
+adhere	æ d h ɪ ə
 adherence	ə d h ɪ ə ɹ ə n s
 adherent	æ d h ɪ ə ɹ ə n t
+adhesion	æ d h iː ʒ ə n
 adhibit	ə d h ɪ b ɪ t
 adhibition	æ d h ɪ b ɪ ʃ ə n
 adhocracy	a d h ɒ k ɹ ə s i
@@ -1123,12 +1133,13 @@ adieux	ə d j ɜː z
 adige	a d ɪ d ʒ e ɪ
 adios	æ d i ɒ s
 adipate	æ d ɪ p e ɪ t
-adipocere	æ d ə p o ʊ s i ə ɹ
-adipocere	æ d ɪ p o ʊ s i ə ɹ
+adipocere	æ d ə p o ʊ s i ɚ
+adipocere	æ d ɪ p o ʊ s i ɚ
 adipocytokine	æ d ɪ p ə ʊ s a ɪ t ə ʊ k a ɪ n
 adipose	æ d ɪ p ə ʊ s
 adipose	æ d ɪ p ə ʊ z
 adirondack	æ d ɪ ɹ ɒ n d æ k
+adit	a d ɪ t
 adit	æ d ɪ t
 adits	æ d ɪ t s
 aditus	æ d ɪ t uː s
@@ -1203,8 +1214,8 @@ admits	ə d m ɪ t s
 admittance	ə d m ɪ t n̩ s
 admitted	ə d m ɪ t ɪ d
 admitting	ə d m ɪ t ɪ ŋ
-admixture	æ d m ɪ k s t͡ʃ ə ɹ
-admixture	ə d m ɪ k s t͡ʃ ə ɹ
+admixture	æ d m ɪ k s t͡ʃ ɚ
+admixture	ə d m ɪ k s t͡ʃ ɚ
 admonish	ə d m ɒ n ɪ ʃ
 admonition	æ d m ə n ɪ ʃ ə n
 ado	ə d uː
@@ -1320,7 +1331,7 @@ advert	ə d v ɜː ɹ t
 advertise	a d v ə ɹ t a ɪ z
 advertisement	æ d v ə t a ɪ z m ə n t
 advertisement	ə d v ɜː t ɪ s m ə n t
-advertiser	æ d v ə ɹ t a ɪ z ə ɹ
+advertiser	æ d v ɚ t a ɪ z ɚ
 advertising	æ d v ə t a ɪ z ɪ ŋ
 advertorial	æ d v ɜː t ɔː ɹ i ə l
 advesperate	æ d v ɛ s p ə ɹ e ɪ t
@@ -1424,12 +1435,14 @@ aesthetic	iː s θ e t ɪ k
 aesthetic	ə s θ e t ɪ k
 aesthetic	ɛ s θ ɛ t ɪ k
 aesthetic	ɪ s θ e t ɪ k
+aesthetician	ɛ s θ ɪ t ɪ ʃ ə n
 aestiferous	ɛ s t ɪ f ɛ ɹ ʌ s
 aestivation	iː s t ɪ v e ɪ ʃ ə n
 aetat	a ɪ t a t
 aetat	iː t a t
 aetheogam	e ɪ iː θ ɪ ə ʊ ɡ æ m
 aetheogamous	e ɪ iː θ iː ɒ ɡ ə m ə s
+aether	eː ð ə
 aether	iː θ ə
 aetiology	iː t ɪ ɒ l ə d ʒ i
 aetites	iː t a ɪ t iː z
@@ -1439,12 +1452,13 @@ aeviternity	iː v ɪ t ɜː n ɪ t i
 aevum	iː v ə m
 af	e ɪ̯ ɛ f
 af	æ f
+afab	e ɪ f æ b
 aface	ə f e ɪ s
 afam	a f a m
 afanc	æ v æ ŋ k
 afanc	ɑ v ɑ ŋ k
 afar	ə f ɑː
-afare	ə f ɛ ə ɹ
+afare	ə f ɛ ɚ
 afeared	ə f ɪ ə ɹ d
 afelimomab	æ f ɛ l ɪ m ə m æ b
 affable	æ f ə b ə l
@@ -1518,16 +1532,15 @@ afghani	æ f ɡ ɑː n i
 afghanistan	æ f ɡ æ n ɪ s t æ n
 afghanistan	æ f ɡ æ n ɪ s t ɑː n
 afghanistan	æ f ɡ ɑː n ɪ s t ɑː n
-afgod	æ f ɡ ɒ d
 aficionado	æ f iː θ j ə ʊ n ɑː ð ə ʊ
 aficionado	æ f ɪ ʃ j ɒ n ɑː d ə ʊ
 aficionado	ə f ɪ s j ə n ɑː d ə ʊ
 aficionado	ə f ɪ ʃ i ə n ɑː d ə ʊ
 aficionado	ə f ɪ ʃ j ə n ɑː d ə ʊ
 afield	ə f iː l d
-afire	ə f a ɪ ə ɹ
+afire	ə f a ɪ ɚ
 aflame	ə f l e ɪ m
-aflare	ə f l ɛ ə ɹ
+aflare	ə f l ɛ ɚ
 aflash	ə f l æ ʃ
 aflat	ə f l æ t
 aflaunt	ə f l ɔː n t
@@ -1535,7 +1548,7 @@ aflibercept	ə f l ɪ b ə ɹ s ɛ p t
 aflight	ə f l a ɪ t
 aflop	ə f l ɒ p
 aflow	ə f l o ʊ
-aflower	ə f l a ʊ ə ɹ
+aflower	ə f l a ʊ ɚ
 aflush	ə f l ʌ ʃ
 aflutter	ə f l ʌ t ə
 afoam	ə f o ʊ m
@@ -1558,7 +1571,7 @@ africana	æ f ɹ ɪ k ɑ n ə
 africo	æ f ɹ ɪ k ə ʊ
 africom	æ f ɹ ɪ k ɑ m
 afrikaans	ɑː f ɹ ɪ k ɑː n z
-afrikaner	æ f ɹ ɪ k ɑː n ə ɹ
+afrikaner	æ f ɹ ɪ k ɑː n ɚ
 afroth	ə f ɹ ɒ θ
 aft	æ f t
 after	ɑː f t ə ɹ
@@ -1605,7 +1618,7 @@ agartala	ə ɡ ə ɹ t ə l ə
 agassi	æ ɡ ə s i
 agate	æ ɡ ə t
 agateophobia	ə ɡ e ɪ t i ə ʊ f ə ʊ b i ə
-agateware	æ ɡ ə t w ɛ ə ɹ
+agateware	æ ɡ ə t w ɛ ɚ
 agatha	æ ɡ ə θ ə
 agave	ə ɡ e ɪ v iː
 agave	ə ɡ ɑː v e ɪ
@@ -1647,6 +1660,7 @@ aggrace	ə ɡ ɹ e ɪ s
 aggrandize	ə ɡ ɹ æ n d a ɪ̯ z
 aggravate	æ ɡ ɹ ə v e ɪ̯ t
 aggravated	æ ɡ ɹ ə v e ɪ̯ t ɪ d
+aggravation	æ ɡ ɹ ə v e ɪ ʃ ə n
 aggregate	æ ɡ ɹ ɪ ɡ e ɪ t
 aggregate	æ ɡ ɹ ɪ ɡ ə t
 aggregation	æ ɡ ɹ ə ɡ e ɪ ʃ ə n
@@ -1662,7 +1676,7 @@ agility	ə d͡ʒ ɪ l ɪ t i
 agin	ə ɡ ɪ n
 aging	e ɪ d͡ʒ ɪ ŋ
 agings	e ɪ d͡ʒ ɪ ŋ z
-aginner	ə ɡ ɪ n ə ɹ
+aginner	ə ɡ ɪ n ɚ
 agio	æ d͡ʒ i o ʊ
 agio	æ d͡ʒ o ʊ
 agio	ɑː d͡ʒ o ʊ
@@ -1677,13 +1691,13 @@ agitatrices	æ d͡ʒ ɪ t e ɪ t ɹ ɪ s iː z
 agitatrix	æ d͡ʒ ɪ t e ɪ t ɹ ɪ k s
 agitprop	æ d ʒ ɪ t p ɹ ɒ p
 agitpropping	æ d ʒ ɪ t p ɹ ɒ p ɪ ŋ
-aglare	ə ɡ l ɛ ə ɹ
+aglare	ə ɡ l ɛ ɚ
 agleam	ə ɡ l iː m
 agley	ə ɡ l e ɪ
 agley	ə ɡ l iː
-aglimmer	ə ɡ l ɪ m ə ɹ
+aglimmer	ə ɡ l ɪ m ɚ
 aglint	ə ɡ l ɪ n t
-aglitter	ə ɡ l ɪ t ə ɹ
+aglitter	ə ɡ l ɪ t ɚ
 agminate	æ ɡ m ɪ n e ɪ t
 agnate	æ ɡ n e ɪ t
 agnath	æ ɡ n ə θ
@@ -1723,6 +1737,7 @@ agra	ə ɡ ɹ ɑː
 agraffe	ə ɡ ɹ æ f
 agrarian	ə ɡ ɹ ɛ ə ɹ i ə n
 agree	ə ɡ ɹ iː
+agreeably	ə ɡ ɹ iː ə b l i
 agreed	ə ɡ ɹ i d
 agreed	ə ɡ ɹ iː d
 agreement	ə ɡ ɹ iː m ə n t
@@ -1928,6 +1943,7 @@ aks	æ k s
 aks	ɑː k s
 aktau	ɑ k t a ʊ
 akubra	ə k uː b ɹ ə
+akwesasne	æ k w ə s æ s n e ɪ
 al	æ l
 al	ɑː l
 alabamian	æ l ə b æ m i ə n
@@ -1989,7 +2005,7 @@ albumen	a l b j ʊ m ɪ n
 albumen	æ l b j uː m ə n
 albumen	æ l b j ʊ m ə n
 albumin	a l b j ʊ m ɪ n
-albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ə ɹ
+albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ɚ
 albuminous	æ l b j uː m ɪ n ə s
 albuquerque	æ l b ə k ɜː k i
 albury	ɔː l b ə ɹ i
@@ -1999,7 +2015,8 @@ alcaide	æ l k a ɪ d i
 alcatote	æ l k ə t ə ʊ t
 alcazar	a l k ə z ɑː
 alcedine	æ l s ə d ʌ ɪ n
-alcester	ɒ l s t ə ɹ
+alces	æ l s iː z
+alcester	ɒ l s t ɚ
 alchemistical	æ l k ə m ɪ s t ɪ k ə l
 alcibiades	æ l s ə b a ɪ ə d i z
 alcid	a l s ɪ d
@@ -2017,8 +2034,8 @@ alcyone	æ l s a ɪ ə n i
 aldcliffe	ɔː k l ɪ f
 aldcliffe	ɔː l d k l ɪ f
 aldebaran	a l d ɛ b ə ɹ ə n
-aldehyde	æ l d ɨ h a ɪ d
-aldehydes	æ l d ɨ h a ɪ d z
+aldehyde	æ l d ɪ h a ɪ d
+aldehydes	æ l d ɪ h a ɪ d z
 alder	ɔː l d ə
 alderfly	ɔː l d ə f l a ɪ
 alderliefest	ɔː l d ə ɹ l iː f ɪ s t
@@ -2059,9 +2076,11 @@ aleut	ə l uː t
 aleutian	ə l uː ʃ ə n
 alewife	e ɪ l w ʌ ɪ f
 alex	æ l ɪ k s
-alexander	æ l ɨ ɡ z ɑː n d ə
-alexanders	æ l ɨ ɡ z ɑː n d ə z
-alexandra	æ l ɨ ɡ z ɑː n d ɹ ə
+alexander	a l ɪ ɡ z ɑː n d ə
+alexander	æ l ɪ ɡ z ɑː n d ə
+alexanders	æ l i ɡ z ɑː n d ə z
+alexanders	æ l ɪ ɡ z ɑː n d ə z
+alexandra	æ l ɪ ɡ z ɑː n d ɹ ə
 alexandrian	æ l ɛ ɡ z æ n d ɹ iː ə n
 alexei	ə l ɛ k s e ɪ
 alexipharmac	ə l ɛ k s ɪ f ɑː m æ k
@@ -2069,7 +2088,7 @@ alexipharmic	ə l ɛ k s ɪ f ɑː m ɪ k
 alexipyretic	ə l ɛ k s ɪ p a ɪ ɹ ɛ t ɪ k
 alexithymia	e ɪ l ɛ k s ə θ a ɪ m i ə
 alexithymic	ə l ɛ k s ɪ θ a ɪ m ɪ k
-alexondra	æ l ɨ ɡ z ɑː n d ɹ ə
+alexondra	æ l ɪ ɡ z ɑː n d ɹ ə
 alf	æ l f
 alfacalcidol	a l f ə k a l s ɪ d ɒ l
 alfalfa	æ l f æ l f ə
@@ -2180,7 +2199,6 @@ alkies	æ l k i z
 alkin	ɔː l k ɪ n
 alkyl	æ l k a ɪ l
 alkyl	æ l k ɪ l
-all	ɔː l
 allahabad	æ l ə h ə b æ d
 allahabad	æ l ə h ə b ɑː d
 allamakee	æ l ə m ə k i
@@ -2222,6 +2240,7 @@ alligator	æ l ɪ ɡ e ɪ t ə
 alligators	æ l ɪ ɡ e ɪ t ə z
 allison	æ l ɪ s ə n
 allistic	æ l ɪ s t ɪ k
+allistic	ɑ l ɪ s t ɪ k
 allistic	ə l ɪ s t ɪ k
 allium	æ l i ə m
 alliyah	ɑː l iː j ə
@@ -2368,7 +2387,8 @@ alsace	æ l s e ɪ s
 alsace	æ l s æ s
 alsatian	æ l s e ɪ ʃ ə n
 also	ɔː l s ə ʊ
-alstroemeria	æ l s t ɹ ɨ m iː ɹ i ə
+alstroemeria	æ l s t ɹ i m iː ɹ ɪ ə
+alt	ɒ l t
 alt	ɔ l t
 alt	ɔː l t
 alta	ɑː l t ə
@@ -2444,7 +2464,9 @@ alytarch	æ l ɪ t ɑː k
 alytus	ə l iː t ə s
 ama	ɑː m ə
 ama	ʔ ɐ m a
+amab	e ɪ m æ b
 amacrine	æ m ə k ɹ ɪ n
+amadeus	æ m ə d e ɪ ə s
 amadou	æ m ə d uː
 amah	ɑː m ə
 amahs	ɑː m ə z
@@ -2488,9 +2510,7 @@ amaze	ə m e ɪ z
 amazed	ə m e ɪ z d
 amazement	ə m e ɪ z m ə n t
 amazes	ə m e ɪ z ɪ z
-amazigh	ʔ a m aː z iː ʁ
-amazigh	ʔ æ m æː z iː ʁ
-amazigh	ʔ ɑ m ɑː z iː ʁ
+amazigh	æ m ə z ɪ ɡ
 amazing	ə m e ɪ z ɪ ŋ
 amazingly	ə m e ɪ z ɪ ŋ l i
 amazon	æ m ə z ə n
@@ -2532,6 +2552,7 @@ amblyopia	æ m b l ɪ ə ʊ p ɪ ə
 amblyopic	æ m b l iː o ʊ p ɪ k
 amblyopic	æ m b l iː ɒ p ɪ k
 ambo	æ m b ə ʊ
+ambrisentan	æ m b ɹ ɪ s ɛ n t æ n
 ambrose	æ m b ɹ ə ʊ z
 ambrosial	a m b ɹ ə ʊ z ɪ ə l
 ambry	æ m b ɹ i
@@ -2593,7 +2614,7 @@ amfilokhia	æ m f ɪ l ə ʊ k a ɪ ə
 amharic	æ m h æ ɹ ɪ k
 amiable	e ɪ m i ə b ə l
 amiable	æ m i ə b ə l
-amicable	æ m ɨ k ə b ə l
+amicable	æ m ɪ k ə b ə l
 amical	a m ɪ k l
 amical	a m ɪ k ə l
 amici	æ m ɪ k i
@@ -2634,6 +2655,7 @@ amit	ə m ɪ t
 amite	e ɪ m ɛ t
 amitriptyline	æ m ɪ t ɹ ɪ p t ɪ l iː n
 amitābha	ə m i t ɑː b ə
+amlwch	a m l ʊ χ
 amma	ʌ m ə
 amman	ə m ɑː n
 ammer	æ m ə
@@ -2706,6 +2728,7 @@ ampersat	æ m p ə s æ t
 ampersat	æ m p ə z æ t
 amphetamine	æ m f ɛ t ə m iː n
 amphetamine	æ m f ɛ t ə m ɪ n
+amphibial	æ m f ɪ b i ə l
 amphibian	æ m f ɪ b ɪ ə n
 amphibole	æ m f ɪ b o ʊ l
 amphibolite	æ m f ɪ b ə l a ɪ t
@@ -2720,7 +2743,7 @@ amphigory	æ m f ɪ ɡ ɔ ɹ i
 amphipathic	a m f ɪ p a θ ɪ k
 amphipod	a m f ɪ p ɒ d
 amphipods	a m f ɪ p ɒ d z
-amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ə ɹ
+amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ɚ
 amphisbaena	æ m f ɪ s b iː n ə
 amphisbæna	æ m f ɪ s b iː n ə
 amphitheatre	æ m f i θ iː ə t ə
@@ -2758,7 +2781,7 @@ amusement	ə m j u z m ə n t
 amuses	ə m j uː z ɪ z
 amusing	ə m j uː z ɪ ŋ
 amusingly	ə m j u z ɪ ŋ l i
-amutter	ə m ʌ t ə ɹ
+amutter	ə m ʌ t ɚ
 amy	e ɪ m i
 amygdala	ə m ɪ ɡ d ə l ə
 amygdalae	ə m ɪ ɡ d ə l a ɪ
@@ -2799,11 +2822,12 @@ anadromes	æ n ə d ɹ o ʊ m z
 anadromous	ə n a d ɹ ə m ə s
 anaerophyte	ə n e ɪ ə ɹ ə ʊ f a ɪ t
 anaesthetist	ə n iː s θ ə t ɪ s t
-anagoge	a n ə ɡ ə ʊ d ʒ i
+anagoge	æ n ə ɡ ɒ d͡ʒ i
+anagoge	æ n ə ɡ ə ʊ d͡ʒ i
 anagogy	æ n ə ɡ o ʊ d͡ʒ i
 anagogy	æ n ə ɡ ɒ d͡ʒ i
 anagram	æ n ə ɡ ɹ æ m
-anagrammer	æ n ə ɡ ɹ æ m ə ɹ
+anagrammer	æ n ə ɡ ɹ æ m ɚ
 anagrams	æ n ə ɡ ɹ æ m s
 anagrind	æ n ə ɡ ɹ ɪ n d
 anaheim	æ n ə h a ɪ m
@@ -2824,7 +2848,6 @@ analogous	ə n æ l ə ɡ ə s
 analogously	ə n æ l ə ɡ ə s l i
 analogy	ə n æ l ə d͡ʒ i
 analphabet	æ n æ l f ə b ɛ t
-analyse	æ n ə l a ɪ z
 analyses	æ n ə l a ɪ z ə z
 analyses	æ n ə l a ɪ z ɪ z
 analyses	ə n æ l ə s iː z
@@ -2835,6 +2858,7 @@ analysises	ə n æ l ɪ s ɪ s ɪ z
 analyst	æ n ə l ɪ s t
 analytic	æ n ə l ɪ t ɪ k
 analytics	æ n ə l ɪ t ɪ k s
+analyze	æ n ə l a ɪ z
 analyzed	æ n ə l a ɪ z d
 anamnesis	æ n æ m n iː s ɪ s
 anamorphic	æ n ə m ɔː f ɪ k
@@ -2889,6 +2913,7 @@ anatase	æ n ə t e ɪ z
 anataxis	a n ə t a k s ɪ s
 anathema	ə n æ θ ə m ə
 anathematize	ə n æ θ ə m ə t a ɪ z
+anatidae	ə n æ t ɪ d iː
 anatiferous	æ n ə t ɪ f ə ɹ ə s
 anatine	a n ə t ʌ ɪ n
 anatole	æ n ə t o ʊ l
@@ -2923,7 +2948,7 @@ ancient	e ɪ n ʃ ə n t
 ancientry	e ɪ n ʃ ə n t ɹ i
 ancienty	e ɪ n t ʃ ə n t i
 ancilla	æ n s ɪ l ə
-ancillary	æ n s ə l ɛ ɹ iː
+ancillary	æ n s ɪ l ə ɹ i
 ancillula	æ n s ɪ l j ʊ l ə
 ancle	æ ŋ k ə l
 ancon	æ ŋ k ɒ n
@@ -2943,7 +2968,7 @@ andorran	æ n d ɔː ɹ ə n
 andouille	ɒ n d uː i
 andouille	ɒ̃ d uː j
 andouilles	ɑ n d uː ɪ z
-andover	æ n d o ʊ v ə ɹ
+andover	æ n d o ʊ v ɚ
 andragogy	a n d ɹ ə ɡ ɒ d ʒ i
 andragogy	a n d ɹ ə ɡ ɒ ɡ i
 andre	ɑː n d ɹ e ɪ
@@ -3058,7 +3083,7 @@ anhelation	æ n h ɪ l e ɪ ʃ n̩
 anhele	ə n h iː l
 anhele	ə n iː l
 anhui	ɑː n h w e ɪ
-anhur	ɑː n h ʊ ə ɹ
+anhur	ɑː n h ʊ ɚ
 anhypostasia	æ n h a ɪ p ə s t e ɪ s ɪ ə
 anhypostasia	æ n h a ɪ p ə s t e ɪ ʒ ə
 anhypostasis	æ n h a ɪ p ə s t e ɪ s ɪ s
@@ -3078,8 +3103,6 @@ animalcule	æ n ɪ m æ l k j uː l
 animalculist	a n ɪ m a l k j ʊ l ɪ s t
 animally	a n ɪ m ə l i
 animals	æ n ɪ m ə l z
-animate	æ n ə m e ɪ t
-animate	æ n ə m ə t
 animate	æ n ɪ m e ɪ t
 animate	æ n ɪ m ə t
 animated	æ n ɪ m e ɪ t ɪ d
@@ -3101,6 +3124,7 @@ anise	ə n iː z
 anishinaabe	ɑː n ɪ ʃ ɪ n ɑː b e ɪ
 anisocytosis	ə n a ɪ s ə ʊ s a ɪ t ə ʊ s ɪ s
 anisogamy	æ n a ɪ s ɒ ɡ ə m i
+anisotropous	æ n a ɪ s ɒ t ɹ ə p ə s
 anita	ə n iː t ə
 aniṭ	ʌ n ɪ t
 anjou	ɒ n ʒ uː
@@ -3124,7 +3148,7 @@ annabeth	æ n ə b ɛ θ
 annal	æ n ə l
 annalist	æ n ə l ɪ s t
 annan	æ n ə n
-annapolis	ə n æ p ə l ɨ s
+annapolis	ə n æ p ə l ɪ s
 anne	æ n
 anneal	ə n iː l
 annette	ə n ɛ t
@@ -3211,6 +3235,7 @@ ansai	ɑː n s a ɪ
 ansatz	æ n s æ t s
 anschluss	a n ʃ l ʊ s
 anselm	a n s ɛ l m
+anser	æ n s ə r
 anserine	a n s ə ɹ iː n
 anserine	a n s ə ɹ ʌ ɪ n
 ansible	æ n s ɪ b ə l
@@ -3221,7 +3246,7 @@ answerable	ɑː n s ə ɹ ə b ə l
 answerable	ɑː n s ɹ ə b ə l
 answered	a n s ə d
 answered	ɑː n s ə d
-answerer	ɑː n s ə ɹ ə
+answerer	ɑː n s ə ɹ ɚ
 answering	ɑː n s ə ɹ ɪ ŋ
 answerphone	æ n s ə f ə ʊ n
 answerphone	æ n s ɜː ɹ f ə ʊ n
@@ -3245,6 +3270,7 @@ ante	æ n t i
 anteater	æ n t iː t ə
 antebellum	æ n t i b ɛ l ə m
 antecedaneous	æ n t ɪ s ɪ d e ɪ n i ə s
+antecedence	æ n t ɛ s ɪ d ə n s
 antecedent	æ n t ɪ s iː d ə n t
 antechamber	æ n t i t͡ʃ e ɪ m b ə
 antechamber	æ n t ɪ t͡ʃ e ɪ m b ə
@@ -3307,7 +3333,7 @@ anthroposophic	æ n θ ɹ ə p ə s ɒ f ɪ k
 anthroposophical	æ n θ ɹ ə p ə s ɒ f ɪ k ə l
 anthroposophist	æ n θ ɹ ə p ɒ s ə f ɪ s t
 anthroposophy	æ n θ ɹ ə p ɒ s ə f i
-anthroposphere	a n θ ɹ ɒ p ə s f ɪ ə ɹ
+anthroposphere	a n θ ɹ ɒ p ə s f ɪ ɚ
 anti	æ n t i
 antialiasing	æ n t i e ɪ l i ə s ɪ ŋ
 antialiasing	æ n t ɑ ɪ̯ e ɪ l i ə s ɪ ŋ
@@ -3415,7 +3441,7 @@ antithrombin	æ n t ɪ θ ɹ ɒ m b ɪ n
 antivenin	æ n t ɪ v ɛ n ɪ n
 antiviral	æ n t i v a ɪ ɹ ə l
 antler	æ n t l ə
-antmire	a n t m a ɪ ə ɹ
+antmire	a n t m a ɪ ɚ
 antoeci	æ n t iː s a ɪ
 antoecian	æ n t iː ʃ ə n
 antoikoi	æ n t ɔ ɪ k ɔ ɪ
@@ -3439,6 +3465,7 @@ antsy	æ n t s i
 antumbra	æ n t ʌ m b ɹ ə
 antwacky	æ n t w æ k i
 anubandha	ə n ʊ b ʌ n d ə
+anura	ə n j ʊ ə r ə
 anuran	ə n j ʊ ə ɹ ə n
 anus	e ɪ n ə s
 anvil	æ n v ɪ l
@@ -3446,7 +3473,7 @@ anxiety	æ ŋ ɡ z a ɪ ə t i
 anxin	ɑː n ʃ iː n
 anxiolytic	æ ŋ k s i ə l ɪ t ɪ k
 anxious	æ ŋ k ʃ ə s
-anxiouser	æ ŋ k ʃ ə s ə ɹ
+anxiouser	æ ŋ k ʃ ə s ɚ
 any	æ n i
 any	ɛ n i
 any	ɛ n ɪ
@@ -3508,7 +3535,7 @@ apeirotheism	ə p iː ɹ ɵ θ iː ɪ z ə m
 apelles	ə p ɛ l iː z
 apennine	æ p ə n a ɪ n
 apennines	æ p ə n a ɪ n z
-aper	e ɪ p ə ɹ
+aper	e ɪ p ɚ
 apert	ə p ɜː ɹ t
 aperture	a p ə t j ʊ ə
 aperture	a p ə t͡ʃ ə
@@ -3523,7 +3550,11 @@ aphanitic	æ f ə n ɪ t ɪ k
 aphasia	ə f e ɪ z ɪ ə
 aphasia	ə f e ɪ ʒ ə
 aphasic	ə f e ɪ z ə k
+aphelia	æ p h iː l ɪ ə
+aphelia	ə f iː l ɪ ə
+aphelion	æ p h iː l ɪ ə
 aphelion	æ p h iː l ɪ ə n
+aphelion	ə f iː l ɪ ə
 aphelion	ə f iː l ɪ ə n
 apheresis	ə f ɪ ə ɹ ɪ s ɪ s
 apheses	æ f ə s iː z
@@ -3532,7 +3563,7 @@ aphetic	ə f ɛ t ɪ k
 aphetism	æ f ə t ɪ z ə m
 aphetize	æ f ə t a ɪ z
 aphid	e ɪ f ɪ d
-aphorism	æ f ə ɹ ɪ z m̩
+aphorism	æ f ə ɹ ɪ z ə m
 aphoristic	æ f ə ɹ ɪ s t ɪ k
 aphotic	e ɪ f ə ʊ t ɪ k
 aphrodisiac	æ f ɹ o ʊ d i z i æ k
@@ -3580,6 +3611,7 @@ apodictism	a p ə ʊ d ɪ k t ɪ z m
 apodioxis	æ p ə ʊ d a ɪ ɒ k s ɪ s
 apodixis	æ p ə ʊ d a ɪ k s ɪ s
 apodixis	æ p ə ʊ d ɪ k s ɪ s
+apodosis	ə p ɒ d ə s ɪ s
 apogamy	ə p ɒ ɡ ə m ɪ
 apogeal	æ p o ʊ d͡ʒ iː ə l
 apogeal	æ p ə d͡ʒ iː ə l
@@ -3643,15 +3675,15 @@ apparatus	æ p ə ɹ æ t ə s
 apparatus	æ p ə ɹ ɑː t ə s
 apparel	ə p æ ɹ ə l
 apparent	ə p æ ɹ ə n t
-apparently	ə p a ɹ ə n t l i
+apparently	ə p æ ɹ ə n t l iː
 apparition	æ p ə ɹ ɪ ʃ n̩
-apparitor	ə p æ ɹ i t ə ɹ
+apparitor	ə p æ ɹ i t ɚ
 appeal	ə p iː l
 appealed	ə p iː l d
 appealing	ə p iː l ɪ ŋ
 appealingly	ə p ɪ i l ɪ ŋ l i
 appear	ə p ɪ ə
-appearance	ə p ɪ ə ɹ ə n s
+appearance	ə p ɪ ɹ ə n s
 appeared	ə p ɪ ə d
 appearing	ə p ɪ ə ɹ ɪ ŋ
 appears	ə p ɪ ə z
@@ -3746,7 +3778,7 @@ appropry	ə p ɹ ə ʊ p ɹ i
 approval	ə p ɹ uː v ə l
 approve	ə p ɹ uː v
 approved	ə p ɹ uː v d
-approver	ə p ɹ uː v ə ɹ
+approver	ə p ɹ uː v ɚ
 approves	ə p ɹ uː v z
 approving	ə p ɹ uː v ɪ ŋ
 approximal	ə p ɹ ɒ k s ɪ m ə l
@@ -3769,6 +3801,7 @@ april	e ɪ p ɹ ə l
 april	e ɪ p ɹ ɪ l
 aprils	e ɪ p ɹ ə l z
 aprium	e ɪ p ɹ i ə m
+aprocitentan	æ p ɹ ə s ɪ t ɛ n t æ n
 apron	e ɪ p ɹ ə n
 aprons	e ɪ p ɹ ə n z
 apronym	æ p ɹ ə n ɪ m
@@ -3823,7 +3856,7 @@ aquila	æ k w ɪ l ə
 aquiline	æ k w ɪ l a ɪ n
 aquinas	ə k w a ɪ n ə s
 aquitaine	æ k w ɪ t e ɪ n
-aquiver	ə k w ɪ v ə ɹ
+aquiver	ə k w ɪ v ɚ
 ar	ɑː
 ara	e ɪ ɹ ə
 ara	ɛ ɹ ə
@@ -3855,7 +3888,7 @@ arachnophobia	æ ɹ æ k n ə f ə ʊ b ɪ ə
 aragon	æ ɹ ə ɡ ə n
 aragonese	æ r ə ɡ ɒ n iː z
 arak	ə ɹ æ k
-arak	ɛ ɹ ɨ k
+arak	ɛ ɹ ɪ k
 aralia	ə ɹ e ɪ l i ə
 aralia	ə ɹ e ɪ l j ə
 aram	e ɪ ɹ ə m
@@ -3979,13 +4012,13 @@ archivist	ɑː ɹ k a ɪ v ɪ s t
 archivist	ɑː ɹ k ə v ɪ s t
 archivist	ɑː ɹ k ɪ v ɪ s t
 archking	ɑ ɹ t͡ʃ k ɪ ŋ
-archleader	ɑ ɹ t͡ʃ l iː d ə ɹ
+archleader	ɑ ɹ t͡ʃ l iː d ɚ
 archmage	ɑː t ʃ m e ɪ d ʒ
 archology	ɑː k ɒ l ə d͡ʒ ɪ
 archon	ɑː ɹ k ə n
 archontes	ɑː k ə n t ɛ z
 archontology	ɑː k ɒ n t ɒ l ə d͡ʒ ɪ
-archpractitioner	ɑː ɹ t ʃ p ɹ æ k t ɪ ʃ ə n ə
+archpractitioner	ɑː ɹ t ʃ p ɹ æ k t ɪ ʃ ə n ɚ
 archy	ɑ ɹ k i
 archy	ɑ ɹ t͡ʃ i
 archy	ɑː t͡ʃ i
@@ -4008,7 +4041,7 @@ arcweld	ɑ ɹ k w ɛ l d
 ard	ɑː d
 ardent	ɑː d ə n t
 ardor	ɑː d ə
-ardor	ɑː ɹ d ə ɹ
+ardor	ɑː ɹ d ɚ
 arduity	ɑː d j uː ɪ t i
 arduous	ɑː d j uː ə s
 arduous	ɑː d͡ʒ uː ə s
@@ -4036,7 +4069,7 @@ areopagitic	ɛ ə ɹ i ə ʊ p ə d͡ʒ ɪ t ɪ k
 areopagus	æ r i ɒ p ə ɡ ə s
 ares	e ə ɹ iː z
 arete	æ ɹ ɪ t iː
-arethusa	æ ɹ ɨ θ j uː z ə
+arethusa	æ ɹ ɪ θ j uː z ə
 arew	ə ɹ ə ʊ
 arezzo	ə ɹ ɛ t s ə ʊ
 argal	ɑː ɹ ɡ ə l
@@ -4044,13 +4077,13 @@ argaman	ɑː ɹ ɡ ə m ə n
 argan	ɑː ɹ ɡ ə n
 argent	ɑː d ʒ ə n t
 argentina	ɑː d͡ʒ ə n t iː n ə
-argentinan	ɑ ɹ d͡ʒ ɨ n t iː n ə n
+argentinan	ɑ ɹ d͡ʒ ɪ n t iː n ə n
 argentine	ɑː d ʒ ə n t a ɪ n
 argentine	ɑː d ʒ ə n t iː n
 argentine	ɑː ɹ d͡ʒ ə n t a ɪ n
 argentine	ɑː ɹ d͡ʒ ə n t iː n
-argentinian	ɑ ɹ d͡ʒ ə n t i n i ə n
-argentinian	ɑ ɹ d͡ʒ ə n t iː n i ə n
+argentinian	ɑ ɹ d͡ʒ ə n t i n ɪ ə n
+argentinian	ɑ ɹ d͡ʒ ə n t iː n ɪ ə n
 argentocracy	ɑː d͡ʒ ə n t ɒ k ɹ ə s ɪ
 argentry	ɑː ɹ d͡ʒ ə n t ɹ i
 argh	ɑ ɹ ɡ
@@ -4114,6 +4147,7 @@ aristocrat	æ ɹ ɪ s t ə k ɹ æ t
 aristocratic	æ ɹ ɪ s t ə k ɹ æ t ɪ k
 aristolochic	ə ɹ ɪ s t ə l o ʊ k ɪ k
 aristophanes	æ ɹ ɪ s t ɒ f ə n iː z
+aristotelian	æ ɹ ɪ s t ə t iː l i ə n
 aristotle	æ ɹ ɪ s t ɒ t ə l
 arithmetic	æ ɹ ɪ θ m ɛ t ɪ k
 arithmetic	ə ɹ ɪ θ m ə t ɪ k
@@ -4186,11 +4220,11 @@ arousing	ə ɹ a ʊ z ɪ ŋ
 arow	ə ɹ o ʊ
 arpa	ɑ ɹ p ə
 arpitan	ɑː p ɪ t æ n
-arquebus	ɑː k w ɨ b ə s
+arquebus	ɑː k w ɪ b ə s
 arr	ɑː ɹ
 arrabbiata	a ɹ ə b j ɑː t ə
 arrack	ə ɹ æ k
-arrack	ɛ ɹ ɨ k
+arrack	ɛ ɹ ɪ k
 arraign	ə ɹ e ɪ n
 arraigned	ə ɹ e ɪ n d
 arraigning	ə ɹ e ɪ n ɪ ŋ
@@ -4241,7 +4275,8 @@ arrogate	æ ɹ ə ɡ e ɪ t
 arrondissement	ə ɹ ɒ n d ɪ s m ə n t
 arrove	ə ɹ ə ʊ v
 arrow	æ ɹ ə ʊ
-arrowmaker	æ ɹ ə ʊ m e ɪ k ə ɹ
+arrowcide	æ ɹ o ʊ s a ɪ d
+arrowmaker	æ ɹ ə ʊ m e ɪ k ɚ
 arrowroot	æ ɹ ə ʊ ɹ uː t
 arrows	æ ɹ ə ʊ z
 arroyo	ə ɹ ɔ ɪ ə ʊ
@@ -4302,8 +4337,8 @@ articulation	ɑː t ɪ k j ə l e ɪ ʃ ə n
 articulatory	ɑː ɹ t ɪ k j ə l ə t ə ɹ ɪ
 artifact	ɑː t ɪ f æ k t
 artifice	ɑː ɹ t ɪ f ɪ s
-artificer	ɑ ɹ t ɪ f ə s ə ɹ
-artificer	ɑ ɹ t ɪ f ɪ s ə ɹ
+artificer	ɑ ɹ t ɪ f ə s ɚ
+artificer	ɑ ɹ t ɪ f ɪ s ɚ
 artificial	ɑː ɹ t ə f ɪ ʃ ə l
 artificiality	ɑː ɹ t ɪ f ɪ ʃ i æ l ɪ t i
 artillery	ɑː t ɪ l ə ɹ i
@@ -4402,15 +4437,15 @@ ashamed	ə ʃ e ɪ m d
 ashanti	ə ʃ æ n t iː
 ashanti	ə ʃ ɑː n t iː
 ashed	æ ʃ t
-ashen	æ ʃ ɪ n
+ashen	æ ʃ ə n
 asher	æ ʃ ə
-asher	æ ʃ ə ɹ
+asher	æ ʃ ɚ
 asherah	ə ʃ iː ɹ ə
 ashes	æ ʃ ɪ z
 ashfield	æ ʃ f iː l d
 ashford	æ ʃ f ə d
 ashine	ə ʃ a ɪ n
-ashiver	ə ʃ ɪ v ə ɹ
+ashiver	ə ʃ ɪ v ɚ
 ashkelon	æ ʃ k ə l ɒ n
 ashkenazi	æ ʃ k ɪ n ɑː z i
 ashkenazi	æ ʃ k ɪ n ə z iː
@@ -4453,7 +4488,7 @@ aslant	ə s l ɑː n t
 asleep	ə s l iː p
 aslope	ə s l ə ʊ p
 asmara	æ s m ɑː ɹ ə
-asmear	ə s m ɪ ə ɹ
+asmear	ə s m ɪ ɚ
 asmodeus	æ z m ə d iː ə s
 asmrtist	e ɪ ɛ s ɛ m ɑː t ɪ s t
 asnarl	ə s n ɑː ɹ l
@@ -4480,7 +4515,7 @@ asper	æ s p ə
 asperate	æ s p ə ɹ e ɪ t
 asperate	æ s p ə ɹ ə t
 asperge	ə s p ɜː ɹ d͡ʒ
-asperger	æ s p ɜː ɹ ɡ ə ɹ
+asperger	æ s p ɜː ɹ ɡ ɚ
 aspergilloma	æ s p ə ɹ d͡ʒ ɪ l o ʊ m ə
 aspergilloses	æ s p ə ɹ d͡ʒ ɪ l o ʊ s i s
 aspergillosis	æ s p ə ɹ d͡ʒ ɪ l o ʊ s ɪ s
@@ -4632,13 +4667,13 @@ assythment	ə s ʌ ɪ ð m ə n t
 astaghfirullah	a s t æ f ɪ ɹ ə l ɒː
 astana	ə s t ɑː n ə
 astand	ə s t æ n d
-astare	ə s t ɛ ə ɹ
+astare	ə s t ɛ ɚ
 astart	ə s t ɑː ɹ t
 astasia	ə s t e ɪ z i ə
 astasia	ə s t e ɪ ʒ ə
 astatine	a s t ə t iː n
 astay	ə s t e ɪ
-aster	æ s t ə ɹ
+aster	æ s t ɚ
 asterisk	æ s t ə ɹ ɪ s k
 asterisk	æ s t ɹ ɪ s k
 asterism	æ s t ə ɹ ɪ z ə m
@@ -4692,7 +4727,7 @@ astrogeometry	æ s t ɹ ə d͡ʒ iː ɑ m ɛ t ɹ i
 astrohistory	æ s t ɹ ə h ɪ s t ə ɹ i
 astrolabe	æ s t ɹ ə l e ɪ b
 astrolinguistics	æ s t ɹ ə l ɪ ŋ ɡ w ɪ s t ɪ k s
-astrologer	ə s t r ɒ l ə d͡ʒ ə ɹ
+astrologer	ə s t r ɒ l ə d͡ʒ ɚ
 astrological	æ s t ɹ ə l ɒ d͡ʒ ɪ k ə l
 astrology	ə s t ɹ ɒ l ə d ʒ i
 astromancy	æ s t ɹ ɵ m æ n s i
@@ -4784,8 +4819,8 @@ atherine	æ θ ə ɹ ɪ n
 athermic	e ɪ θ ɜ ɹ m ɪ k
 athetesis	æ θ ɪ t iː s ɪ s
 athirst	ə θ əː s t
-athleisure	æ θ l iː ʒ ə ɹ
-athleisure	æ θ l ɛ ʒ ə ɹ
+athleisure	æ θ l iː ʒ ɚ
+athleisure	æ θ l ɛ ʒ ɚ
 athlete	æ θ l iː t
 athletic	æ θ l ɛ t ɪ k
 athletics	æ θ l ɛ t ɪ k s
@@ -4820,6 +4855,7 @@ atoll	ə t ɒ l
 atoltivimab	æ t ɒ l t ɪ v ɪ m æ b
 atom	æ t ə m
 atomic	ə t ɒ m ɪ k
+atomicity	æ t ə m ɪ s ɪ t i
 atomist	æ t ə m ɪ s t
 atompunk	æ t ə m p ʌ ŋ k
 atoms	a t ə m z
@@ -4851,6 +4887,7 @@ atrium	e ɪ t ɹ i ə m
 atrocious	ə t ɹ ə ʊ ʃ ə s
 atrocity	ə t ɹ ɒ s ɪ t i
 atrophy	æ t ɹ ə f i
+atropia	ə t ɹ ə ʊ p i ə
 atropine	a t ɹ ə p iː n
 atropine	a t ɹ ə p ɪ n
 atropos	æ t ɹ ə p ɒ s
@@ -4907,7 +4944,7 @@ attesting	ə t ɛ s t ɪ ŋ
 attests	ə t ɛ s t s
 attic	æ t ɪ k
 attinge	ə t ɪ n d͡ʒ
-attire	ə t a ɪ ə ɹ
+attire	ə t a ɪ ɚ
 attitude	æ t ɪ t j uː d
 attitudinize	æ t ɪ t j uː d ɪ n a ɪ z
 attitudinize	æ t ɪ t uː d ɪ n a ɪ z
@@ -4935,13 +4972,14 @@ attrit	ə t ɹ ɪ t
 attrition	ə t ɹ ɪ ʃ ə n
 attritive	ə t r a ɪ t ɪ v
 attune	ə t j uː n
+attune	ə t͜ʃ uː n
 atumble	ə t ʌ m b ə l
 atwain	ə t w e ɪ n
 atwinkle	ə t w ɪ ŋ k ə l
 atwirl	ə t w ɜː ɹ l
 atwist	ə t w ɪ s t
 atwitch	ə t w ɪ t͡ʃ
-atwitter	ə t w ɪ t ə ɹ
+atwitter	ə t w ɪ t ɚ
 atyap	ə t j a b
 atypical	e ɪ t ɪ p ɪ k ə l
 atyrau	ɑ t ɪ ɹ a ʊ
@@ -4971,7 +5009,7 @@ audiophile	ɔː d i ə ʊ f a ɪ l
 audiovisual	ɔː d i ə ʊ v ɪ z j ʊ ə l
 audit	ɔː d ɪ t
 audition	ɔː d ɪ ʃ ə n
-auditor	ɔː d ɪ t ə ɹ
+auditor	ɔː d ɪ t ɚ
 auditorium	ɔː d ɪ t ɔː ɹ i ə m
 auditory	ɔː d ɪ t ə ɹ i
 auditory	ɔː d ɪ t ɹ i
@@ -5064,9 +5102,9 @@ austenesque	ɔː s t ə n ɛ s k
 austenian	ɔː s t iː n ɪ ə n
 austenite	ɒ s t ɪ n a ɪ t
 auster	ɒ s t ə
-auster	ɒ s t ə ɹ
+auster	ɒ s t ɚ
 auster	ɔː s t ə
-auster	ɔː s t ə ɹ
+auster	ɔː s t ɚ
 austere	ɒ s t ɪ ə ɹ
 austere	ɔː s t ɪ ə ɹ
 austerlitz	a ʊ s t ə l ɪ t s
@@ -5102,10 +5140,12 @@ austronesian	ɔː s t ɹ o ʊ n iː ʒ ə n
 austronesians	ɔː s t ɹ o ʊ n iː ʒ ə n z
 austrophobe	ɒ s t ɹ ə ʊ f ə ʊ b
 autarchic	ɔː t ɑː k ɪ k
-autarchy	ɔː t ɑː ɹ k i
+autarchy	ɔː t ə k i
 autarkic	ɔː t ɑː k ɪ k
+autarky	ɔː t ə k i
 auteur	ɔː t ɜː
 auteur	ə ʊ t ɜː
+authentic	ɒ θ ɛ n t ɪ k
 author	ɔː θ ə
 authoress	ɔː θ ə ɹ ɛ s
 authoritah	ə θ ɔ ɹ ə t ɑː
@@ -5226,7 +5266,7 @@ avenge	ə v ɛ n d͡ʒ
 avens	æ v ɪ n z
 aventail	æ v ə n t e ɪ l
 aventine	æ v ə n t a ɪ n
-aventre	ə v ɛ n t ə ɹ
+aventre	ə v ɛ n t ɚ
 aventurine	ə v ɛ n t j ʊ ə ɹ ɪ n
 aventurine	ə v ɛ n t͡ʃ ə ɹ ɪ n
 avenue	æ v ə n j uː
@@ -5283,6 +5323,7 @@ avon	e ɪ v ɑ n
 avon	e ɪ v ə n
 avondale	e ɪ v ə n d e ɪ l
 avonmouth	e ɪ v ə n m ə θ
+avosentan	æ v ə s ɛ n t æ n
 avouch	ə v a ʊ t͡ʃ
 avourneen	ə v ɔː n iː n
 avourneen	ə v ʊ ə n iː n
@@ -5317,7 +5358,7 @@ awaze	ɑ w ɑ z e ɪ
 awaze	ɑ w ɑ z i
 awe	ɔː
 aweary	ə w ɪ ə ɹ i
-aweather	ə w ɛ ð ə ɹ
+aweather	ə w ɛ ð ɚ
 awed	ɔː d
 aweigh	ə w e ɪ
 aweless	ɔː l ɪ s
@@ -5346,12 +5387,11 @@ awkwards	ɔː k w ə d z
 awl	ɔː l
 awlwort	ɔː l w ɜː ɹ t
 awn	ɔː n
-awner	ɔː n ə ɹ
+awner	ɔː n ɚ
 awning	ɔː n ɪ ŋ
 awnry	ɔː n ɹ i
 awoke	ə w ə ʊ k
 awoken	ə w ə ʊ k ə n
-awoman	e ɪ w ʊ m ɘ n
 awoman	e ɪ w ʊ m ə n
 awoman	ɑː w ʊ m ə n
 awook	ə w ʊ k
@@ -5454,7 +5494,7 @@ azores	ə z ɔː z
 azote	æ z ə ʊ t
 azotemia	æ z ə ʊ t iː m ɪ ə
 azoth	ɑː z ɒ θ
-azotometer	e ɪ z ə ʊ t ɒ m ɪ t ə ɹ
+azotometer	e ɪ z ə ʊ t ɒ m ɪ t ɚ
 azov	ɑː z ɒ v
 azoxystrobin	ə z ɒ k s i s t ɹ ə ʊ b ɪ n
 azrael	æ z ɹ i ə l
@@ -5494,7 +5534,7 @@ babblery	b æ b ə l ɹ i
 babby	b æ b i
 babe	b e ɪ b
 babel	b e ɪ b l̩
-babergh	b e ɪ b ə ɹ
+babergh	b e ɪ b ɚ
 babes	b e ɪ b z
 babiche	b æ b iː ʃ
 babiche	b ə b iː ʃ
@@ -5550,7 +5590,7 @@ backdam	b æ k d æ m
 backdraught	b æ k d ɹ ɑː f t
 backdrop	b æ k d ɹ ɒ p
 backed	b æ k t
-backer	b æ k ə ɹ
+backer	b æ k ɚ
 backfield	b a k f iː l d
 backfisch	b æ k f ɪ ʃ
 backflip	b æ k f l ɪ p
@@ -5638,6 +5678,7 @@ badenoch	b æ d ə n ɒ x
 badge	b æ d͡ʒ
 badger	b æ d ʒ ɚ
 badger	b æ d͡ʒ ə
+badigeon	b ə d ɪ d ʒ ə n
 badinage	b æ d ɪ n ɑː d ʒ
 badinage	b æ d ɪ n ɑː ʒ
 badine	b ə d iː n
@@ -5652,7 +5693,7 @@ badness	b æ d n ə s
 badong	b ə d ɔ ŋ
 badonkadonk	b ə d ɔ ŋ k ə d ɔ ŋ k
 bae	b e ɪ
-baenomere	b iː n ə m ɪ ə ɹ
+baenomere	b iː n ə m ɪ ɚ
 baenopod	b iː n ə p ɒ d
 baetyl	b iː t a ɪ ɫ
 baff	b æ f
@@ -5716,7 +5757,7 @@ baihe	b a ɪ h ə
 baiji	b a ɪ d͡ʒ i
 baijiu	b a ɪ d͡ʒ uː
 baikal	b a ɪ k æ l
-baikonur	b a ɪ k ə n ɪ ə ɹ
+baikonur	b a ɪ k ə n ɪ ɚ
 bail	b e ɪ̯ l
 baile	b a ɪ l i
 baile	b e ɪ l
@@ -5783,8 +5824,9 @@ balalaiki	b a l ə l a ɪ k i
 balalaiki	b æ l ə l a ɪ k ɪ
 balance	b æ l ə n s
 balanced	b æ l ə n s t
-balancer	b æ l ə n s ə ɹ
+balancer	b æ l ə n s ɚ
 balanephagous	b æ l ə n iː f ə ɡ ə s
+balanic	b ə l æ n ɪ k
 balanitis	b æ l ə n a ɪ t ɪ s
 balanophagous	b æ l ə n ɒ f ə ɡ ə s
 balas	b a l ə s
@@ -5814,6 +5856,7 @@ baled	b e ɪ l d
 baleen	b e ɪ l iː n
 baleen	b ə l iː n
 baleful	b e ɪ l f ə l
+balenciaga	b ə l ɛ n s i ɑː ɡ ə
 bales	b e ɪ l z
 bali	b ɑː l i
 balinese	b ɑː l ɪ n iː z
@@ -5834,7 +5877,7 @@ balladry	b æ l ə d ɹ i
 ballarat	b æ l ə ɹ æ t
 ballast	b æ l ə s t
 ballcock	b ɔː l k ɒ k
-baller	b ɔː l ə ɹ
+baller	b ɔː l ɚ
 ballerina	b æ l ə ɹ iː n ə
 ballerino	b æ l ə ɹ iː n o ʊ
 ballet	b æ l e ɪ
@@ -5849,7 +5892,7 @@ ballistics	b ə l ɪ s t ɪ k s
 ballonet	b a l ə n ɛ t
 balloon	b ə l uː n
 ballooned	b ə l uː n d
-ballooner	b ə l uː n ə ɹ
+ballooner	b ə l uː n ɚ
 ballooning	b ə l uː n ɪ ŋ
 balloonings	b ə l uː n ɪ ŋ z
 balloons	b ə l uː n z
@@ -5871,7 +5914,7 @@ balmily	b ɑː m ɪ l i
 balmoral	b æ l m ɒ ɹ ə l
 balmy	b ɑː m i
 baloney	b ə l ə ʊ n i
-balquhidder	b æ l k w ɪ d ə ɹ
+balquhidder	b æ l k w ɪ d ɚ
 balrog	b a l ɹ ɒ ɡ
 balrog	b ɔː l ɹ ɒ ɡ
 balsa	b æ l s ə
@@ -5896,18 +5939,19 @@ bambooey	b æ m b uː i
 bamboozle	b æ m b uː z l̩
 bambuterol	b æ m b j uː t ə ɹ ɒ l
 bamma	b æ m ə
-bammer	b æ m ə ɹ
+bammer	b æ m ɚ
 bammy	b a m i
 bamp	b æ m p
 bampot	b æ m p ɒ t
 ban	b æ n
+banaba	b ə n ɑː b ə
 banach	b a n a k
 banach	b a n a x
 banal	b e ɪ n ə l
 banal	b ə n æ l
 banal	b ə n ɑː l
-banality	b e ɪ n æ l ɨ t i
-banality	b ə n æ l ɨ t i
+banality	b e ɪ n æ l ɪ t i
+banality	b ə n æ l ɪ t i
 banana	b ə n ɑː n ə
 bananas	b ə n ɑː n ə z
 bananery	b ə n ɑː n ə ɹ i
@@ -5932,8 +5976,9 @@ bandit	b æ n d ɪ t
 bandmate	b æ n d m e ɪ t
 bandog	b a n d ɒ ɡ
 bandolero	b æ n d ə l e ə ɹ ə ʊ
-bandolier	b æ n d ə l ɪ ə ɹ
+bandolier	b æ n d ə l ɪ ɚ
 bandolierwise	b æ n d ə l ɪ ə ɹ w a ɪ z
+bandra	b æ n d ɹ ə
 bands	b æ n d z
 bandstand	b æ n d s t æ n d
 bandung	b æ n d ʊ ŋ
@@ -5951,14 +5996,14 @@ bangable	b æ ŋ ɡ ə b ə ɫ
 bangalore	b æ ŋ ɡ ə l ɔː
 bangarang	b æ ŋ ə ɹ æ ŋ
 bangel	b e ɪ n d͡ʒ ə l
-banger	b æ ŋ ə ɹ
+banger	b æ ŋ ɚ
 banging	b æ ŋ ɪ ŋ
 bangiophyte	b æ n d͡ʒ ɪ ɔ f a ɪ t
 bangkok	b æ ŋ k ɒ k
 bangladesh	b æ ŋ ɡ l ə d ɛ ʃ
 bangladesh	b ɑː ŋ ɡ l ə d ɛ ʃ
 bangle	b æ ŋ ɡ ə l
-bangor	b æ ŋ ɡ ə ɹ
+bangor	b æ ŋ ɡ ɚ
 bangs	b æ ŋ z
 bangui	b ɑː ŋ ɡ i
 bangui	b ɑː ŋ ɡ iː
@@ -5969,7 +6014,7 @@ banishes	b æ n ɪ ʃ ɪ z
 banishing	b æ n ɪ ʃ ɪ ŋ
 banishings	b æ n ɪ ʃ ɪ ŋ z
 banishment	b æ n ɪ ʃ m ə n t
-banister	b æ n ɪ s t ə ɹ
+banister	b æ n ɪ s t ɚ
 banjax	b æ n d͡ʒ æ k s
 banjo	b æ n d ʒ ə ʊ
 banjouke	b æ n d͡ʒ ə ʊ j uː k
@@ -6119,6 +6164,7 @@ barghest	b ɑː ɡ ɛ s t
 bargirl	b ɑː ɹ ɡ ɜː ɹ l
 bari	b æ ɹ i
 baria	b ɛ ə ɹ i ə
+bariatric	b æ ɹ i æ t ɹ ɪ k
 bariatrician	b æ ɹ i ə t ɹ ɪ ʃ ə n
 baric	b æ ɹ ɪ k
 baric	b ɛ ə ɹ ɪ k
@@ -6136,7 +6182,7 @@ bark	b ɑː k
 barkeep	b ɑː ɹ k iː p
 barken	b ɑː ɹ k ə n
 barker	b ɑː r k ə r
-barker	b ɑː ɹ k ə ɹ
+barker	b ɑː ɹ k ɚ
 barking	b ɑː k ɪ ŋ
 barking	b ɑː ɹ k ɪ ŋ ɡ
 barkled	b ɑː k ə l d
@@ -6187,7 +6233,7 @@ barramundi	b æ ɹ ə m ʌ n d i
 barranca	b ə ɹ æ ŋ k ə
 barrasso	b ə ɹ æ s o ʊ
 barrasso	b ə ɹ ɑ s o ʊ
-barrator	b æ ɹ ə t ə ɹ
+barrator	b æ ɹ ə t ɚ
 barrators	b æ ɹ ə t ə ɹ z
 barratry	b æ ɹ ə t ɹ i
 barred	b ɑː ɹ d
@@ -6200,7 +6246,7 @@ barrier	b æ ɹ i ə ɹ
 barring	b ɑː ɹ ɪ ŋ ɡ
 barrister	b æ ɹ ɪ s t ə ɹ
 barrow	b æ ɹ ə ʊ
-barry	b æ ɹ i
+barry	b æ ɹ ɪ
 barry	b ɑː ɹ i
 bars	b ɑː ɹ z
 barse	b ɑː s
@@ -6217,8 +6263,7 @@ bartizan	b ɑː t ɪ z æ n
 bartlett	b ɑː ɹ t l ə t
 barton	b ɑː ɹ t ə n
 bartonite	b ɑː ɹ t ə n a ɪ t
-baruch	b ə r u k
-baruch	b ɛ ə r ə k
+baruch	b ə r u x
 baryon	b æ ɹ i ɒ n
 baryon	b ɛ ə ɹ i ɒ n
 barythymia	b æ ɹ ɪ θ a ɪ m ɪ ə
@@ -6287,8 +6332,8 @@ basketball	b ɑː s k ɪ t b ɔː l
 basketweaving	b æ s k ə t w ɪ i v ɪ ŋ
 basketweaving	b æ s k ɪ t w ɪ i v ɪ ŋ
 basle	b ɑː l
-basler	b æ z l ə ɹ
-basler	b ɑː z l ə ɹ
+basler	b æ z l ɚ
+basler	b ɑː z l ɚ
 basmati	b æ z m æ t i
 basmati	b æ z m ɑː t i
 basmati	b ɑː z m ɑː t i
@@ -6300,13 +6345,14 @@ bass	b æ s
 bassaleg	b æ s æ l ɛ ɡ
 bassein	b ə s e ɪ n
 basset	b æ s ɪ t
+basseterre	b æ s t ɛ ə ɹ
 bassinet	b æ s ɪ n ɛ t
 bassist	b e ɪ s ɪ s t
 bassline	b e ɪ s l a ɪ n
 basslines	b e ɪ s l a ɪ n z
 bassoon	b ə s uː n
 bassooned	b ə s uː n d
-bassooner	b ə s uː n ə ɹ
+bassooner	b ə s uː n ɚ
 bassooning	b ə s uː n ɪ ŋ
 bassoons	b ə s uː n z
 basswood	b æ s w ʊ d
@@ -6389,7 +6435,9 @@ batley	b æ t l i
 batman	b a t m a n
 batman	b æ t m æ n
 batman	b æ t m ə n
+baton	b æ t n̩
 baton	b æ t ɒ n
+baton	b æ t ə n
 batoon	b ə t uː n
 batrachian	b ə t ɹ e ɪ k ɪ ə n
 batrachophagous	b ə t ɹ æ k ə f e ɪ ɡ ə s
@@ -6400,7 +6448,7 @@ batsqueak	b a t s k w iː k
 batta	b ʌ t ə
 battalion	b ə t æ l ɪ ə n
 batted	b æ t ɪ d
-batter	b æ t ə ɹ
+batter	b æ t ɚ
 batteries	b æ t ə ɹ i z
 battering	b æ t ə ɹ ɪ ŋ ɡ
 battersea	b æ t ə s i
@@ -6448,6 +6496,7 @@ baxter	b æ k s t ə
 bay	b e ɪ
 bayadère	b a ɪ ə d ɛː
 baybars	b a ɪ b ɑː s
+baybayin	b a ɪ b a j i n
 bayed	b e ɪ d
 bayesian	b e ɪ z i ə n
 bayesian	b e ɪ ʒ ə n
@@ -6502,6 +6551,7 @@ beadings	b iː d ɪ ŋ z
 beads	b iː d z
 beadsman	b iː d z m ə n
 beady	b iː d i
+beagle	b iː ɡ ə l
 beak	b iː k
 beaked	b iː k t
 beaker	b iː k ə ɹ
@@ -6592,6 +6642,7 @@ beauties	b j uː t i z
 beautification	b j uː t ɪ f ɪ k e ɪ ʃ ə n
 beautifies	b j u t ə f a ɪ z
 beautiful	b j uː t ɪ f ə l
+beautiful	b j uː t ɪ f ʊ l
 beautifully	b j uː t ɪ f ə l i
 beautify	b j uː t ɪ f a ɪ
 beautility	b j uː t ɪ l ə t i
@@ -6717,7 +6768,7 @@ beepings	b iː p ɪ ŋ z
 beeps	b iː p s
 beer	b iː ə
 beer	b ɪ ə
-beer	b ɪ ə ɹ
+beer	b ɪ ɚ
 beer	b ɪː
 beers	b ɪ ə ɹ z
 beersheba	b ɛ ə ɹ ʃ e ɪ b ə
@@ -6810,7 +6861,7 @@ beheld	b ɪ h ɛ l d
 behelp	b ɪ h ɛ l p
 behemoth	b iː ə m ə θ
 behemoth	b ə h iː m ə θ
-behest	b i h ɛ s t
+behest	b ɪ h ɛ s t
 behind	b ə h a ɪ n d
 behind	b ɪ h a ɪ n d
 behl	b e ɪ l
@@ -6821,6 +6872,7 @@ behoof	b ɪ h uː f
 behoove	b ɪ h uː v
 behove	b ɪ h ə ʊ v
 behoveful	b ɪ h ə ʊ v f ə l
+behoven	b ɪ h ə ʊ v ə n
 beibei	b e ɪ b e ɪ
 beida	b e ɪ d a
 beige	b e ɪ d͡ʒ
@@ -6828,7 +6880,9 @@ beige	b e ɪ ʒ
 beigey	b e ɪ ʒ i
 beignet	b ɛ n j e ɪ
 beijing	b e ɪ d͡ʒ ɪ ŋ
+beijinger	b e ɪ d ʒ ɪ ŋ ə ɹ
 bein	b iː n
+being	b iː ŋ
 being	b iː ɪ ŋ
 beings	b iː ɪ ŋ z
 beiping	b e ɪ p ɪ ŋ
@@ -6892,7 +6946,7 @@ belief	b ɪ l iː f
 believe	b ɪ l iː v
 believer	b ɪ l iː v ə
 belinda	b ə l ɪ n d ə
-belittle	b ɨ l ɪ t ə l
+belittle	b ɪ l ɪ t ə l
 belive	b ɪ l a ɪ v
 beliven	b ɪ l ɪ v ə n
 belize	b e ɪ l iː z
@@ -6946,7 +7000,7 @@ belove	b ɪ l ʌ v
 beloved	b ɪ l ʌ v d
 beloved	b ɪ l ʌ v ɪ d
 below	b ɪ l ə ʊ
-belswagger	b ɛ l s w æ ɡ ə ɹ
+belswagger	b ɛ l s w æ ɡ ɚ
 belt	b ɛ l t
 belted	b ɛ l t ɪ d
 belter	b ɛ l t ə
@@ -6977,7 +7031,7 @@ benbecula	b ɛ n b ɛ k j ʊ l ə
 bench	b ɛ n t ʃ
 bench	b ɛ n ʃ
 benched	b ɛ n t͡ʃ t
-bencher	b ɛ n t͡ʃ ə ɹ
+bencher	b ɛ n t͡ʃ ɚ
 benches	b ɛ n t͡ʃ ɪ z
 benching	b ɛ n t͡ʃ ɪ ŋ
 benchings	b ɛ n t͡ʃ ɪ ŋ z
@@ -7044,7 +7098,7 @@ benumb	b i n ʌ m
 benxi	b ʌ n ʃ iː
 benz	b ɛ n z
 benzene	b ɛ n z iː n
-benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɨ p iː n
+benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɪ p iː n
 benzoin	b ɛ n z ɔ ɪ n
 benzoin	b ɛ n z ə ʊ ɪ n
 benzonatate	b ɛ n z o ʊ n ə t e ɪ t
@@ -7129,6 +7183,7 @@ berserker	b ə z ɜː k ə
 berserker	b ɜː s ɜː k ə
 bert	b ɜː t
 berth	b ɜː θ
+bertha	b ɜː ɹ θ ə
 bertha	b ɜː θ ə
 bertillonage	b ɛː t i j ɒ n ɑː ʒ
 bertram	b ɜː t ɹ ə m
@@ -7193,8 +7248,8 @@ betager	b e ɪ t ə d ʒ ə
 betake	b ɪ t e ɪ k
 betcha	b ɛ t͡ʃ ə
 betcho	b ɛ t͡ʃ o ʊ
-betear	b ɪ t ɛ ə ɹ
-betear	b ɪ t ɪ ə ɹ
+betear	b ɪ t ɛ ɚ
+betear	b ɪ t ɪ ɚ
 betel	b i tᵊ l
 betelgeuse	b iː t l d ʒ əː z
 beth	b ɛ t
@@ -7252,11 +7307,11 @@ bevor	b iː v ə
 bevvy	b ɛ v i
 bevy	b ɛ v i
 bewail	b ɪ w e ɪ l
-beware	b i w ɛ ə ɹ
-beware	b ə w ɛ ə ɹ
-beware	b ɪ w ɛ ə ɹ
-bewater	b ɪ w ɔː t ə ɹ
-bewelter	b ɪ w ɛ l t ə ɹ
+beware	b i w ɛ ɚ
+beware	b ə w ɛ ɚ
+beware	b ɪ w ɛ ɚ
+bewater	b ɪ w ɔː t ɚ
+bewelter	b ɪ w ɛ l t ɚ
 bewhape	b ɪ w e ɪ p
 bewhape	b ɪ ʍ e ɪ p
 bewhore	b ɪ h ɔː ɹ
@@ -7306,7 +7361,7 @@ bhaji	b ɑː d͡ʒ i
 bhang	b a ŋ
 bhang	b æ ŋ
 bhangra	b ɑː ŋ ɡ ɹ ə
-bheer	b ɪ ə ɹ
+bheer	b ɪ ɚ
 bhikkhu	b ɪ k uː
 bhojpuri	b o ʊ d͡ʒ p ʊ ə r i
 bhopal	b ə ʊ p ɑː l
@@ -7338,6 +7393,7 @@ bibliometrist	b ɪ b l i ɒ m ə t ɹ ɪ s t
 bibliopoly	b ɪ b l i ɒ p ə l i
 bibliotheca	b ɪ b l i ə θ iː k ə
 bibliothecal	b ɪ b l i ə θ iː k ə l
+bibliotheque	b ɪ b l i ə θ iː k
 bibliotic	b ɪ b l i ɒ t ɪ k
 biblist	b ɪ b l ɪ s t
 bibs	b ɪ b z
@@ -7377,7 +7433,7 @@ bide	b a ɪ d
 bided	b a ɪ d ɪ d
 bideford	b ɪ d ɪ f ə r d
 biden	b a ɪ d ə n
-bidencare	b a ɪ d ə n k ɛ ə ɹ
+bidencare	b a ɪ d ə n k ɛ ɚ
 bidenomics	b a ɪ d ə n ɒ m ɪ k s
 bides	b a ɪ d z
 bidet	b iː d e ɪ
@@ -7391,6 +7447,7 @@ bieber	b iː b ə
 biennial	b a ɪ ɛ n i ə l
 biennium	b ʌ ɪ ɛ n ɪ ə m
 bier	b ɪ ə
+bifarious	b a ɪ f ɛ ə ɹ i ə s
 bifenthrin	b a ɪ f ɛ n θ ɹ ɪ n
 bifeprunox	b ɪ f ɛ p ɹ ə n ɒ k s
 biff	b ɪ f
@@ -7433,7 +7490,7 @@ bikini	b ɪ k iː n i
 bikini	b ɪ k ɪ n i
 bilabial	b a ɪ l e ɪ b i ə l
 bilali	b ɪ l ɑː l i
-bilander	b ɪ l ə n d ə ɹ
+bilander	b ɪ l ə n d ɚ
 bilbao	b ɪ l b a ʊ
 bilberry	b ɪ l b ə ɹ ɪ
 bilbo	b ɪ l b ə ʊ
@@ -7480,7 +7537,6 @@ bimetallic	b a ɪ m ɪ t æ l ɪ k
 bimillennial	b a ɪ m ɪ l ɛ n i ə l
 bimini	b ɪ m ɪ n i
 bimini	b ɪ m ɪ n iː
-bin	b iː n
 bin	b ɪ n
 binal	b a ɪ n ə l
 binarseniate	b a ɪ n ɑː ɹ s iː n i e ɪ t
@@ -7499,7 +7555,11 @@ bine	b a ɪ n
 bines	b a ɪ n z
 bing	b ɪ ŋ
 binge	b ɪ n d͡ʒ
+binged	b ɪ n d͡ʒ d
+binged	b ɪ ŋ d
 binghi	b ɪ ŋ a ɪ
+binging	b ɪ n d͡ʒ ɪ ŋ
+binging	b ɪ ŋ ɪ ŋ
 bingo	b ɪ ŋ ɡ ə ʊ
 bingy	b ɪ ŋ i
 binhai	b ɪ n h a ɪ
@@ -7515,10 +7575,11 @@ binner	b ɪ n ə ɹ
 binning	b ɪ n ɪ ŋ
 binns	b ɪ n z
 binny	b ɪ n i
-binocular	b ɪ n ɒ k j ʊ l ə ɹ
+binocular	b ɪ n ɒ k j ʊ l ɚ
 binoculars	b ə n ɒ k j ə l ə ɹ z
 binoculars	b ɪ n ɒ k j ʊ l ə ɹ z
 binomial	b a ɪ n ə ʊ m i ə l
+binoxide	b a ɪ n ɒ k s a ɪ d
 bins	b ɪ n z
 bint	b ɪ n t
 bintje	b ɪ n t͡ʃ ə
@@ -7527,7 +7588,7 @@ bio	b a ɪ ə ʊ
 bioanalytical	b a ɪ ə ʊ æ n ə l ɪ t ɪ k ə l
 bioanalytics	b a ɪ o ʊ æ n ə l ɪ t ɪ k s
 biocide	b a ɪ ə ʊ s a ɪ d
-biodiversity	b a ɪ ə ʊ d a ɪ v ɜː ɹ s ɪ t i
+biodiversity	b a ɪ ə ʊ d a ɪ v ɜː s ɪ t i
 biofuel	b a ɪ ə ʊ f j ʊ ə l
 biogenesis	b ʌ ɪ ə ʊ d ʒ ɛ n ə s ɪ s
 biographize	b a ɪ ɒ ɡ ɹ ə f a ɪ z
@@ -7704,14 +7765,14 @@ bizbabble	b ɪ z b æ b ə l
 bizen	b a ɪ z ə n
 blab	b l æ b
 blabbed	b l æ b d
-blabber	b l æ b ə ɹ
+blabber	b l æ b ɚ
 blabbermouth	b l æ b ə ɹ m a ʊ θ
 blabbing	b l æ b ɪ ŋ
 blabby	b l æ b i
 blabs	b l æ b z
 blaby	b l e ɪ b i
 black	b l æ k
-blackadder	b l æ k æ d ə ɹ
+blackadder	b l æ k æ ɚ
 blackamoor	b l æ k ə m ɔː
 blackamoor	b l æ k ə m ɔː ɹ
 blackamoor	b l æ k ə m ʊ ə
@@ -7762,7 +7823,7 @@ blaeberry	b l e ɪ b ə ɹ i
 blaenrhondda	b l a ɪ n r ɒ n ð ə
 blag	b l æ ɡ
 blaggard	b l æ ɡ ə d
-blagger	b l æ ɡ ə ɹ
+blagger	b l æ ɡ ɚ
 blagoveshchensk	b l ɑ ɡ ə v ɛ ʃ t͡ʃ ɛ n s k
 blah	b l a
 blah	b l ɑː
@@ -7770,7 +7831,7 @@ blahaj	b l o ʊ h a ɪ
 blahaj	b l ɑː h ɑː ʒ
 blain	b l e ɪ n
 blaine	b l e ɪ n
-blair	b l ɛ ə ɹ
+blair	b l ɛ ɚ
 blaisdon	b l e ɪ z d ə n
 blake	b l e ɪ k
 blamable	b l e ɪ m ə b ə l
@@ -7791,8 +7852,8 @@ blanchability	b l æ n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l æ n ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n ʃ ə b ɪ l ɪ t i
-blancher	b l æ n t͡ʃ ə ɹ
-blancher	b l ɑː n t͡ʃ ə ɹ
+blancher	b l æ n t͡ʃ ɚ
+blancher	b l ɑː n t͡ʃ ɚ
 blancmange	b l ə m ɒ n d͡ʒ
 blanco	b l æ ŋ k ə ʊ
 bland	b l æ n d
@@ -7806,7 +7867,7 @@ blankie	b l æ ŋ k i
 blankley	b l æ ŋ k l i
 blanquette	b l ɒ̃ k ɛ t
 blaow	b l a ʊ
-blare	b l ɛ ə ɹ
+blare	b l ɛ ɚ
 blarney	b l ɑː n i
 blasian	b l e ɪ ʒ ə n
 blaspheme	b l æ s f iː m
@@ -7834,12 +7895,12 @@ blazer	b l e ɪ z ə
 blazes	b l e ɪ z ɪ z
 blazing	b l e ɪ z ɪ ŋ
 blazon	b l e ɪ z ə n
-blazoner	b l e ɪ z ə n ə ɹ
+blazoner	b l e ɪ z ə n ɚ
 blazoning	b l e ɪ z ə n ɪ ŋ
 blazonry	b l e ɪ z ə n ɹ i
 bleach	b l iː t͡ʃ
 bleached	b l iː t͡ʃ t
-bleacher	b l iː t͡ʃ ə ɹ
+bleacher	b l iː t͡ʃ ɚ
 bleachfield	b l iː t ʃ f ɪ ə l d
 bleaching	b l iː t͡ʃ ɪ ŋ
 blead	b l iː d
@@ -7884,8 +7945,8 @@ blessedness	b l ɛ s ɪ d n ɪ s
 blesses	b l ɛ s ɪ z
 blessing	b l ɛ s ɪ ŋ
 blessings	b l ɛ s ɪ ŋ z
-blessure	b l ɛ s j ʊ ə ɹ
-blessure	b l ɛ ʃ ə ɹ
+blessure	b l ɛ s j ʊ ɚ
+blessure	b l ɛ ʃ ɚ
 blessèd	b l ɛ s ə d
 blest	b l ɛ s t
 blet	b l ɛ t
@@ -7920,7 +7981,7 @@ blindside	b l a ɪ n d s a ɪ d
 bling	b l ɪ ŋ
 blink	b l ɪ ŋ k
 blinkard	b l ɪ ŋ k ə ɹ d
-blinker	b l ɪ ŋ k ə ɹ
+blinker	b l ɪ ŋ k ɚ
 blinks	b l ɪ ŋ k s
 blinky	b l ɪ ŋ k i
 blip	b l ɪ p
@@ -7936,7 +7997,7 @@ blithedale	b l a ɪ θ d e ɪ l
 blitheful	b l a ɪ ð f ʊ l
 blitheful	b l a ɪ θ f ʊ l
 blithely	b l a ɪ ð l i
-blither	b l a ɪ ð ə ɹ
+blither	b l a ɪ ð ɚ
 blither	b l ɪ ð ə ɹ
 blitz	b l ɪ t s
 blitzed	b l ɪ t s t
@@ -8222,7 +8283,7 @@ boiling	b ɔ ɪ l ɪ ŋ
 boilings	b ɔ ɪ l ɪ ŋ z
 boils	b ɔ ɪ l z
 boinc	b ɔ ɪ ŋ k
-boing	b o ɪ ŋ
+boing	b ɔ ɪ ŋ
 boingy	b ɔ ɪ ŋ ɡ iː
 boink	b ɔ ɪ ŋ k
 boisterous	b ɔ ɪ s t ə ɹ ə s
@@ -8268,7 +8329,6 @@ bolshevist	b ɒ l ʃ ə v ɪ s t
 bolshie	b ɒ l ʃ i
 bolster	b ə ʊ l s t ə
 bolt	b ɒ l t
-bolt	b ɔ ʊ l t
 bolt	b ə ʊ l t
 bolted	b ə ʊ l t ɪ d
 bolth	b o ʊ ɫ θ
@@ -8300,6 +8360,7 @@ bonanza	b ə n æ n z ə
 bonapartism	b ə ʊ n ə p ɑː t ɪ z ə m
 bonavista	b o ʊ n ə v ɪ s t ə
 bonbright	b ɔ n b ɹ a ɪ t
+bonce	b ɒ n s
 bond	b ɒ n d
 bondage	b ɒ n d ɪ d͡ʒ
 bondi	b ɒ n d a ɪ
@@ -8359,6 +8420,7 @@ bookings	b ʊ k ɪ ŋ z
 bookish	b ʊ k ɪ ʃ
 bookkeeper	b ʊ k k iː p ə ɹ
 bookkeeper	b ʌ ʔ k iː p ə ɹ
+bookkeeping	b ʊ k k iː p ɪ ŋ
 booklegging	b ʊ k l ɛ ɡ ɪ ŋ
 booklet	b ʊ k l ə t
 booklist	b ʊ k l ɪ s t
@@ -8414,6 +8476,7 @@ booths	b uː ð z
 booths	b uː θ s
 bootikin	b uː t ɪ k ɪ n
 bootle	b uː t ə l
+bootleggery	b uː t l ɛ ɡ ə ɹ i
 boots	b uː t s
 bootstrap	b uː t s t ɹ æ p
 booty	b uː t i
@@ -8465,6 +8528,7 @@ borne	b ɔː n
 borneo	b ɔː n i ə ʊ
 bornholm	b ɔ ɹ n h ə ʊ m
 borning	b ɔː n ɪ ŋ
+borogove	b ɒ ɹ ə ʊ ɡ ə ʊ v
 boron	b ɔː ɹ ɒ n
 borough	b ʌ ɹ ə
 borrel	b ɒ ɹ ə l
@@ -8487,6 +8551,7 @@ bosanquet	b o ʊ z ə n k ɪ t
 boscage	b ɒ s k ɪ d ʒ
 bose	b ə ʊ s
 bose	b ə ʊ z
+bosentan	b ə ʊ s ɛ n t æ n
 bosh	b ɒ ʃ
 bosk	b ɒ s k
 bosket	b ɒ s k ɪ t
@@ -8505,6 +8570,7 @@ bosque	b ɒ s k e ɪ
 bosques	b ɒ s k e ɪ z
 bosques	b ɒ s k s
 boss	b ɒ s
+bossale	b o ʊ s æ l
 bossman	b ɒ s m æ n
 bosspot	b ɒ s p ɒ t
 bossy	b ɒ s i
@@ -8540,6 +8606,8 @@ bottom	b ɒ t ə m
 bottomless	b ɒ t ə m l ə s
 bottoms	b ɒ t ə m s
 botulism	b ɒ t j ʊ l ɪ z ə m
+botw	b ɑː t w ə
+botw	b ɔː t w ə
 botwood	b ɒ t w ʊ d
 bouche	b uː ʃ
 bouclé	b uː k l e ɪ
@@ -8552,9 +8620,12 @@ boudoir	b uː d w ɑː
 bouffant	b uː f ɑ̃
 bougainville	b ə ʊ ɡ ə n v ɪ l
 bougainvillea	b uː ɡ ə n v ɪ l ɪ ə
+bougar	b uː ɡ ɑː
 bougar	b uː ɡ ə
-bougar	k uː ɡ ɑː
 bouge	b uː d͡ʒ
+bouget	b uː d ʒ ɛ t
+bouget	b uː d ʒ ɪ t
+bouget	b uː ɡ ɛ t
 bough	b a ʊ
 boughs	b a ʊ z
 bought	b ɔː t
@@ -8573,6 +8644,8 @@ boulder	b ə ʊ l d ə ɹ
 boule	b uː l
 bouleutic	b ə l j uː t ɪ k
 boulevard	b uː l ə v ɑː d
+boulevardier	b ʊ l ə v ɑ ɹ d j e ɪ
+boulevardier	b ʊ l ə v ɑ ɹ d ɪ ɹ
 boulogne	b ə l ɔ ɪ n
 boulogne	b ʊ l ɔ ɪ n
 boulton	b o ʊ l t ə n
@@ -8824,6 +8897,7 @@ branle	b ɹ ɔː l
 branny	b ɹ æ n i
 brans	b ɹ æ n z
 brant	b ɹ æ n t
+branta	b r æ n t ə
 brantle	b ɹ æ n t ə l
 brash	b ɹ æ ʃ
 brass	b ɹ æ s
@@ -8886,6 +8960,7 @@ breachings	b ɹ iː t͡ʃ ɪ ŋ z
 bread	b ɹ ɛ d
 breadalbane	b r ə d ɔː l b æ n
 breadbasket	b ɹ ɛ d b ɑː s k ɪ t
+breadbox	b ɹ ɛ d b ɒ k s
 breadfruit	b ɹ e d f ɹ uː t
 breadstuff	b ɹ ɛ d s t ʌ f
 breadth	b ɹ ɛ d θ
@@ -9346,6 +9421,7 @@ bruv	b ɹ ʌ v
 bruvver	b ɹ ʌ v ə ɹ
 brux	b ɹ ʌ k s
 bruxism	b ɹ ʌ k s ɪ z ə m
+bruz	b ɹ ʌ z
 bryan	b ɹ a ɪ ə n
 bryanite	b ɹ a ɪ ə n a ɪ t
 bryant	b ɹ a ɪ ə n t
@@ -9383,9 +9459,9 @@ buccal	b ʌ k ə l
 buccally	b ʌ k ə l i
 buccaneer	b ʌ k ə n ɪ ə ɹ
 buccinator	b ʌ k s ɪ n e ɪ t ə
-buccoapical	b ʌ k o ʊ e ɪ p ɨ k l̩
-buccocervical	b ʌ k o ʊ s ɝː v ɨ k l̩
-buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɨ v l̩
+buccoapical	b ʌ k o ʊ e ɪ p ɪ k l̩
+buccocervical	b ʌ k o ʊ s ɝː v ɪ k l̩
+buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɪ v l̩
 buccolabial	b ʌ k o ʊ l e ɪ b i l̩
 buccolingual	b ʌ k o ʊ l ɪ ŋ ɡ w ə l
 buccopalatal	b ʌ k o ʊ p æ l ə t ə l
@@ -9707,6 +9783,7 @@ burp	b ɜː p
 burra	b ʌ ɹ ə
 burrampooter	b ʌ r ə m p uː t ə r
 burrata	b ʊ ɹ ɑː t ə
+burrel	b ʌ ɹ ə l
 burrito	b ə ɹ iː t ə ʊ
 burrito	b ʊ r iː t ə ʊ
 burrovian	b ə ɹ ə ʊ v ɪ ə n
@@ -9776,7 +9853,7 @@ busulfan	b j uː s ʌ l f æ n
 busy	b ɪ z i
 busybodyish	b ɪ z i b ɒ d i ɪ ʃ
 busybodyism	b ɪ z i b ɒ d i ɪ z m̩
-busyness	b ɪ z ɪ n ə s
+busyness	b ɪ z ɪ n ɪ s
 but	b ʌ t
 but's	b ʌ t s
 butane	b j uː t e ɪ n
@@ -9926,6 +10003,9 @@ cacahuatepec	k ɑː k ə w ɑː t ɛ p ɛ k
 cacao	k ə k e ɪ̯ ə ʊ̯
 cacao	k ə k ɑː ə ʊ̯
 cacciatore	k æ t ʃ ə t ɔː ɹ i
+cachaemia	k æ k iː m i ə
+cachaemic	k æ k iː m ɪ k
+cachaemic	k æ k ɛ m ɪ k
 cachalot	k a ʃ ə l ɒ t
 cachalot	k a ʃ ə l ə ʊ
 cachaça	k ə ʃ ɑː s ə
@@ -9953,6 +10033,7 @@ cacogamy	k ə k ɒ ɡ ə m i
 cacogenic	k æ k ə d͡ʒ ɛ n ɪ k
 cacography	k a k ɒ ɡ ɹ ə f i
 cacology	k ə k ɒ l ə d͡ʒ i
+cacophonic	k ə k ɒ f ə n ɪ k
 cacophonous	k ə k ɒ f ə n ə s
 cacophony	k ə k ɒ f ə n i
 cacothymia	k a k ə ʊ θ ʌ ɪ m ɪ ə
@@ -10035,6 +10116,7 @@ cagliari	k æ l j ə ɹ i
 cagliari	k ɑː l j ə ɹ i
 cagot	k ə ɡ ə ʊ
 cagoule	k ə ɡ uː l
+cahier	k a ɪ j e ɪ
 cahoot	k ə h uː t
 cahoots	k ə h uː t s
 caib	k e ɪ b
@@ -10133,6 +10215,7 @@ cali	k æ l i
 caliban	k æ l ɪ b æ n
 caliber	k æ l ɪ b ə ɹ
 calibrate	k æ l ɪ b ɹ e ɪ t
+calibre	k æ l ɪ b ə ɹ
 caliche	k ə l i t͡ʃ i
 calico	k æ l ɪ k ə ʊ
 california	k æ l ɪ f ɔː n i ə
@@ -10231,6 +10314,7 @@ cama	k ɑː m ə
 camail	k æ m e ɪ l
 camail	k ə m e ɪ l
 camaldolese	k ə m ɑ l d ə l i z
+camaraderie	k æ m ə ɹ æ d ə ɹ i
 camaraderie	k æ m ə ɹ ɑː d ə ɹ i
 camas	k ɑː m ə z
 camber	k æ m b ə
@@ -10352,6 +10436,7 @@ candelabrum	k æ n d ɪ l e ɪ b ɹ ə m
 candelabrum	k æ n d ɪ l ɑː b ɹ ə m
 candian	k æ n d ɪ ə n
 candid	k æ n d ɪ d
+candidacy	k æ n d ɪ d ə s i
 candidate	k æ n d ɪ d e ɪ t
 candidate	k æ n d ɪ d ə t
 candidature	k æ n d ɪ d ə t j ʊ ə ɹ
@@ -10587,6 +10672,7 @@ caracole	k æ ɹ ə k ə ʊ l
 carafe	k ə ɹ æ f
 caragana	k æ ɹ ə ɡ ɑː n ə
 caragana	k ɑː ɹ ə ɡ ɑː n ə
+carambola	k æ ɹ ə m b ə ʊ l ə
 caramel	k æ ɹ ə m ə l
 caramel	k æ ɹ ə m ɛ l
 caramelize	k a r ə m ə l ʌ ɪ z
@@ -10598,7 +10684,9 @@ carat	k æ ɹ ə t
 caravaggesque	k æ ɹ ə v æ d ʒ ɛ s k
 caravaggio	k æ ɹ ə v æ d ʒ i ə ʊ
 caravan	k æ ɹ ə v æ n
-caravanserai	k a ɹ ə v a n s ə ɹ ʌ ɪ
+caravansary	k æ ɹ ə v æ n s ə ɹ i
+caravanserai	k æ ɹ ə v æ n s ə ɹ a ɪ
+caravanserial	k æ ɹ ə v æ n s ə ɹ i ə l
 caravel	k æ ɹ ə v ɛ l
 caraway	k æ ɹ ə w e ɪ
 carb	k ɑː b
@@ -10759,7 +10847,7 @@ carn	k ɑː n
 carnaby	k ɑː ɹ n ə b i
 carnage	k ɑː n ɪ d ʒ
 carnaroli	k ɑː n ə ɹ ə ʊ l ɪ
-carnatic	k ɑ ɹ n æ t ɨ k
+carnatic	k ɑ ɹ n æ t ɪ k
 carnation	k ɑː n e ɪ ʃ ə n
 carnaval	k ɑ ɹ n ə v ɑ l
 carnegie	k ɑː n ɛ ɡ i
@@ -11057,6 +11145,8 @@ catecholamine	k a t ə k ɒ l ə m iː n
 catecholamine	k a t ə k ə ʊ l ə m iː n
 catechu	k æ t ɪ t͡ʃ uː
 catechumen	k æ t ɪ k j uː m ɛ n
+catechumenate	k æ t ɪ k j uː m ə n e ɪ t
+catechumenate	k æ t ɪ k j uː m ə n ə t
 categorially	k æ t ə ɡ ɒ ɹ ɪ ə l i
 categorically	k æ t ə ɡ ɒ ɹ ɪ k ə l i
 categories	k æ t ɪ ɡ ə ɹ i z
@@ -11074,6 +11164,7 @@ caterham	k e ɪ t ə ɹ ə m
 catering	k e ɪ t ə ɹ ɪ ŋ
 caterpillar	k æ t ə p ɪ l ə
 caterwaul	k æ t ə w ɔː l
+caterwauling	k æ t ə w ɔː l ɪ ŋ
 catesby	k e ɪ t s b i
 catfighting	k æ t f a ɪ t ɪ ŋ
 catford	k æ t f ə d
@@ -11115,6 +11206,10 @@ catloaf	k æ t l ə ʊ f
 catmint	k æ t m ɪ n t
 catnip	k a t n ɪ p
 cato	k e ɪ t ə ʊ
+catoblepas	k æ t o ʊ b l iː p ə s
+catoblepas	k æ t o ʊ b l ɛ p ə s
+catoblepas	k æ t o ʊ b l ɪ p ə s
+catoblepas	k ə t ɒ b l ɪ p ə s
 catoecic	k ə t iː s ɪ k
 catoptric	k a t ɒ p t ɹ ɪ k
 catridge	k a t ɹ ɪ d͡ʒ
@@ -11154,6 +11249,8 @@ caulis	k ɔː l ɪ s
 caulk	k ɔː k
 cauma	k a ʊ m ə
 causal	k ɔː z ə l
+causality	k ɔː z æ l ɪ t ɪ
+causation	k ɔː z e ɪ ʃ ə n
 causative	k ɔː z ə t ɪ v
 causator	k ɔː z e ɪ t ə ɹ
 cause	k ɔː z
@@ -11314,7 +11411,6 @@ cells	s ɛ l z
 celluloid	s ɛ l j ə l ɔ ɪ d
 cellulose	s ɛ l j ʊ l ə ʊ z
 celly	s ɛ l i
-celsius	s ɛ l s i ə s
 celt	k ɛ l t
 celt	s ɛ l t
 celta	s ɛ l t ə
@@ -11433,6 +11529,7 @@ cephalon	s e f ə l ɒ n
 cephalon	s e f ə l ə n
 cephalopod	s ɛ f a l a p ɒ d
 cephalosporin	k ɛ f ə l ə ʊ s p ɔ ə ɹ ɪ n
+cephas	s i f ə s
 cepheus	s iː f i ə s
 cepheus	s iː f j uː s
 cepstrum	k ɛ p s t ɹ ə m
@@ -11473,14 +11570,15 @@ ceremonies	s ɛ ɹ ɪ m ə n i z
 ceremony	s ɛ ɹ ɪ m ə n i
 cereology	s ɪ ə ɹ ɪ ɒ l ə d ʒ i
 cereous	s ɪ ə ɹ i ə s
-cererian	s ɨ ɹ ɪ ə ɹ i ə n
+cererian	s ə ɹ ɪ ə ɹ ɪ ə n
 ceres	s ɪ ə ɹ iː z
-ceresian	s ɨ ɹ iː z i ə n
+ceresian	s ə ɹ iː z i ə n
 cerise	s ə ɹ iː s
 cerise	s ə ɹ iː z
 cerium	s ɪ ə ɹ i ə m
 cernuous	s ɜː ɹ n j u ə s
 cerrial	s ɛ ɹ i ə l
+cerrigceinwen	k ɛ r ɪ ɡ k ɛ i n ʊ ɛ n
 certain	s ɜː t n̩
 certainly	s ɜː t n̩ l i
 certainty	s ɜː t n̩ t i
@@ -11500,7 +11598,7 @@ cervantes	s ɛ ɹ v ɑː n t e ɪ z
 cervelliere	s ɛ ɹ v ə l j ɛ ə ɹ
 cervical	s ɜː v a ɪ k l̩
 cervical	s ɜː v ɪ k l̩
-cervices	s ɝ v ɨ s iː z
+cervices	s ɝ v ɪ s iː z
 cervidae	s ə ɹ v ə d i
 cervine	s əː v ʌ ɪ n
 cervix	s ɜː v ɪ k s
@@ -11599,6 +11697,7 @@ challenged	t͡ʃ æ l ə n d͡ʒ d
 challenging	t͡ʃ æ l ə n d͡ʒ ɪ ŋ
 challenging	t͡ʃ æ l ɪ n d͡ʒ ɪ ŋ
 challis	ʃ æ l i
+challoch	t ʃ æ l ə x
 chalmers	t͡ʃ ɑː m ə z
 chalmette	ʃ æ l m ɛ t
 chalmette	ʃ ɛ l m ɛ t
@@ -11732,7 +11831,7 @@ chaplaincy	t ʃ æ p l ɪ n s i
 chaplet	t͡ʃ æ p l ə t
 chaplet	t͡ʃ æ p l ɪ t
 chapleted	t͡ʃ æ p l ə t ə d
-chapleted	t͡ʃ æ p l ɨ ɾ ɨ d
+chapleted	t͡ʃ æ p l ɪ ɾ ɨ d
 chapman	t͡ʃ æ p m ə n
 chappe	ʃ æ p
 chapped	t͡ʃ æ p t
@@ -11745,6 +11844,7 @@ chaptalization	ʃ æ p t ə l a ɪ z e ɪ ʃ ə n
 chapter	t͡ʃ æ p t ə
 chapters	t͡ʃ æ p t ə z
 chaqu	t͡ʃ ɑː t͡ʃ uː
+char	k æ ɹ
 char	k ɑː
 char	k ɛ ə
 char	t͡ʃ ɑː
@@ -11769,6 +11869,7 @@ chardonnay	ʃ ɑː ɹ d ə n e ɪ
 chare	t͡ʃ ɛ ə
 charette	ʃ ə ɹ ɛ t
 charge	t͡ʃ ɑː d͡ʒ
+charged	t͡ʃ ɑː d͡ʒ d
 chargeous	t͡ʃ ɑː ɹ d͡ʒ ə s
 charger	t ʃ ɑː d ʒ ə
 charges	t͡ʃ ɑː d͡ʒ ɪ z
@@ -11963,7 +12064,7 @@ cheese	t͡ʃ iː z
 cheesecake	t͡ʃ iː z k e ɪ k
 cheesed	t͡ʃ iː z d
 cheesehead	t͡ʃ iː z h ɛ d
-cheeselet	t͡ʃ iː z l ə t
+cheeselet	t͡ʃ iː z l ɪ t
 cheeser	t͡ʃ iː z ə
 cheeses	t͡ʃ iː z ɪ z
 cheesetastic	t͡ʃ iː z t æ s t ɪ k
@@ -12201,7 +12302,6 @@ chilaquiles	t͡ʃ i l ə k i l e ɪ s
 chilblain	t͡ʃ ɪ l b l e ɪ n
 chilcotin	t͡ʃ ɪ l k o ʊ t ɪ n
 child	t͡ʃ a ɪ l d
-child	t͡ʃ a ɪ ə l d
 childbed	t͡ʃ a ɪ l d b ɛ d
 childe	t͡ʃ a ɪ l d
 childer	t͡ʃ ɪ l d ə r
@@ -12241,6 +12341,7 @@ chilver	t͡ʃ ɪ l v ə ɹ
 chimbley	t͡ʃ ɪ m b l i
 chime	t ʃ a ɪ m
 chimed	t͡ʃ a ɪ m d
+chimenea	t ʃ ɪ m ə n e ɪ ə
 chimera	k ɪ m ɪ ə ɹ ə
 chimera	k ʌ ɪ m ɪ ə ɹ ə
 chimeric	k a ɪ m ɛ ɹ ɪ k
@@ -12281,6 +12382,8 @@ chinned	t͡ʃ ɪ n d
 chinning	t͡ʃ ɪ n ɪ ŋ
 chinny	t͡ʃ ɪ n i
 chinoiserie	ʃ iː n w ɑː z ə ɹ iː
+chinone	k a ɪ n ə ʊ n
+chinone	k ɪ n ə ʊ n
 chinook	t͡ʃ ɪ n uː k
 chinook	ʃ ɪ n ʊ k
 chinquapin	t͡ʃ ɪ n k ə p ɪ n
@@ -12294,6 +12397,7 @@ chip	t͡ʃ ɪ p
 chipewyan	t͡ʃ ɪ p ə w a ɪ ə n
 chipmunk	t͡ʃ ɪ p m ʌ ŋ k
 chipolata	t͡ʃ ɪ p ə l ɑː t ə
+chipotle	t ʃ ɪ p ɒ t l e ɪ
 chipotle	t ʃ ɪ p ə ʊ t l e ɪ
 chipped	t͡ʃ ɪ p t
 chippendale	t͡ʃ ɪ p n̩ d e ɪ l
@@ -12331,6 +12435,8 @@ chirurgy	k ɪ ɹ ɜː ɹ d͡ʒ i
 chisel	t͡ʃ ɪ z ə l
 chiseled	t͡ʃ ɪ z ə l d
 chislehurst	t͡ʃ ɪ z ə l h ɜː s t
+chislic	t͡ʃ ɪ s l ɪ k
+chislic	t͡ʃ ɪ z l ɪ k
 chiswick	t͡ʃ ɪ z ɪ k
 chit	t͡ʃ ɪ t
 chita	t͡ʃ ɪ t ɑː
@@ -12407,7 +12513,7 @@ choctaw	t͡ʃ ɒ k t ɔː
 chode	t ʃ ə ʊ d
 choenix	k iː n ɪ k s
 choffer	t͡ʃ ɔː f ə
-choi	t ʃʰ ɔ ɪ
+choi	t ʃ ɔ ɪ
 choice	t͡ʃ ɔ ɪ s
 choiceful	t͡ʃ ɔ ɪ s f ə l
 choices	t͡ʃ ɔ ɪ s ɪ z
@@ -12479,6 +12585,7 @@ choreograph	k ɒ ɹ i ə ɡ ɹ æ f
 choreograph	k ɒ ɹ i ə ɡ ɹ ɑː f
 choreography	k ɔ ɹ i ɒ ɡ ɹ ə f i
 chori	k ɔː ɹ a ɪ
+choric	k ɔː ɹ ɪ k
 chorion	k ɔ ɹ i ɑ n
 chorister	k ɒ ɹ ɪ s t ə ɹ
 chorizo	t͡ʃ ɒ ɹ iː s ə ʊ
@@ -12490,7 +12597,7 @@ choroid	k ɒ ɹ ɔ ɪ d
 choroid	k ɔː ɹ ɔ ɪ d
 chorus	k ɔː ɹ a ɪ
 chorus	k ɔː ɹ ə s
-chose	t ʃ ə ʊ z
+chose	t͡ʃ ə ʊ z
 chosen	t͡ʃ ə ʊ z ə n
 choss	t͡ʃ ɒ s
 chotki	t͡ʃ ɒ t k i
@@ -12578,11 +12685,13 @@ chrysolite	k ɹ ɪ s ə l a ɪ t
 chrysopoeia	k ɹ ɪ s ə p iː ə
 chrysopoeian	k ɹ ɪ s ə p iː ə n
 chrysostom	k ɹ ɪ s ə s t ə m
+chthamaloid	θ æ m ə l ɔ ɪ d
 chthonian	k θ ə ʊ n ɪ ə n
 chthonian	θ ə ʊ n ɪ ə n
 chthonic	k θ ɒ n ɪ k
 chu	t ʃ u
 chub	t͡ʃ ʌ b
+chubasco	t ʃ uː b ɑː s k ə ʊ
 chubby	t͡ʃ ʌ b i
 chubs	t͡ʃ ʌ b z
 chuchotage	ʃ u ʃ ə ʊ t ɑː ʒ
@@ -12650,6 +12759,7 @@ churl	t ʃ ɜː l
 churlish	t ʃ ɜː l ɪ ʃ
 churly	t͡ʃ ɜː ɹ l i
 churn	t ʃ ɜː n
+churnalism	t ʃ əː n ə l ɪ z ə m
 churrasco	t͡ʃ ʊ ɹ æ s k ə ʊ
 churrasco	t͡ʃ ʊ ɹ ɑː s k ə ʊ
 churro	t ʃ ʊ ɹ ə ʊ
@@ -12741,8 +12851,10 @@ cinching	s ɪ n t͡ʃ ɪ ŋ
 cinchona	s ɪ ŋ k ə ʊ n ə
 cinchophen	s ɪ ŋ k ə f ɛ n
 cinchy	s ɪ n t͡ʃ i
-cincinnati	s ɪ n s ɨ n æ t i
-cincinnati	s ɪ n s ɨ n æ t ə
+cincinnati	s ɪ n s ɪ n æ t i
+cincinnati	s ɪ n s ɪ n æ t ə
+cincinnatus	s ɪ n s ɪ n e ɪ t ə s
+cincinnatus	s ɪ n s ɪ n ɑː t ə s
 cincture	s ɪ ŋ k t͡ʃ ə ɹ
 cinder	s ɪ n d ə ɹ
 cinderella	s ɪ n d ə ɹ ɛ l ə
@@ -12760,7 +12872,8 @@ cingulum	s ɪ ŋ ɡ j ə l ə m
 cinnabar	s ɪ n ə b ɑ ɹ
 cinnabar	s ɪ n ə b ɑː ɹ
 cinnamon	s ɪ n ə m ə n
-cinquain	s ɪ n k e n
+cinquain	s æ ŋ k e ɪ n
+cinquain	s ɪ ŋ k e ɪ n
 cinque	s æ ŋ k
 cinque	s ɪ ŋ k
 cinquecentist	t ʃ i ŋ k w ɛ t ʃ ɛ n t ɪ s t
@@ -12797,7 +12910,7 @@ circuline	s ɜː ɹ k j ʊ l a ɪ n
 circumambulate	s ɝ k ə m æ m b j u l e ɪ t
 circumambulation	s ɝ k ə m æ m b j u l e ɪ ʃ ə n
 circumaural	s ɝ k ʌ m a ɹ ʌ l
-circumbendibus	s ɝ k m̩ b ɛ n d ɨ b ə s
+circumbendibus	s ɝ k m̩ b ɛ n d ɪ b ə s
 circumcellion	s ɜː k ə m s ɛ l ɪ ə n
 circumclusion	s ɜː ɹ k ə m k l uː ʒ ə n
 circumference	s ɜː k ʌ m f ɹ ə n s
@@ -13077,12 +13190,14 @@ claymation	k l e ɪ m e ɪ ʃ ə n
 claymore	k l e ɪ m ɔː ɹ
 clays	k l e ɪ z
 clayton	k l e ɪ t ə n
+clazosentan	k l e ɪ z ə ʊ s ɛ n t æ n
 clean	k l iː n
 cleaned	k l iː n d
 cleaner	k l iː n ə
 cleaning	k l iː n ɪ ŋ
 cleanings	k l iː n ɪ ŋ z
 cleanliness	k l ɛ n l i n ə s
+cleanliness	k l ɛ n l i n ɪ s
 cleanly	k l iː n l i
 cleanly	k l ɛ n l i
 cleanness	k l iː n n ə s
@@ -13122,7 +13237,7 @@ clementine	k l ɛ m ə n t iː n
 clemizole	k l ɛ m ɪ z o ʊ l
 clen	k l ɛ n
 clench	k l ɛ n t͡ʃ
-cleopatra	k l i o ʊ p æ t ɹ ə
+cleopatra	k l iː o ʊ p æ t ɹ ə
 clepe	k l iː p
 clepsydra	k l ɛ p s ɪ d ɹ ə
 clept	k l ɛ p t
@@ -13272,6 +13387,7 @@ cloom	k l uː m
 clooney	k l uː n i
 cloop	k l uː p
 clop	k l ɒ p
+clopen	k l ə ʊ p ə n
 clopidogrel	k l ə ʊ p ɪ d ə ɡ ɹ ɛ l
 cloque	k l ɒ k e ɪ
 close	k l ə ʊ s
@@ -13280,6 +13396,7 @@ closed	k l ə ʊ z d
 closely	k l ə ʊ s l iː
 closen	k l ə ʊ s ə n
 closeness	k l ə ʊ s n ə s
+closer	k l ə ʊ s ə
 closer	k l ə ʊ z ɚ
 closes	k l ə ʊ s ɪ z
 closes	k l ə ʊ z ɪ z
@@ -13386,8 +13503,8 @@ clutter	k l ʌ t ə ɹ
 clutton	k l ʌ t ə n
 clydach	k l ʌ d ə x
 clyde	k l a ɪ d
-clymene	k l a ɪ m ɨ n i
-clymene	k l ɪ m ɨ n i
+clymene	k l a ɪ m ɪ n i
+clymene	k l ɪ m ɪ n i
 clypei	k l ɪ p ɪ a ɪ
 clypeus	k l ɪ p ɪ ə s
 clyster	k l ɪ s t ə
@@ -13543,7 +13660,7 @@ codical	k ə ʊ d ɪ k ə l
 codicil	k ɒ d ɪ s ɪ l
 codicil	k ə ʊ d ɪ s ɪ l
 codies	k ə ʊ d i z
-codification	k ə ʊ d ɨ f ɪ k e ɪ ʃ ə n
+codification	k ə ʊ d ɪ f ɪ k e ɪ ʃ ə n
 codlet	k ɒ d l ə t
 codling	k ɒ d l ɪ ŋ
 codominant	k ə ʊ d ɒ m ɪ n ə n t
@@ -13573,6 +13690,7 @@ coextensive	k ə ʊ ɪ k s t ɛ n s ɪ v
 coextinct	k o ʊ ɛ k s t ɪ ŋ k t
 coextinct	k o ʊ ɪ k s t ɪ ŋ k t
 cofe	s iː ə v iː
+cofeoffee	k ə ʊ f ɛ f iː
 coffa	k ɔ f ə
 coffee	k ɒ f i
 coffeemaking	k ɒ f i m e ɪ k ɪ ŋ
@@ -13708,7 +13826,8 @@ coliseum	k ɒ l ə s iː ə m
 coll	k ɒ l
 collab	k o ʊ l æ b
 collab	k ə l æ b
-collaborate	k ə l a b ə ɹ e ɪ t
+collaborate	k ə l æ b ə ɹ e ɪ t
+collaborate	k ə l æ b ɹ e ɪ t
 collaboration	k ə l æ b ə ɹ e ɪ ʃ ə n
 collaborative	k ə l a b ə ɹ ə t ɪ v
 collaborator	k ə l æ b ə ɹ e ɪ t ə
@@ -13716,7 +13835,7 @@ collage	k ɒ l ɑː ʒ
 collage	k ə l ɑː ʒ
 collagen	k ɒ l ə d͡ʒ ə n
 collagen	k ɒ l ə d͡ʒ ɪ n
-collagenous	k ə l æ d͡ʒ ɨ n ə s
+collagenous	k ə l æ d͡ʒ ɪ n ə s
 collagic	k ə l æ d͡ʒ ɪ k
 collapse	k ə l æ p s
 collar	k ɒ l ə
@@ -13956,7 +14075,7 @@ commentative	k ə m ɛ n t ə t ɪ v
 commented	k ɒ m ɛ n t ɪ d
 comments	k ɒ m ɛ n t s
 commerce	k ɒ m ə s
-commerce	k ɒ m ɜː s
+commerce	k ə m ɜː s
 commercial	k ə m ɜː ʃ ə l
 comminate	k ɒ m ɪ n e ɪ t
 comminute	k ɒ m ɪ n j uː t
@@ -14057,7 +14176,8 @@ compassed	k ʌ m p ə s t
 compassion	k ə m p æ ʃ ə n
 compassionate	k ə m p æ ʃ ə n e ɪ t
 compassionate	k ə m p æ ʃ ə n ə t
-compatibility	k ə m p æ t ɪ b ɪ l ɪ t i
+compatibility	k ə m p æ t ə b ɪ l ɪ t i
+compatible	k ə m p æ t ə b ə l
 compatriot	k ə m p e ɪ t ɹ i ə t
 compatriot	k ə m p æ t ɹ i ə t
 compeer	k ɒ m p ɪ ə ɹ
@@ -14118,6 +14238,7 @@ completely	k ə m p l iː t l i
 completes	k ə m p l iː t s
 completing	k ə m p l iː t ɪ ŋ
 completion	k ə m p l iː ʃ ə n
+completist	k ə m p l iː t ɪ s t
 completory	k ə m p l iː t ə ɹ i
 complex	k ɒ m p l ɛ k s
 complex	k ə m p l ɛ k s
@@ -14266,7 +14387,7 @@ conche	k ɒ n t ʃ
 conches	k ɒ n t͡ʃ ə z
 conches	k ɒ ŋ k
 conchifer	k ɒ ŋ k ɪ f ə ɹ
-conchoidal	k ɒ n k ɔ ɪ ɪ d ə l
+conchoidal	k ɒ ŋ k ɔ ɪ d ə l
 conchology	k ɒ ŋ k ɒ l ə d͡ʒ i
 conchs	k ɒ n t͡ʃ
 conchs	k ɒ ŋ k s
@@ -14310,7 +14431,7 @@ concurrent	k ɒ ŋ k ʌ ɹ ə n t
 concurrent	k ə ŋ k ʌ ɹ ə n t
 concuss	k ɒ n k ʌ s
 concuss	k ə n k ʌ s
-concussion	k ə n k ʌ ʃ n
+concussion	k ə n k ʌ ʃ n̩
 concussion	k ə n k ʌ ʃ ə n
 condemn	k ə n d ɛ m
 condemnable	k ə n d ɛ m n ə b ə l
@@ -14428,7 +14549,7 @@ conflate	k ə n f l e ɪ t
 conflation	k ə n f l e ɪ ʃ ə n
 conflict	k ɒ n f l ɪ k t
 conflict	k ə n f l ɪ k t
-conflicted	k ə n f l ɪ k t ɪ d
+conflicted	k ə n f l ɪ t ɪ d
 conflow	k ə n f l ə ʊ
 confluence	k ɒ n f l u ə n s
 conforaneous	k ɒ n f ə ɹ e ɪ n ɪ ə s
@@ -14503,6 +14624,7 @@ congruous	k ɑ ŋ ɡ ɹ u ə s
 conic	k ɒ n ɪ k
 conical	k ɒ n ɪ k ə l
 conifer	k ɒ n ɪ f ə ɹ
+coniferous	k ə n ɪ f ə ɹ ə s
 conject	k ə n d͡ʒ ɛ k t
 conjecture	k ə n d͡ʒ ɛ k t͡ʃ ə ɹ
 conjoin	k ə n d͡ʒ ɔ ɪ n
@@ -14685,8 +14807,8 @@ consternation	k ɒ n s t ə n e ɪ ʃ ə n
 constipate	k ɒ n s t ɪ p e ɪ t
 constipated	k ɒ n s t ə p e ɪ t ə d
 constipation	k ɒ n s t ɪ p e ɪ ʃ ə n
-constituencies	k ə n s t ɪ t j u ə n s ɨ z
-constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s ɨ z
+constituencies	k ə n s t ɪ t j u ə n s iː z
+constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s iː z
 constituency	k ə n s t ɪ t j u ə n s i
 constituency	k ə n s t ɪ t͡ʃ u ə n s i
 constituent	k ə n s t ɪ t j u ə n t
@@ -15129,6 +15251,7 @@ cor	k ɔː
 coral	k ɒ ɹ ə l
 coranto	k ə ɹ æ n t ə ʊ
 coranto	k ə ɹ ɑː n t ə ʊ
+corb	k ɔː ɹ b
 corbe	k ɔː ɹ b
 corbel	k ɔː b ə l
 corbyn	k ɔː b ɪ n
@@ -15149,6 +15272,7 @@ cordon	k ɔː ɹ d ə n
 cordovan	k ɔː d ə v ə n
 cords	k ɔː d z
 corduroy	k ɔː d ə ɹ ɔ ɪ
+corduroy	k ɔː d ɹ ɔ ɪ
 cordyceps	k ɔː d ɪ s ɛ p s
 core	k ɔː
 corelborin	k ɒ ɹ ə l b ɔː ɹ ɪ n
@@ -15209,6 +15333,7 @@ corollary	k ɒ ɹ ə l ə ɹ i
 corona	k ə ɹ ə ʊ n ə
 coronach	k ɒ ɹ ə n ə k
 coronach	k ɒ ɹ ə n ə x
+coronado	k ɒ ɹ ə n ɑː d ə ʊ
 coronae	k ə ɹ ə ʊ n iː
 coronal	k ɒ ɹ ə n ə l
 coronal	k ə ɹ ə ʊ n ə l
@@ -15217,7 +15342,7 @@ coronas	k ə ɹ ə ʊ n ə s
 coronate	k ɒ ɹ ə n e ɪ t
 coronate	k ɒ ɹ ə n ə t
 coronatide	k ə ɹ ə ʊ n ə t a ɪ d
-coronation	k ɒ ɹ ə n e ɪ ʃ ə n
+coronation	k ɒ ɹ ə n e ɪ ʃ n̩
 coronavirus	k ə ɹ o ʊ n ə v a ɪ ɹ ə s
 coronavirus	k ə ɹ ə ʊ n ə v a ɪ ɹ ə s
 coronel	k ɒ ɹ ə n ə l
@@ -15468,7 +15593,7 @@ countervail	k a ʊ n t ə v e ɪ l
 countervailing	k a ʊ n t ə v e ɪ l ɪ ŋ
 counterview	k a ʊ n t ə ɹ v j uː
 counterweigh	k a ʊ n t ə w e ɪ
-countess	k a ʊ n t ɨ s
+countess	k a ʊ n t ɪ s
 counties	k a ʊ n t i z
 counting	k a ʊ n t ɪ ŋ
 countings	k a ʊ n t ɪ ŋ z
@@ -15550,6 +15675,7 @@ coventry	k ɒ v ə n t ɹ i
 cover	k ʌ v ə
 coverack	k ɒ v ə ɹ ə k
 coverage	k ʌ v ə ɹ ɪ d ʒ
+coverall	k ʌ v ə ɹ ɔː l
 covered	k ʌ v ə ɹ d
 covering	k ʌ v ə ɹ ɪ ŋ
 coverlet	k ʌ v ə ɹ l ɪ t
@@ -15787,6 +15913,7 @@ creasings	k ɹ iː s ɪ ŋ z
 creasy	k ɹ iː s i
 create	k ɹ iː e ɪ t
 created	k ɹ i e ɪ t ɪ d
+creatic	k ɹ iː æ t ɪ k
 creatify	k ɹ i e ɪ t ɪ f a ɪ
 creatine	k ɹ iː ə t iː n
 creating	k ɹ iː e ɪ t ɪ ŋ
@@ -15891,7 +16018,6 @@ cretic	k ɹ iː t ɪ k
 cretin	k ɹ ɛ t ɪ n
 crevasse	k ɹ ə v æ s
 crevice	k ɹ ɛ v ɪ s
-crew	k ɹ u ʊ̯
 crew	k ɹ uː
 crewe	k ɹ u ʊ̯
 crewe	k ɹ uː
@@ -16009,7 +16135,6 @@ criterion	k ɹ ɪ t ɪ ə ɹ i ə n
 criterium	k ɹ a ɪ t ɪ ə ɹ i ə m
 crith	k ɹ ɪ θ
 critic	k ɹ ɪ t ɪ k
-critical	k ɹ ɪ t ə k ə l
 critical	k ɹ ɪ t ɪ k ə l
 critically	k ɹ ɪ t ɪ k l i
 critically	k ɹ ɪ t ɪ k ə l i
@@ -16146,9 +16271,11 @@ crubeen	k ɹ ə b iː n
 crucial	k ɹ uː ʃ ə l
 crucially	k ɹ uː ʃ ə l i
 crucian	k ɹ uː ʃ ə n
+cruciate	k r uː ʃ i ə t
 crucible	k ɹ uː s ɪ b ə l
 cruciferous	k ɹ u s ɪ f ə ɹ ə s
-crucifix	k ɹ uː s ɨ f ɪ k s
+crucifices	k ɹ uː s ɨ f ɪ s iː z
+crucifix	k ɹ uː s ɪ f ɪ k s
 crucifixion	k ɹ uː s ɪ f ɪ k ʃ ə n
 crucify	k ɹ uː s ɪ f a ɪ
 cruck	k ɹ ʌ k
@@ -16195,6 +16322,7 @@ crunchings	k ɹ ʌ n t͡ʃ ɪ ŋ z
 crunchy	k ɹ ʌ n t͡ʃ i
 crunk	k ɹ ʌ ŋ k
 crunkmeister	k ɹ ʌ ŋ k m a ɪ s t ə
+cruor	k ɹ uː ə ɹ
 crup	k ɹ ʌ p
 crupper	k ɹ ʌ p ə
 crural	k ɹ ʊ ə ɹ ə l
@@ -16228,6 +16356,7 @@ cry	k ɹ a ɪ̯
 crybaby	k ɹ a ɪ b e ɪ b i
 crying	k ɹ a ɪ̯ ɪ ŋ
 cryobiotic	k ɹ a ɪ ə ʊ b a ɪ ɒ t ɪ k
+cryonicist	k ɹ a ɪ ɒ n ɪ s ɪ s t
 cryovolcanic	k ɹ ʌ ɪ ə ʊ v ɒ l k a n ɪ k
 crypsis	k ɹ ɪ p s ɪ s
 crypt	k ɹ ɪ p t
@@ -16251,6 +16380,8 @@ crypts	k ɹ ɪ p t s
 crystal	k ɹ ɪ s t ə l
 crystalize	k ɹ ɪ s t ə l a ɪ z
 crystalline	k ɹ ɪ s t ə l a ɪ n
+crystalline	k ɹ ɪ s t ə l iː n
+crystalline	k ɹ ɪ s t ə l ɪ n
 crystallize	k ɹ ɪ s t ə l a ɪ z
 crystals	k ɹ ɪ s t ə l z
 crèche	k ɹ e ɪ ʃ
@@ -16309,10 +16440,12 @@ cud	k ʊ d
 cud	k ʌ d
 cudden	k ʌ d ə n
 cuddle	k ʌ d l̩
+cuddleologist	k ʌ d ʌ l ɒ l ə d͡ʒ ɪ s t
 cuddler	k ʌ d l ə
 cuddler	k ʌ d l̩ ə
 cuddly	k ʌ d l i
 cuddly	k ʌ d l̩ i
+cuddly	k ʌ d ə l i
 cuddy	k ʌ d i
 cudgel	k ʌ d͡ʒ ə l
 cudgerie	k ʌ d ʒ ə ɹ i
@@ -16644,6 +16777,7 @@ cyanotype	s a ɪ æ n ə t a ɪ p
 cyanotype	s a ɪ æ n ə ʊ t a ɪ p
 cyattie	k j æ t i
 cyber	s a ɪ b ə
+cyberbole	s a ɪ b ɜː b ə l i
 cyberdisinhibition	s a ɪ b ə d ɪ s ɪ n h ɪ b ɪ ʃ ə n
 cybernat	s a ɪ b ə n æ t
 cybernetic	s a ɪ b ə ɹ n ɛ t ɪ k
@@ -17189,6 +17323,7 @@ dartmoor	d ɑː t m ɔː ɹ
 dartmouth	d ɑː t m ə θ
 darts	d ɑː t s
 daruma	d ɑː ɹ ʊ m ə
+darusentan	d æ ɹ ə s ɛ n t æ n
 darvel	d ɑː ɹ v ə l
 darwin	d ɑː w ɪ n
 darwinian	d ɑː w ɪ n i ə n
@@ -17253,6 +17388,7 @@ dauntless	d ɔː n t l ə s
 dauphin	d ɔː f ɪ n
 dauphin	d ə ʊ f æ̃
 dauphinoise	d ɔː f ɪ n w ɑː z
+dauphiné	d ə ʊ f ɪ n e ɪ
 daurade	d ɔː ɹ ɑː d
 dauria	d ɑː ʊ ə r ɪ ə
 dauw	d a ʊ
@@ -17381,7 +17517,7 @@ deagglomerate	d iː æ ɡ l ɒ m ə ɹ e ɪ t
 deagglomeration	d iː æ ɡ l ɒ m ə ɹ e ɪ ʃ ə n
 deal	d iː l
 dealate	d i e ɪ l e ɪ t
-dealate	d i e ɪ l ɨ t
+dealate	d i e ɪ l ɪ t
 dealated	d i e ɪ l e ɪ t ə d
 dealbation	d iː æ l b e ɪ ʃ ə n
 dealer	d iː l ə ɹ
@@ -17428,6 +17564,8 @@ dearthy	d ɜː θ i
 dearticulate	d iː ɑː t ɪ k j ə l e ɪ t
 dearworth	d ɪ ə ɹ w ɜː ɹ θ
 deary	d ɪ ə ɹ i
+deas	d e ɪ ə s
+deas	d iː ə s
 deasil	d i s ə l
 deasil	d i z ə l
 deasil	d j ɛ ʃ ə l
@@ -17570,7 +17708,7 @@ debutant	d ɛ b j uː t ə n t
 debutante	d e ɪ b j uː t ɑː n t
 debutante	d ɛ b j uː t ɑː n t
 debuted	d e ɪ b j uː d
-debuted	d ɨ b j uː d
+debuted	d ɪ b j uː d
 debuts	d e ɪ b j uː z
 debuts	d ɛ b j uː z
 debutyration	d iː b j uː t a ɪ ɹ e ɪ ʃ ə n
@@ -17622,7 +17760,7 @@ decan	d i k æ n
 decan	d ɛ k ə n
 decanal	d ɛ k ə n æ l
 decanal	d ɛ k ə n ə l
-decanal	d ɨ k e ɪ n ə l
+decanal	d ɪ k e ɪ n ə l
 decangle	d ɛ k æ ŋ ɡ ə l
 decangular	d ɪ k æ ŋ ɡ j ə l ə ɹ
 decani	d ɪ k e ɪ n a ɪ
@@ -18071,6 +18209,7 @@ decussation	d ɛ k ʌ s e ɪ ʃ ə n
 decussative	d ɪ k ʌ s ə t ɪ v
 dedicant	d ɛ d ɪ k ə n t
 dedicate	d ɛ d ɪ k e ɪ t
+dedicate	d ɛ d ɪ k ɪ t
 dedicated	d ɛ d ɪ k e ɪ t ə d
 dedicatedly	d ɛ d ɪ k e ɪ t ə d l i
 dedicatee	d ɛ d ɪ k ə t iː
@@ -18122,6 +18261,7 @@ deepen	d iː p ə n
 deepener	d iː p ə n ə ɹ
 deeper	d iː p ə
 deepest	d iː p ɪ s t
+deepfake	d i p f e ɪ k
 deeply	d iː p l i
 deepness	d iː p n ə s
 deer	d ɪ ə
@@ -18246,10 +18386,11 @@ defined	d ɪ f ʌ ɪ n d
 definedness	d ɪ f a ɪ n d n ə s
 definement	d ɪ f a ɪ n m ə n t
 definer	d ɪ f a ɪ n ə ɹ
+definiendum	d ɪ f ɪ n i ɛ n d ə m
 definiens	d eː f iː n i eː n s
 definiens	d iː f a ɪ n ɪ ɛː n z
 definiens	d ɪ f ɪ n ɪ ɛ n z
-definite	d ɛ f ɪ n ɪ t
+definite	d ɛ f ɪ n ə t
 definitely	d ɛ f n ɪ t l i
 definitely	d ɛ f ə n ɪ t l i
 definitely	d ɛ f ɪ n ɪ t l i
@@ -18651,7 +18792,7 @@ demideity	d ɛ m iː d e ɪ ɪ t ɪ
 demideity	d ɛ m iː d e ɪ̯ ə t ɪ
 demideity	d ɛ m iː d iː ɪ t ɪ
 demiflat	d ɛ m ɪ f l æ t
-demigod	d ɛ m ɪ ɡ ɒ d
+demigod	d ɛ m i ɡ ɒ d
 demigrate	d iː m a ɪ ɡ ɹ e ɪ t
 demigrate	d ɛ m ɪ ɡ ɹ e ɪ t
 demijohn	d ɛ m ɪ d ʒ ɒ n
@@ -18753,7 +18894,7 @@ demyelinating	d iː m a ɪ j ə l ɪ n e ɪ t ɪ ŋ
 demystify	d iː m ɪ s t ɪ f a ɪ
 den	d ɛ n
 dena'ina	d ə n aː i n ə
-denali	d ɨ n ɑː l i
+denali	d ɪ n ɑː l i
 denar	d e ɪ n ɑː ɹ
 denar	d ɛ n ɑː ɹ
 denarius	d ɪ n ɑː ɹ ɪ ə s
@@ -19267,7 +19408,7 @@ detailed	d ɪ t e ɪ l d
 details	d iː t e ɪ l z
 details	d ɪ t e ɪ l z
 detain	d ɪ t e ɪ n
-detained	d ɨ t e ɪ n d
+detained	d ɪ t e ɪ n d
 detainee	d ɪ t e ɪ n iː
 detect	d ɪ t ɛ k t
 detectable	d ɪ t ɛ k t ə b ə ɫ
@@ -19363,7 +19504,7 @@ developers	d ɪ v ɛ l ə p ə ɹ z
 developing	d ɪ v ɛ l ə p ɪ ŋ
 development	d ɪ v ɛ l ə p m ə n t
 developmentals	d ɪ v ɛ l ə p m ɛ n t ə l z
-developmentation	d ɨ v ɛ l ə p m ə n t e ɪ ʃ ə n
+developmentation	d ɪ v ɛ l ə p m ə n t e ɪ ʃ ə n
 deverbalize	d iː v ɜː b ə l a ɪ z
 devi	d e ɪ v i
 deviance	d iː v ɪ ə n s
@@ -19457,7 +19598,6 @@ dhyana	d j ɑː n ə
 di	d a ɪ
 diabase	d a ɪ ə b e ɪ s
 diabeetus	d a ɪ ə b iː t ə s
-diabetes	d a ɪ ə b eː t ɪ s
 diabetes	d a ɪ ə b iː t iː z
 diabetes	d a ɪ ə b iː t ɪ s
 diabetic	d a ɪ ə b ɛ t ɪ k
@@ -19643,7 +19783,7 @@ diclofenac	d a ɪ k l o ʊ f ə n æ k
 dicrotic	d ʌ ɪ k ɹ ɒ t ɪ k
 dicrotophos	d a ɪ k ɹ ə ʊ t ə f ɒ s
 dictamen	d ɪ k t e ɪ m ə n
-dictamina	d ɪ k t æ m ɨ n ə
+dictamina	d ɪ k t æ m ɪ n ə
 dictaphone	d ɪ k t ə f ə ʊ n
 dictate	d ɪ k t e ɪ t
 dictated	d ɪ k t e ɪ t ɪ d
@@ -19662,6 +19802,8 @@ dicyclic	d a ɪ s a ɪ k l ɪ k
 did	d ɪ d
 didactic	d a ɪ d æ k t ɪ k
 didactic	d ɪ d æ k t ɪ k
+didactician	d a ɪ d ə k t ɪ ʃ ə n
+didactics	d a ɪ d æ k t ɪ k s
 didanosine	d ɪ d a n ə ʊ s iː n
 diddest	d ɪ d ɛ s t
 diddly	d ɪ d ə l i
@@ -19685,6 +19827,7 @@ died	d a ɪ d
 diedre	d ɪ ə d r i
 diegetic	d a ɪ ə d͡ʒ ɛ t ɪ k
 diego	d i e ɪ ɡ o ʊ
+dieguez	d i e ɪ ɡ ɛ z
 diel	d a ɪ ə l
 diel	d i ə l
 dielectric	d a ɪ ə l ɛ k t ɹ ɪ k
@@ -19703,12 +19846,14 @@ diet	d a ɪ ə t
 dietary	d a ɪ ə t ɛ ɹ i
 dietary	d a ɪ ə t ɹ i
 dietetic	d a ɪ ə t ɛ t ɪ k
+dietetician	d a ɪ ə t ɪ t ɪ ʃ ə n
+dietetics	d a ɪ ə t ɛ t ɪ k s
 diethylstilboestrol	d ʌ ɪ iː θ ʌ ɪ l s t ɪ l b iː s t ɹ ɒ l
 diethylstilboestrol	d ʌ ɪ ɛ θ ɪ l s t ɪ l b iː s t ɹ ɒ l
 dietitian	d a ɪ ə t ɪ ʃ ə n
 diff	d ɪ f
 differ	d ɪ f ə
-difference	d ɪ f ɹ ə n s
+difference	d ɪ f ə ɹ ə n s
 differences	d ɪ f ɹ ə n s ɪ z
 different	d ɪ f ə ɹ ə n t
 different	d ɪ f ɹ ə n t
@@ -19754,7 +19899,7 @@ digestible	d a ɪ d ʒ ɛ s t ə b ə ɫ
 digestif	d a ɪ d ʒ ɛ s t ɪ f
 digestif	d iː ʒ ɛ s t iː f
 digestion	d a ɪ d͡ʒ ɛ s t͡ʃ ə n
-digestion	d ɨ d͡ʒ ɛ s t͡ʃ ə n
+digestion	d ɪ d͡ʒ ɛ s t͡ʃ ə n
 digestive	d a ɪ d ʒ ɛ s t ɪ v
 diggens	d ɪ ɡ ɪ n z
 digger	d ɪ ɡ ə
@@ -19937,6 +20082,8 @@ dines	d a ɪ n z
 dinette	d a ɪ n ɛ t
 ding	d ɪ ŋ
 dinge	d ɪ n d͡ʒ
+dinged	d ɪ n d͡ʒ d
+dinged	d ɪ ŋ d
 dinger	d ɪ ŋ ɡ ə ɹ
 dinghy	d ɪ ŋ ɡ i
 dingily	d ɪ n d ʒ ɪ l i
@@ -19968,6 +20115,7 @@ dinocarid	d a ɪ n ə k æ ɹ ɪ d
 dinocarid	d a ɪ n ə k ɛ ə ɹ ɪ d
 dinokaryote	d a ɪ n ə ʊ k æ ɹ i ə ʊ t
 dinomania	d a ɪ n ə ʊ m e ɪ n ɪ ə
+dinorwig	d ɪ n ɔ r w ɪ ɡ
 dinosaur	d a ɪ n ə s ɔː ɹ
 dinosaurian	d ʌ ɪ n ə ʊ s ɔː ɹ ɪ ə n
 dinq	d ɪ ŋ k
@@ -20541,7 +20689,7 @@ disseize	d ɪ s iː z
 disseizin	d ɪ s iː z ɪ n
 dissemblance	d ɪ s ɛ m b l ə n s
 disseminate	d ɪ s ɛ m ɪ n e ɪ t
-dissemination	d ɨ s ɛ m ɨ n e ɪ ʃ ə n
+dissemination	d ɪ s ɛ m ɪ n e ɪ ʃ ə n
 dissension	d ɪ s ɛ n ʃ ə n
 dissensus	d ɪ s ɛ n s ə s
 dissent	d ɪ s ɛ n t
@@ -20715,6 +20863,7 @@ divert	d a ɪ v ɜː t
 diverted	d a ɪ v ɜː t ə d
 diverticulum	d ɑ ɪ v ɜː t ɪ k j ə l ə m
 divertimento	d ɪ v ɜː t ɪ m ɛ n t ə ʊ
+divertisement	d ɪ v ɜː ɹ t ɪ z m ə n t
 divertive	d a ɪ v ɜː ɹ t ɪ v
 dives	d a ɪ v z
 divest	d a ɪ v ɛ s t
@@ -20725,7 +20874,7 @@ divide	d ɪ v a ɪ d
 dividend	d ɪ v ɪ d ɛ n d
 divider	d ɪ v a ɪ d ə ɹ
 dividual	d ɪ v ɪ d͡ʒ u ə l
-divination	d ɪ v ɨ n e ɪ ʃ ə n
+divination	d ɪ v ɪ n e ɪ ʃ ə n
 divinatory	d ɪ v ɪ n ə t ɹ i
 divine	d ɪ v a ɪ n
 diviner	d ɪ v a ɪ n ə ɹ
@@ -20780,6 +20929,7 @@ djokovic	d ʒ ə ʊ k ə v ɪ t ʃ
 dkim	d iː k ɪ m
 dmz	d iː ɛ m z iː
 dmz	d iː ɛ m z ɛ d
+dna	d iː ɛ n e ɪ
 dnieper	d n iː p ə
 dnieper	n iː p ə
 dnipro	d n iː p r ə ʊ
@@ -20876,6 +21026,7 @@ dogma	d ɒ ɡ m ə
 dogman	d ɒ ɡ m ə n
 dogmatic	d ɒ ɡ m a t ɪ k
 dogra	d o ʊ ɡ ɾ ə
+dogs	d ɒ ɡ z
 dogsbody	d ɒ ɡ z b ɒ d ɪ
 dogwatch	d ɒ ɡ w ɒ t͡ʃ
 dogwood	d ɒ ɡ w ʊ d
@@ -20890,7 +21041,9 @@ doink	d ɔ ɪ ŋ k
 doit	d ɔ ɪ t
 dojigger	d uː d͡ʒ ɪ ɡ ə ɹ
 dojo	d ə ʊ d ʒ ə ʊ
+dokkaebi	d o ʊ k e ɪ b i
 dolan	d ə ʊ l ə n
+dolbadarn	d ɔ l b a d aː n
 dolcelatte	d ɒ l t ʃ ə l a t ɪ
 dolcelatte	d ɒ l t ʃ ə l ɑː t e ɪ
 dolcelatte	d ɒ l t ʃ ə l ɑː t ɪ
@@ -20912,6 +21065,7 @@ dollarization	d ɑ l ɝ ɪ z e ɪ̯ ʃ ɪ n
 dollars	d ɒ l ə z
 dollop	d ɒ l ə p
 dolly	d ɒ l i
+dollywood	d ɒ l i w ʊ d
 dolman	d ɒ l m ə n
 dolmen	d ɒ l m ɛ n
 dolomite	d ɒ l ə m a ɪ t
@@ -20932,6 +21086,7 @@ dolt	d ɔ ʊ l t
 dolt	d ə ʊ l t
 dolts	d o ʊ l t s
 dolus	d o ʊ l ə s
+dolwyddelan	d ɔ l w ɪ ð ɛ l a n
 dom	d ɒ m
 domable	d ə ʊ m ə b l̩
 domain	d ə m e ɪ n
@@ -21149,6 +21304,7 @@ doubled	d ʌ b l̩ d
 doublet	d ʌ b l ə t
 doubloon	d ʌ b l uː n
 doubly	d ʌ b l i
+doubly	d ʌ b ə l l i
 doubs	d uː
 doubt	d a ʊ t
 doubted	d a ʊ t ɪ d
@@ -21239,6 +21395,7 @@ dows	d a ʊ z
 dowse	d a ʊ s
 dowse	d a ʊ z
 dowser	d a ʊ z ə
+doxa	d ɒ k s ə
 doxastic	d ɒ k s æ s t ɪ k
 doxepin	d ɒ k s ə p ɪ n
 doxology	d ɒ k s ɒ l ə d ʒ i
@@ -21257,6 +21414,7 @@ drabble	d ɹ æ b ə l
 drachm	d ɹ æ m
 drachma	d ɹ æ k m ə
 drachmae	d ɹ æ k m iː
+drachme	d ɹ æ k m i
 draco	d ɹ e ɪ k ə ʊ
 draconian	d ɹ æ k ə ʊ n i ə n
 draconian	d ɹ ə k ə ʊ n i ə n
@@ -21558,7 +21716,6 @@ druse	d ɹ u z
 drusilla	d ɹ u s ɪ l ə
 druxy	d ɹ ʌ k s i
 dry	d ɹ a ɪ
-dry	d͡ʒ ɹ a ɪ
 dryad	d ɹ a ɪ æ d
 dryad	d ɹ a ɪ ə d
 dryas	d ɹ a ɪ æ s
@@ -21597,7 +21754,7 @@ dubitation	d j uː b ɪ t e ɪ ʃ ə n
 dubitation	d ʒ uː b ɪ t e ɪ ʃ ə n
 dubitative	d j uː b ɪ t ə t ɪ v
 dublin	d ʌ b l ə n
-dublin	d ʌ b l ɨ n
+dublin	d ʌ b l ɪ n
 dubnium	d ʌ b n i ə m
 dubonnet	d j uː b ɒ n e ɪ
 dubplate	d ʌ b p l e ɪ t
@@ -21664,6 +21821,7 @@ dukedom	d j uː k d ə m
 dukedom	d ʒ uː k d ə m
 dukedoms	d j uː k d ə m z
 dukkha	d ʊ k ə
+dulce	d ʌ l s
 dulcet	d ʌ l s ə t
 dulcet	d ʌ l s ɪ t
 dulcify	d ʌ l s ɪ f a ɪ
@@ -22016,6 +22174,7 @@ ears	ɪ ə ɹ z
 earsh	æː ɹ ʃ
 earshot	ɪ ə ʃ ɒ t
 earth	ɜː θ
+earthen	ɜː ɹ ð ə n
 earthen	ɜː ɹ θ ə n
 earthenware	əː θ ə n w ɛː
 earthling	ɜː θ l ɪ ŋ
@@ -22039,9 +22198,7 @@ eases	iː z ɪ z
 easesome	iː z s ʌ m
 easie	iː z i
 easier	iː z i ə
-easily	iː z ə l iː
 easily	iː z ɪ l i
-easily	iː z ɪ l iː
 easiness	iː z ɪ n ə s
 easing	iː z ɪ ŋ
 easings	iː z ɪ ŋ z
@@ -22169,7 +22326,7 @@ ecstatic	ɛ k s t æ t ɪ k
 ecstatica	ɛ k s t æ t ɪ k ə
 ectal	ɛ k t ə l
 ectasia	ɛ k t e ɪ z j ə
-ectasis	ɛ k t ə s ɨ s
+ectasis	ɛ k t ə s ɪ s
 ectomorph	ɛ k t ə ʊ m ɔː f
 ectoparasite	ɛ k t ə ʊ p æ ɹ ə s a ɪ t
 ectoplasm	ɛ k t ə p l æ z ə m
@@ -22250,6 +22407,8 @@ edmundston	ɛ d m ə n d s t ə n
 edo	ɛ d ə ʊ
 edom	i d ə m
 edomite	iː d ə m a ɪ t
+edonentan	ɛ d ə n ɛ n t æ n
+edriophthalmic	ɛ d r ɪ ɒ f θ æ l m ɪ k
 educate	ɛ d j ʊ k e ɪ t
 educate	ɛ d͡ʒ ʊ k e ɪ t
 educated	ɛ d j uː k e ɪ t ɪ d
@@ -22358,6 +22517,7 @@ egging	ɛ ɡ ɪ ŋ
 eggings	ɛ ɡ ɪ ŋ z
 eggless	ɛ ɡ l ə s
 eggnog	ɛ ɡ n ɒ ɡ
+eggplant	ɛ ɡ p l æ n t
 eggs	ɛ ɡ z
 eggshell	ɛ ɡ ʃ ɛ l
 eggy	ɛ ɡ i
@@ -22580,8 +22740,8 @@ elie	ɛ l i
 eliezer	ɛ l i iː z ə ɹ
 eliezer	ɛ l i ɛ z ə ɹ
 eligible	ɛ l ɪ d͡ʒ ə b ə l
-elijah	ɨ l a ɪ d͡ʒ ə
-elijah	ɨ l a ɪ ʒ ə
+elijah	ɪ l a ɪ d͡ʒ ə
+elijah	ɪ l a ɪ ʒ ə
 eliminate	ɪ l ɪ m ɪ n e ɪ t
 elimination	ɪ l ɪ m ɪ n e ɪ ʃ ə n
 eliminatrix	ɪ l ɪ m ɪ n e ɪ t ɹ ɪ k s
@@ -22643,7 +22803,7 @@ elohim	ɛ l o ʊ h ɪ m
 eloign	ɪ l ɔ ɪ n
 eloise	ɛ l ə ʊ iː z
 elon	iː l ɔ n
-elongate	ɪ l ɔ ŋ ɡ e ɪ t
+elongate	ɪ l ɒ ŋ ɡ e ɪ t
 elope	ɛ l ə ʊ p
 elope	ɪ l ə ʊ p
 eloquate	ɛ l ə k w e ɪ t
@@ -22885,6 +23045,7 @@ emphatic	ɪ m f æ t ɪ k
 emphatically	ɛ m f æ t ɪ k l i
 emphysema	ɛ m f ɪ s iː m ə
 empire	ɛ m p a ɪ ə
+empiric	ɪ m p ɪ ɹ ɪ k
 empirical	ɪ m p ɪ ɹ ɪ k ə l
 employ	ɛ m p l ɔ ɪ
 employ	ɪ m p l ɔ ɪ
@@ -23255,6 +23416,7 @@ enrage	ɪ n ɹ e ɪ d͡ʒ
 enraged	ɪ n ɹ e ɪ d͡ʒ d
 enrapture	ɛ n ɹ æ p t͡ʃ ə ɹ
 enrapture	ɪ n ɹ æ p t͡ʃ ə ɹ
+enrasentan	ɛ n ɹ ə s ɛ n t æ n
 enrich	ɪ n ɹ ɪ t͡ʃ
 enrichen	ɛ n ɹ ɪ t͡ʃ ə n
 enrichen	ɪ n ɹ ɪ t͡ʃ ə n
@@ -23264,6 +23426,7 @@ ens	ɛ n z
 ensanguine	ɛ n s æ ŋ ɡ w ə n
 ensanguined	ɛ n s a ŋ ɡ w ɪ n d
 ensconce	ɛ n s k ɒ n s
+enscripturate	ɪ n s k ɹ ɪ p t͡ʃ ə r e ɪ t
 ensear	ɪ n s ɪ ə ɹ
 ensemble	ɒ n s ɒ m b ə l
 ensemble	ɒ̃ n s ɒ̃ m b l ə
@@ -23325,7 +23488,7 @@ enterolith	ɛ n t ə ɹ ə l ɪ θ
 enterolith	ɛ n t ɛ ɹ ə l ɪ θ
 enteropathy	ɛ n t ə ɹ ɒ p ə θ i
 enterothorax	ɛ n t ə ɹ o ʊ θ ɔː ɹ æ k s
-enterprise	ɛ n t ɚ p ɹ a ɪ z
+enterprise	ɛ n t ə p ɹ a ɪ z
 enters	ɛ n t ə z
 entertain	ɛ n t ə t e ɪ n
 entertained	ɛ n t ə t e ɪ n d
@@ -23354,6 +23517,7 @@ entitle	ɛ n t a ɪ t ə l
 entitled	ɪ n t a ɪ t l̩ d
 entitlement	ə n t a ɪ t ə l m ə n t
 entity	e n t ɪ t i
+entomb	ɪ n t uː m
 entombment	ɛ n t uː m m ə n t
 entombment	ɪ n t uː m m ə n t
 entomophagy	ɛ n t ə m ɒ f ə d͡ʒ i
@@ -23368,6 +23532,7 @@ entrail	ɛ n t ɹ ə l
 entrails	ɛ n t ɹ e ɪ l z
 entrails	ɛ n t ɹ ə l z
 entrance	ɛ n t ɹ æ n s
+entrance	ɛ n t ɹ ɑː n s
 entrance	ɛ n t ɹ ə n s
 entranced	ɛ n t ɹ ɑː n s t
 entrances	ɛ n t ɹ æ n s ə z
@@ -23407,21 +23572,19 @@ enunciate	ɪ n ʌ n s i e ɪ t
 enunciation	ɪ n ʌ n s ɪ e ɪ ʃ ə n
 enunciation	ɪ n ʌ n ʃ ɪ e ɪ ʃ ə n
 envelop	ɛ n v ɛ l ə p
-envelope	ɑ̃ v ə l ə ʊ p
 envelope	ɒ n v ə l ə ʊ p
 envelope	ɛ n v ə l ə ʊ p
 envelope	ɛ n v ɛ l ə p
 enveloped	ɪ n v ɛ l ə p t
 envenom	ɪ n v ɛ n ə m
 enviable	ɛ n v i ə b l̩
+envie	ɑː n v iː
 envie	ɛ n v a ɪ
 envie	ɪ n v a ɪ
 envied	ɛ n v i d
 envied	ɪ n v a ɪ d
 envious	ɛ n v iː ə s
 environ	ɪ n v a ɪ ɹ ə n
-environment	ɪ n v a ɪ ɚ n m ə n t
-environment	ɪ n v a ɪ ɹ ə n m ə n t
 environmental	ɪ n v a ɪ ɹ ə n m ɛ n t ə l
 envisage	ɛ n v ɪ z ɪ d͡ʒ
 envisage	ɪ n v ɪ z ɪ d͡ʒ
@@ -23435,7 +23598,7 @@ envy	ɛ n v i
 enweaken	ɛ n w iː k n̩
 enwiden	ɛ n w a ɪ d ə̆ n
 enwisen	ɛ n w a ɪ z ə̆ n
-enyo	ɨ n a ɪ o ʊ
+enyo	ɪ n a ɪ o ʊ
 enzedder	ɛ n z ɛ d ə ɹ
 enzo	ɛ n z o ʊ
 enzo	ɛ n z ə ʊ
@@ -23564,7 +23727,7 @@ epiphysis	ə p ɪ f ɪ s ɪ s
 epiphysis	ɪ p ɪ f ɪ s ɪ s
 epiphyte	ɛ p ɪ f ɑ ɪ t
 epirot	ɪ p ʌ ɪ ɹ ə t
-epirus	ɨ p a ɪ ə ɹ ə s
+epirus	ɪ p a ɪ ə ɹ ə s
 episcopacy	ɪ p ɪ s k ə p ə s i
 episcopal	ə p ɪ s k ə p l̩
 episcopalian	ə p ɪ s k ə p e ɪ l i n̩
@@ -23708,7 +23871,7 @@ eratosthenian	ɛ ɹ æ t ə s θ iː n i ə n
 eratosthenian	ɛ ɹ ə t ə s θ iː n i ə n
 erbium	ɜː b ɪ ə m
 erd	ɜː d
-erdoğan	ɛ ə ɹ d o ʊ ɑː n
+erdoğan	ɛ ə ɹ d ə w æ n
 ere	ɛ ə
 ere	ɛː
 ere	ɪ ə ɹ
@@ -23742,8 +23905,8 @@ erinaceous	ɛ ɹ ə n e ɪ ʃ ə s
 erinaceous	ɛ ɹ ɪ n e ɪ ʃ ə s
 erinyes	ɪ ɹ ɪ n i iː z
 erinys	ɪ ɹ ɪ n ɪ s
-eris	ɛ ɹ ɨ s
-eris	ɪ ə ɹ ɨ s
+eris	ɛ ɹ ɪ s
+eris	ɪ ə ɹ ɪ s
 eriskay	ɛ ɹ ɪ s k e ɪ
 erith	iː ɹ ɪ θ
 eritrea	ɛ ɹ ɪ t ɹ e ɪ ə
@@ -23831,6 +23994,8 @@ escapologist	ɛ s k ə p ɒ l ə d ʒ ɪ s t
 escapology	ɛ s k ə p ɒ l ə d ʒ iː
 escargot	ɪ s k ɑː ɡ ə ʊ
 escarole	ɛ s k ə ɹ ə ʊ l
+escarp	ɪ s k ɑː p
+escarpment	ɪ s k ɑː p m ə n t
 eschar	ɛ s k ɑː
 eschatological	ɛ s k ə t ə l ɒ d ʒ ɪ k ə l
 eschatology	ɛ s k ə t ɒ l ə d͡ʒ i
@@ -23936,8 +24101,8 @@ esthiomene	ɛ s θ i ɒ m ə n i
 esthonia	ɛ s t ə ʊ n i ə
 esthonia	ɛ s θ ə ʊ n i ə
 estimable	ɛ s t ɪ m ə b ə l
-estimate	ɛ s t ɨ m e ɪ̪ t
-estimate	ɛ s t ɨ m ɨ t
+estimate	ɛ s t ɪ m e ɪ̪ t
+estimate	ɛ s t ɪ m ɪ t
 estimation	ɛ s t ɪ m e ɪ ʃ ə n
 estimative	ɛ s t ɪ m e ɪ t ɪ v
 estimative	ɛ s t ɪ m ə t ɪ v
@@ -24125,7 +24290,7 @@ euphony	j uː f ə n i
 euphoria	j uː f ɔː ɹ i ə
 euphoriant	j u f ɔ ɹ i ə n t
 euphrates	j uː f ɹ e ɪ t iː z
-euphrosyne	j uː f ɹ ɒ z ɨ n i
+euphrosyne	j uː f ɹ ɒ z ɪ n i
 eupyrion	j uː p ɪ ɹ i ə n
 eurafrican	j ʊ ə ɹ æ f ɹ ɪ k ə n
 euramerica	j ʊ ə ɹ ə m ɛ ɹ ə k ə
@@ -24381,6 +24546,9 @@ excited	ɪ k s a ɪ t ɪ d
 excitement	ɪ k s a ɪ t m ə n t
 exciting	ɛ k s ʌ ɪ t ɪ ŋ
 exciting	ɪ k s ʌ ɪ t ɪ ŋ
+exciton	ɛ k s a ɪ t ɒ n
+exciton	ɛ k s ɪ t ə n
+exciton	ɪ k s a ɪ t ɑ n
 exclaim	ɛ k s k l e ɪ m
 exclaim	ɪ k s k l e ɪ m
 exclaimed	ɛ k s k l e ɪ m d
@@ -24413,8 +24581,8 @@ excruciating	ɪ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ
 excruciatingly	ɛ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ l i
 excruciatingly	ɪ k s k ɹ uː s iː e ɪ t ɪ ŋ l i
 exculpate	ɛ k s k ə l p e ɪ t
-exculpatory	ɛ k s k ʌ l p ə t ə ɹ i
-exculpatory	ɛ k s k ʌ l p ə t ɹ i
+exculpatory	ɪ k s k ʌ l p ə t ə ɹ i
+exculpatory	ɪ k s k ʌ l p ə t ɹ i
 excursion	ɛ k s k ɜː ɹ ʃ ə n
 excursion	ɛ k s k ɜː ɹ ʒ ə n
 excursus	ɪ k s k ɜː s ə s
@@ -24447,7 +24615,7 @@ exegesis	ɛ k s ɪ d ʒ iː s ɪ s
 exegete	ɛ k s ɪ d ʒ iː t
 exemplar	ɛ ɡ z ɛ m p l ə
 exemplar	ɪ k z ɛ m p l ə
-exemplary	ɛ ɡ z ɛ m p l ə ɹ i
+exemplary	ɪ ɡ z ɛ m p l ə ɹ i
 exemplify	ɛ ɡ z ɛ m p l ɪ f a ɪ
 exemplify	ɪ ɡ z ɛ m p l ɪ f a ɪ
 exempt	ɛ ɡ z ɛ m p t
@@ -24490,7 +24658,7 @@ exhibitry	ɛ ɡ z ɪ b ɪ t ɹ i
 exhilarate	ɪ ɡ z ɪ l ə ɹ e ɪ t
 exhort	ɛ ɡ z ɔː t
 exhort	ɪ ɡ z ɔː t
-exhortative	ɨ ɡ z ɔ ɹ t ə t ɪ v
+exhortative	ɪ ɡ z ɔ ɹ t ə t ɪ v
 exhumation	e k s h j uː m e ɪ ʃ ə n
 exhume	ɛ k s h j uː m
 exhume	ɪ ɡ z j uː m
@@ -24585,6 +24753,7 @@ expenditures	ɛ k s p ɛ n d ɪ t͡ʃ ə z
 expenditures	ɪ k s p ɛ n d ɪ t͡ʃ ə z
 expends	ɛ k s p ɛ n d z
 expends	ɪ k s p ɛ n d z
+expenny	ɪ k s p ɛ n i
 expense	ɪ k s p ɛ n s
 expenses	ɪ k s p ɛ n s ɪ z
 expensive	ɛ k s p ɛ n s ɪ v
@@ -24598,7 +24767,7 @@ experiential	ɛ k s p ɪ ə ɹ i ɛ n ʃ ə l
 experiential	ɪ k s p ɪ ə ɹ i ɛ n ʃ ə l
 experiment	ɛ k s p ɛ ɹ ɪ m ə n t
 experiment	ɪ k s p ɛ ɹ ɪ m ə n t
-experimental	ɨ k s p ɛ ɹ ə m ɛ n t ə l
+experimental	ɪ k s p ɛ ɹ ə m ɛ n t ə l
 experiments	ɛ k s p ɛ ɹ ɪ m ə n t s
 experiments	ɪ k s p ɛ ɹ ɪ m ə n t s
 expert	ɛ k s p əː t
@@ -24805,7 +24974,6 @@ exudate	ɛ ɡ z j ʊ d e ɪ t
 exude	ɪ ɡ z j uː d
 exult	ɪ ɡ z ʌ l t
 exultation	ɛ ɡ z ʌ l t e ɪ ʃ ə n
-exuma	ɛ k s uː m ə
 exuviate	ɛ k s uː v ɪ e ɪ t
 exuviate	ɪ ɡ z j uː v ɪ e ɪ t
 ey	e ɪ
@@ -24927,8 +25095,8 @@ fadge	f æ d͡ʒ
 fading	f e ɪ d ɪ ŋ
 fado	f ɑː d o ʊ
 fady	f e ɪ d i
+fady	f æ d i
 fady	f ɑː d i
-faeces	f iː s iː z
 faena	f a e n ə
 faff	f æ f
 faffy	f æ f i
@@ -25061,6 +25229,7 @@ fan	f æ n
 fanac	f æ n æ k
 fanatic	f ə n æ t ɪ k
 fanatical	f ə n æ t ɪ k ə l
+fanaticism	f ə n æ t ɪ s ɪ z ə m
 fancied	f æ n s ɪ d
 fancies	f æ n s i z
 fanciful	f æ n s ɪ f ə l
@@ -25070,6 +25239,7 @@ fandabidozi	f æ n d æ b iː d ə ʊ z i
 fandango	f æ n d æ ŋ ɡ ə ʊ
 fandemonium	f æ n d ə m ə ʊ n i ə m
 fandom	f æ n d ə m
+fandosentan	f æ n d ə s ɛ n t æ n
 fandub	f æ n d ʌ b
 fane	f e ɪ n
 faned	f æ n ɛ d
@@ -25116,6 +25286,7 @@ fantastical	f æ n t æ s t ɪ k ə l
 fantasticalness	f a n t a s t ɪ k ə l n ə s
 fantasy	f æ n t ə s i
 fanti	f æ n t i
+fantods	f æ n t ɒ d z
 fanzine	f æ n z iː n
 fap	f æ p
 fapiao	f ɑː p i a ʊ
@@ -25359,6 +25530,7 @@ februarys	f ɛ b ɹ u ɛ ɹ i z
 februation	f ɛ b ɹ ʊ e ɪ ʃ ə n
 febuary	f ɛ b j ʊ ə ɹ i
 fecal	f iː k ə l
+feces	f iː s iː z
 feck	f ɛ k
 feckful	f ɛ k f ə l
 feckless	f ɛ k l ə s
@@ -25394,6 +25566,7 @@ feeler	f iː l ə
 feelgoodery	f iː l ɡ ʊ d ə ɹ i
 feeling	f iː l ɪ ŋ
 feelings	f iː l ɪ ŋ z
+feels	f i j ə l z
 feels	f iː l z
 feely	f iː l i
 feeney	f i n i
@@ -25409,11 +25582,12 @@ feijoa	f e ɪ d͡ʒ o ʊ ə
 feijoa	f e ɪ h o ʊ ə
 feijoa	f e ɪ ʒ o ʊ ə
 feijoa	f iː d͡ʒ ɐ ʉ ɐ
-feijoada	f ɛ ɪ ʒ w ɑː d ə
+feijoada	f e ɪ ʒ w ɑː d ə
 feinstein	f a ɪ n s t a ɪ n
 feinstein	f a ɪ n s t iː n
 feint	f e ɪ n t
 feinter	f e ɪ n t ə ɹ
+feirie	f ɪ ə r i
 feis	f ɛ ʃ
 feiseanna	f ɛ ʃ ə n ə
 feist	f a ɪ s t
@@ -25442,6 +25616,7 @@ felly	f ɛ l i
 felly	f ɛ l l i
 felon	f ɛ l ə n
 felony	f ɛ l ə n i
+feloprentan	f ɛ l ə p ɹ ɛ n t æ n
 felt	f ɛ l t
 felter	f ɛ l t ə ɹ
 feltham	f ɛ l t ə m
@@ -25521,7 +25696,7 @@ ferm	f ɜː ɹ m
 fermanagh	f ə ɹ m æ n ə
 fermata	f ɜː m ɑː t ə
 ferment	f ə m ɛ n t
-ferment	f əː m ɛ n t
+ferment	f ɜː m ɛ n t
 fermentate	f ɜː ɹ m ə n t e ɪ t
 fermentation	f ɜː ɹ m ə n t e ɪ ʃ ə n
 fermentation	f ɜː ɹ m ɛ n t e ɪ ʃ ə n
@@ -25669,7 +25844,8 @@ fibrillate	f ʌ ɪ b r ɪ l e ɪ t
 fibrillogenic	f ɪ b ɹ ɪ l ə ʊ d͡ʒ ɛ n ɪ k
 fibrillose	f ɪ b ɹ ɪ l ə ʊ s
 fibrin	f a ɪ b ɹ ɪ n
-fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɨ n ə s
+fibrine	f a ɪ b ɹ ɪ n
+fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɪ n ə s
 fibrous	f a ɪ b ɹ ə s
 fibula	f ɪ b j ʊ l ə
 fic	f ɪ k
@@ -25739,7 +25915,7 @@ fifeshire	f a ɪ f ʃ ə ɹ
 fifeshire	f a ɪ f ʃ ɪ ə ɹ
 fifi	f i f i
 fifo	f a ɪ f ə ʊ
-fifteenth	f ɪ f t iː n θ
+fifteenth	h ɪ f t iː n θ
 fifth	f ɪ f t
 fifth	f ɪ f θ
 fifth	f ɪ θ
@@ -25856,8 +26032,8 @@ finally	f a ɪ n ə l i
 finals	f a ɪ n ə l z
 finance	f a ɪ n æ n s
 finance	f ɪ n æ n s
-finances	f a ɪ n æ n s ɨ z
-finances	f ɪ n æ n s ɨ z
+finances	f a ɪ n æ n s ɪ z
+finances	f ɪ n æ n s ɪ z
 financial	f a ɪ n æ n ʃ ə l
 financial	f ɪ n æ n ʃ ə l
 financialization	f ʌ ɪ n a n ʃ l̩ ʌ ɪ z e ɪ ʃ n̩
@@ -26008,6 +26184,7 @@ fissiparous	f ɪ s ɪ p ə ɹ ə s
 fissure	f ɪ ʃ ə
 fist	f ɪ s t
 fisted	f ɪ s t ɪ d
+fister	f ɪ s t ə
 fistfight	f ɪ s t f a ɪ t
 fistful	f ɪ s t f ʊ l
 fistiana	f ɪ s t ɪ e ɪ n ə
@@ -26076,7 +26253,6 @@ flabby	f l æ b i
 flabellate	f l ə b ɛ l ə t
 flabellum	f l ə b ɛ l ə m
 flaccid	f l æ k s ɪ d
-flaccid	f l æ s ɪ d
 flack	f l æ k
 flacon	f l æ k ɒ n
 flacon	f l ɑː k ɒ n
@@ -26222,6 +26398,7 @@ flecking	f l ɛ k ɪ ŋ
 fleckings	f l ɛ k ɪ ŋ z
 flecks	f l ɛ k s
 flecky	f l ɛ k i
+flector	f l ɛ k t ə ɹ
 fled	f l ɛ d
 fledge	f l ɛ d͡ʒ
 fledged	f l ɛ d͡ʒ d
@@ -26332,7 +26509,7 @@ floccinaucinihilipilification	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l 
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɒ s ɪ n ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 flocculation	f l ɒ k j ʊ l ɛ ɪ̯ ʃ ə n
-flocculent	f l ɒ k j ʊ l ə n t
+flocculent	f l ɒ k j ə l ə n t
 flock	f l ɒ k
 flocks	f l ɒ k s
 floe	f l ə ʊ
@@ -26408,6 +26585,7 @@ flowering	f l a ʊ ə ɹ ɪ ŋ
 flowerpot	f l a ʊ ə p ɒ t
 flowers	f l a ʊ ə z
 flowing	f l ə ʊ ɪ ŋ
+flowk	f l a ʊ k
 flown	f l ə ʊ n
 flows	f l ə ʊ z
 flox	f l ɒ k s
@@ -26606,6 +26784,7 @@ foof	f uː f
 foofaraw	f u f ə ɹ ɔ
 foofooraw	f uː f ə ɹ ɔː
 fook	f uː k
+fook	f ʊ k
 fool	f uː l
 fooled	f uː l d
 fooler	f uː l ə ɹ
@@ -26679,7 +26858,7 @@ forbear	f ɔː b ɛ ə
 forbearance	f ɔː b ɛː ɹ ə n t s
 forbearingly	f ɔː b ɛː ɹ ɪ ŋ l i
 forbid	f ə b ɪ d
-forbidden	f ə b ɪ d ə n
+forbidden	f ə b ɪ d n̩
 forbidding	f ə b ɪ d ɪ ŋ
 forby	f ə b ʌ ɪ
 force	f ɔː s
@@ -26831,6 +27010,7 @@ formulae	f ɔː ɹ m j ə l a ɪ
 formulae	f ɔː ɹ m j ə l e ɪ
 formulae	f ɔː ɹ m j ə l i
 formulaicity	f ɔ ɹ m j ə l e ɪ ɪ s ə t iː
+formulary	f ɔː ɹ m j ʊ l ə ɹ i
 formulate	f ɔː ɹ m j ʊ l e ɪ t
 formule	f ɔː ɹ m j uː l
 fornicate	f ɔː n ɪ k e ɪ t
@@ -26908,7 +27088,9 @@ forworn	f ə ɹ w ɔː ɹ n
 fosaprepitant	f ɒ s ə p ɹ ɛ p ɪ t ə n t
 fosphenytoin	f ɒ s f ə n ɪ t ə ʊ ɪ n
 foss	f ɒ s
+fossa	f uː s ə
 fossa	f ɒ s ə
+fossa	f ʊ s ə
 fosse	f ɒ s
 fossette	f ɒ s ɛ t
 fossick	f ɒ s ɪ k
@@ -27012,6 +27194,7 @@ fragor	f ɹ e ɪ ɡ ə ɹ
 fragrance	f ɹ e ɪ ɡ ɹ ə n s
 fragrant	f ɹ e ɪ ɡ ɹ ə n t
 fraidy	f ɹ e ɪ d i
+fraight	f ɹ e ɪ t
 frail	f ɹ e ɪ l
 fraischeur	f ɹ e ɪ ʃ ə ɹ
 fraise	f ɹ e ɪ z
@@ -27416,6 +27599,7 @@ frumpy	f ɹ ʌ m p ɪ
 frush	f ɹ ʌ ʃ
 frustrate	f ɹ ə s t ɹ e ɪ t
 frustrated	f ɹ ə s t ɹ e ɪ t ɪ d
+frustrating	f ɹ ə s t ɹ e ɪ̯ t ɪ ŋ
 frustrating	f ɹ ʌ s t ɹ e ɪ̯ t ɪ ŋ
 frutage	f ɹ uː t ə d͡ʒ
 frutescence	f ɹ uː t ɛ s ə n s
@@ -27432,6 +27616,7 @@ fubbery	f ʌ b ə ɹ i
 fubble	f ʌ b ə l
 fubsy	f ʌ b s ɪ
 fubu	f u b ʊ
+fuchien	f uː t ʃ i ɛ n
 fuchs	f j uː k s
 fuchsia	f j uː ʃ ə
 fuchsine	f uː k s iː n
@@ -27467,6 +27652,7 @@ fuel	f j ʊ ə l
 fuero	f w ɛ ə ɹ ə ʊ
 fufufu	f uː f uː f uː
 fug	f ʌ ɡ
+fuga	f j uː ɡ ə
 fugacious	f j uː ɡ e ɪ ʃ ə s
 fugazi	f u ɡ ɑː z i
 fugged	f ʌ ɡ d
@@ -27546,11 +27732,13 @@ fume	f j uː m
 fumed	f j uː m d
 fumer	f j uː m ə ɹ
 fumes	f j uː m z
+fumfer	f ʌ m f ə
 fumigate	f j uː m ɪ ɡ e ɪ t
 fumigation	f j uː m ɪ ɡ e ɪ ʃ ə n
 fuming	f j uː m ɪ ŋ
 fumings	f j uː m ɪ ŋ z
 fun	f ʌ n
+funafuti	f uː n ə f uː t i
 funalicious	f ʌ n ə l ɪ ʃ ə s
 funambulate	f j ʊ n æ m b j ʊ l e ɪ t
 funambulist	f j uː n æ m b j ʊ l ɪ s t
@@ -27578,6 +27766,7 @@ fundraiser	f ʌ n d ɹ e ɪ z ə
 fundraising	f ʌ n d ɹ e ɪ z ɪ ŋ
 funds	f ʌ n d z
 funemployed	f ʌ n ɪ m p l ɔ ɪ d
+funen	f j uː n ə n
 funeral	f j uː n ə ɹ ə l
 funeral	f j uː n ɹ ə l
 funerary	f j uː n ə ɹ ə ɹ i
@@ -27723,7 +27912,6 @@ fuxin	f u ʃ ɪ n
 fuxing	f u ʃ ɪ ŋ
 fuze	f j uː z
 fuzed	f j uː z d
-fuzhou	f u t͡s o ʊ
 fuzhou	f uː d͡ʒ ə ʊ
 fuzz	f ʌ z
 fuzzed	f ʌ z d
@@ -27764,8 +27952,9 @@ gabby	ɡ æ b i
 gabe	ɡ e ɪ b
 gabel	ɡ e ɪ b ə l
 gabelle	ɡ a b ɛ l
-gabion	ɡ e ɪ b ɪ ə n
+gabion	ɡ e ɪ b i ə n
 gable	ɡ e ɪ b ə l
+gablet	ɡ e ɪ b l ə t
 gabon	ɡ ə b ɒ n
 gabonese	ɡ æ b ə n iː z
 gaborone	ɡ æ b ə ɹ ə ʊ n i
@@ -27795,6 +27984,7 @@ gadolinium	ɡ æ d ə l ɪ n i ə m
 gadroon	ɡ ə d ɹ uː n
 gadrooned	ɡ ə d ɹ uː n d
 gadsbud	ɡ æ d z b ʌ d
+gadus	ɡ e ɪ d ə s
 gadzooks	ɡ æ d z uː k s
 gaea	d͡ʒ iː ə
 gaea	ɡ a ɪ ə
@@ -27846,6 +28036,7 @@ gaiting	ɡ e ɪ t ɪ ŋ
 gaits	ɡ e ɪ t s
 gaiwan	ɡ a ɪ w ɑː n
 gaja	ɡ ɑː d͡ʒ ə
+gak	ɡ æ k
 gal	ɡ æ l
 gala	ɡ ɑː l ə
 galactagogue	ɡ ə l æ k t ə ɡ ɒ ɡ
@@ -27862,7 +28053,7 @@ galantine	ɡ a l ə n t iː n
 galashiels	ɡ æ l ə ʃ iː ə l z
 galatea	ɡ æ l ə t ɪ ə
 galatians	ɡ ə l e ɪ ʃ ə n z
-galaxy	ɡ a l ə k s i
+galaxy	ɡ æ l ə k s i
 galbanum	ɡ æ l b ə n ə m
 galbe	ɡ æ l b
 gale	ɡ e ɪ l
@@ -27875,6 +28066,7 @@ galicia	ɡ ə l ɪ s i ə
 galicia	ɡ ə l ɪ ʃ ə
 galician	ɡ ə l ɪ s i ə n
 galician	ɡ ə l ɪ ʃ ə n
+galileo	ɡ æ l ɪ l e ɪ ə ʊ
 galimatias	ɡ æ l ə m e ɪ ʃ i ə s
 galingale	ɡ æ l ɪ ŋ ɡ e ɪ l
 gall	ɡ ɔː l
@@ -27923,7 +28115,7 @@ galvanic	ɡ æ l v æ n ɪ k
 galvanism	ɡ æ l v ə n ɪ z ə m
 galvanize	ɡ æ l v ə n a ɪ̯ z
 galvanometer	ɡ æ l v ə n ɒ m ɪ t ə
-galveston	ɡ æ l v ə s t ə n
+galveston	ɡ æ l v ɪ s t ə n
 galway	ɡ ɔː l w e ɪ
 galwegian	ɡ ɔː l w iː d ʒ ə n
 galyak	ɡ æ l j æ k
@@ -27934,9 +28126,9 @@ gamaliel	ɡ ə m e ɪ l y ə l
 gamb	ɡ a m b
 gambado	ɡ æ m b e ɪ d ə ʊ
 gambell	ɡ æ m b ə l
-gambeson	ɡ æ m b ɨ s ə n
+gambeson	ɡ æ m b ɪ s ə n
 gambia	ɡ æ m b i ə
-gambison	ɡ æ m b ɨ s ə n
+gambison	ɡ æ m b ɪ s ə n
 gamble	ɡ æ m b ə l
 gambling	ɡ æ m b l ɪ ŋ
 gambling	ɡ æ m b l̩ ɪ ŋ
@@ -27998,6 +28190,9 @@ gangsteress	ɡ æ ŋ s t ə ɹ ɛ s
 gangue	ɡ æ ŋ
 ganguro	ɡ ɑː n ɡ u ɹ ə ʊ
 ganister	ɡ æ n ɪ s t ə ɹ
+ganj	g ɑː n d ʒ
+ganj	g ʌ n d ʒ
+ganj	ɡ æ n d ʒ
 ganja	ɡ æ n d ʒ ə
 ganjapreneur	ɡ æ n d͡ʒ ə p ɹ ə n ɜː ɹ
 ganjapreneur	ɡ ɑ n d͡ʒ ə p ɹ ə n ɜː ɹ
@@ -28088,18 +28283,20 @@ garçon	ɡ ɑː ɹ s ɒ n
 garçon	ɡ ɑː ɹ s ɒ̃
 garçonnière	ɡ ɑː s ə n j ɛ ə
 gas	ɡ æ s
+gas	ɡ æ z
 gasbag	ɡ æ s b æ ɡ
 gascoigne	ɡ æ s k ɔ ɪ n
 gascon	ɡ æ s k ə n
 gasconade	ɡ a s k ə n e ɪ d
 gases	ɡ æ s ɪ z
+gases	ɡ æ z ɪ z
 gash	ɡ æ ʃ
 gasket	ɡ æ s k ɪ t
 gaskin	ɡ æ s k ɪ n
 gaslight	ɡ æ s l a ɪ t
 gasoline	ɡ æ s l i n
 gasoline	ɡ æ s l̩ i n
-gasoline	ɡ æ s ə l i n
+gasoline	ɡ æ s ə l iː n
 gasometer	ɡ æ s ɒ m ɪ t ə
 gasp	ɡ ɑː s p
 gasped	ɡ ɑː s p t
@@ -28129,6 +28326,7 @@ gather	ɡ æ ð ə
 gathered	ɡ æ ð ə d
 gathering	ɡ æ ð ə ɹ ɪ ŋ
 gator	ɡ e ɪ t ə ɹ
+gatorade	ɡ e ɪ t ə ɹ e ɪ d
 gau	ɡ a ʊ
 gauche	ɡ ə ʊ ʃ
 gaucherie	ɡ o ʊ ʃ ə ɹ iː
@@ -28168,6 +28366,7 @@ gaw	ɡ ɔː
 gawa	ɡ a w a
 gawain	ɡ ɑː w e ɪ n
 gawain	ɡ ə w e ɪ n
+gawber	ɡ ɔː b ə ɹ
 gawd	ɡ ɔː d
 gawf	ɡ ɔː f
 gawk	ɡ ɔː k
@@ -28195,7 +28394,7 @@ gazehound	ɡ e ɪ z h a ʊ n d
 gazella	ɡ ə z ɛ l ə
 gazelle	ɡ ə z ɛ l
 gazes	ɡ e ɪ z ə z
-gazes	ɡ e ɪ z ɨ z
+gazes	ɡ e ɪ z ɪ z
 gazette	ɡ ə z ɛ t
 gazillion	ɡ ə z ɪ l j ə n
 gazing	ɡ e ɪ z ɪ ŋ
@@ -28303,6 +28502,7 @@ gene	d͡ʒ iː n
 genealogist	d ʒ iː n iː æ l ə d ʒ ɪ s t
 genealogy	d ʒ iː n i æ l ə d ʒ i
 genealogy	d ʒ iː n i ɒ l ə d ʒ i
+genearch	d ʒ iː n i ɑː ɹ k
 genera	d͡ʒ ɛ n ə ɹ ə
 general	d͡ʒ ɛ n ɹ ə l
 generalia	d͡ʒ ɛ n ə ɹ e ɪ l i ə
@@ -28463,11 +28663,12 @@ geordie	d ʒ ɔː d i
 george	d ʒ ɔː ɹ d ʒ
 georgeson	d ʒ ɔː ɹ d ʒ s ə n
 georgetown	d͡ʒ ɔː ɹ d͡ʒ t a ʊ n
-georgia	d ʒ ɔː d ʒ ə
-georgian	d ʒ ɔː d ʒ ə n
+georgia	d͡ʒ ɔː d͡ʒ ə
+georgian	d͡ʒ ɔː d͡ʒ ə n
 georgina	d ʒ ɔː ɹ d ʒ iː n ə
 geosmin	d͡ʒ iː ɒ z m ɪ n
 geospace	d͡ʒ iː ə ʊ s p e ɪ s
+geospeedometry	d ʒ iː ə ʊ s p iː d ɒ m ɪ t ɹ i
 geosphere	d͡ʒ iː ə s f ɪ ə ɹ
 geosphere	d͡ʒ iː ə ʊ s f ɪ ə ɹ
 geosyncline	d ʒ iː ə ʊ s ɪ ŋ k l ʌ ɪ n
@@ -28480,6 +28681,7 @@ geppetto	d͡ʒ ə p ɛ t o ʊ
 ger	ɡ ɛ ə ɹ
 geraint	ɡ ɛ ɹ a ɪ n t
 gerald	d͡ʒ ɛ ɹ ə l d
+geranium	d ʒ ə ɹ e ɪ n i ə m
 geranylgeranylacetone	d͡ʒ ɛ ɹ ə n ɪ l d͡ʒ ɛ ɹ ə n ɪ l æ s ɪ t ə ʊ n
 gerard	d͡ʒ ɛ ɹ ɑː d
 gerasena	ɡ ɛ ɹ ə s iː n ə
@@ -28499,6 +28701,7 @@ germans	d͡ʒ ɜː m ə n z
 germany	d͡ʒ ɜː m ə n i
 germen	d ʒ ɜː m ə n
 germinal	d ʒ ɜː m ɪ n ə l
+germinal	d ʒ ɜː ɹ m ɪ n ə l
 germinate	d͡ʒ ɜː ɹ m ɪ n e ɪ t
 gern	ɡ ɜː ɹ n
 gerocomy	d ʒ ɪ ə ɹ ɒ k ə m i
@@ -28514,7 +28717,7 @@ gershon	ɡ ɜː ʃ ɒ n
 gersum	ɡ ɜː s ə m
 gerund	d͡ʒ ɛ ɹ ə n d
 gerundive	d ʒ ə ɹ ʌ n d ɪ v
-gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɨ
+gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɪ
 gesellschaft	ɡ ə z ɛ l ʃ a f t
 gesso	d͡ʒ ɛ s ə ʊ
 gest	d͡ʒ ɛ s t
@@ -28574,6 +28777,7 @@ ghent	ɡ ɛ n t
 gherao	ɡ ɛ ɹ a ʊ
 gherkin	ɡ ɜː k ɪ n
 ghetto	ɡ ɛ t ə ʊ
+ghey	d ʒ a ɪ
 ghibelline	ɡ ɪ b ɪ l a ɪ n
 ghibli	ɡ ɪ b l i
 ghillie	ɡ ɪ l i
@@ -28718,7 +28922,7 @@ gingerol	d͡ʒ ɪ n d͡ʒ ə ɹ ɒ l
 gingham	ɡ ɪ ŋ ə m
 gingiva	d͡ʒ ɪ n d͡ʒ a ɪ v ə
 gingiva	d͡ʒ ɪ n d͡ʒ ɪ v ə
-gingival	d͡ʒ ɪ n d͡ʒ ɨ v ə l
+gingival	d͡ʒ ɪ n d͡ʒ ɪ v ə l
 gingivitis	d͡ʒ ɪ n d͡ʒ ɪ v a ɪ t ə s
 ginglymus	d ʒ ɪ ŋ ɡ l ɪ m ə s
 ginglymus	ɡ ɪ ŋ ɡ l ɪ m ə s
@@ -28738,7 +28942,6 @@ ginseng	d͡ʒ ɪ n s ɪ ŋ
 ginsu	ɡ ɪ n s uː
 giovanni	d͡ʒ iː ə v ɑ n i
 giovanni	d͡ʒ o ʊ v ɑ n i
-gipper	ɡ ɪ p ɚ
 gippo	d͡ʒ ɪ p ə ʊ
 giraffe	d ʒ ɪ ɹ ɑː f
 giraffes	d ʒ ɪ ɹ ɑː f s
@@ -28753,6 +28956,7 @@ girl	ɡ ɪ ə l
 girlcock	ɡ ɜː l k ɑ k
 girldick	ɡ ɜː l d ɪ k
 girleen	ɡ əː l iː n
+girlf	ɡ ɜː l f
 girlfriend	ɡ ɜː l f ɹ ɛ n d
 girlish	ɡ ɜː l ɪ ʃ
 girls	ɡ ɜː l z
@@ -28765,6 +28969,8 @@ girt	ɡ ɜː t
 girth	ɡ ɜː θ
 girus	d͡ʒ a ɪ ɹ ə s
 gisborne	ɡ ɪ z b ə n
+giselle	d ʒ ɪ z ɛ l
+giselle	ʒ ɪ z ɛ l
 gismu	ɡ iː s m uː
 gissard	ɡ ɪ s ɜː d
 gist	d͡ʒ ɪ s t
@@ -28866,6 +29072,7 @@ glazed	ɡ l e ɪ z d
 glazes	ɡ l e ɪ z ɪ z
 glazier	ɡ l e ɪ z i ə ɹ
 glazier	ɡ l e ɪ z j ə ɹ
+glazier	ɡ l e ɪ ʒ ə ɹ
 glazing	ɡ l e ɪ z ɪ ŋ
 glazings	ɡ l e ɪ z ɪ ŋ z
 glazy	ɡ l e ɪ z i
@@ -28954,6 +29161,7 @@ globish	ɡ l ə ʊ b ɪ ʃ
 globster	ɡ l ɒ b s t ə
 globule	ɡ l ɒ b j uː l
 globulin	ɡ l ɒ b j ʊ l ɪ n
+globus	ɡ l ə ʊ b ə s
 globy	ɡ l ə ʊ b i
 glocal	ɡ l ə ʊ k ə l
 glockenspiel	ɡ l ɒ k ə n ʃ p iː l
@@ -28994,6 +29202,8 @@ glossatrix	ɡ l ɒ s e ɪ t ɹ ɪ k s
 glossitis	ɡ l ɒ s a ɪ t ɪ s
 glossolalia	ɡ l ɒ s ə l e ɪ l i ə
 glossology	ɡ l ɒ s ɒ l ə d ʒ i
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t a ɪ n
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t ɪ n
 glossopharyngeal	ɡ l ɒ s ə ʊ f a ɹ n̩ d͡ʒ iː ə l
 glossopharyngeal	ɡ l ɒ s ə ʊ f a ɹ ə n d͡ʒ iː ə l
 glossopharyngeal	ɡ l ɒ s ə ʊ f ə ɹ ɪ n d͡ʒ i ə l
@@ -29207,7 +29417,7 @@ golborne	ɡ ɒ l b ɔː ɹ n
 golconda	ɡ ɒ l k ɒ n d ə
 gold	ɡ ə ʊ l d
 golden	ɡ ə ʊ l d ə n
-goldeneye	ɡ ə ʊ l d n̩ ɑ ɪ
+goldeneye	ɡ ə ʊ l d ə n a ɪ
 goldfish	ɡ o ʊ l d f ɪ ʃ
 goldilocks	ɡ ə ʊ l d i l ɒ k s
 golding	ɡ ə ʊ l d ɪ ŋ
@@ -29295,7 +29505,7 @@ goop	ɡ uː p
 goopy	ɡ uː p i
 goos	ɡ uː s
 goos	ɡ uː z
-goose	ɡ uː s
+goose	ɡ ʉː s
 gooseberry	ɡ uː s b ə ɹ i
 gooseberry	ɡ ʊ z b ə ɹ i
 goosefoot	ɡ uː s f ʊ t
@@ -29321,14 +29531,13 @@ gorget	ɡ ɔː d ʒ ɪ t
 gorgias	ɡ ɔ ɹ d͡ʒ i ə s
 gorgon	ɡ ɔː r ɡ ə n
 gorhen	ɡ ɔː h ɛ n
-gorilla	ɡ ɒ ɹ ɪ l ə
 gorilla	ɡ ə ɹ ɪ l ə
 gork	ɡ ɔː k
 gorm	ɡ ɔː ɹ m
 gormless	ɡ ɔː m l ə s
 gormy	ɡ ɔː m i
 goropism	ɡ ə ɹ ə ʊ p ɪ z ə m
-gorp	ɡ ɔː ɹ p
+gorp	ɡ ɔː p
 gorringe	ɡ ɒ ɹ ɪ n d͡ʒ
 gorse	ɡ ɔː s
 gorsedd	ɡ ɔː ɹ s ɛ ð
@@ -29344,6 +29553,7 @@ gosh	ɡ ɒ ʃ
 gosha	ɡ o ʊ ʃ ə
 goshawk	ɡ ɒ s h ɔː k
 goshbustified	ɡ ɒ ʃ b ʌ s t ɪ f a ɪ d
+gosht	ɡ o ʊ ʃ t
 gosling	ɡ ɒ z l ɪ ŋ
 gospel	ɡ ɒ s p ə l
 gosplan	ɡ ɒ s p l æ n
@@ -29581,6 +29791,8 @@ grasped	ɡ ɹ ɑː s p t
 grasping	ɡ ɹ ɑː s p ɪ ŋ
 grass	ɡ ɹ æ s
 grass	ɡ ɹ ɑː s
+grasshawk	ɡ ɹ æ s h ɔː k
+grasshawk	ɡ ɹ ɑː s h ɔː k
 grasshopper	ɡ ɹ æ s h ɒ p ə ɹ
 grasshopper	ɡ ɹ ɑː s h ɒ p ə ɹ
 grassley	ɡ ɹ æ s l i
@@ -29700,7 +29912,7 @@ greenford	ɡ ɹ iː n f ə d
 greengage	ɡ ɹ iː n ɡ e ɪ d͡ʒ
 greengrocer	ɡ ɹ i n ɡ ɹ ə ʊ s ə ɹ
 greenhouse	ɡ ɹ iː n h a ʊ s
-greeniac	ɡ ɹ i n i æ k
+greeniac	ɡ ɹ iː n i æ k
 greening	ɡ ɹ iː n ɪ ŋ
 greenings	ɡ ɹ iː n ɪ ŋ z
 greenish	ɡ ɹ iː n ɪ ʃ
@@ -29760,8 +29972,10 @@ greven	ɡ ɹ i v ə n
 greviere	ɡ ɹ ɛ v j ɛ ə ɹ
 grew	ɡ ɹ u ʊ̯
 grew	ɡ ɹ uː
+grex	ɡ ɹ ɛ k s
 grexit	ɡ ɹ ɛ k s ɪ t
 grexit	ɡ ɹ ɛ ɡ z ɪ t
+grey	ɡ ɹ e ɪ
 greyback	ɡ ɹ e ɪ b a k
 greyhound	ɡ ɹ e ɪ h a ʊ n d
 greyish	ɡ ɹ e ɪ ɪ ʃ
@@ -29774,6 +29988,7 @@ grice	ɡ ɹ ʌ ɪ s
 grid	ɡ ɹ ɪ d
 gridded	ɡ ɹ ɪ d ɪ d
 gridding	ɡ ɹ ɪ d ɪ ŋ
+griddle	ɡ ɹ ɪ d ə l
 gride	ɡ ɹ a ɪ d
 griding	ɡ ɹ a ɪ d ɪ ŋ
 gridiron	ɡ ɹ ɪ d a ɪ ə n
@@ -29797,6 +30012,7 @@ griff	ɡ ɹ ɪ f
 griffe	ɡ ɹ ɪ f
 griffin	ɡ ɹ ɪ f ɪ n
 griffith	ɡ ɹ ɪ f ɪ θ
+griffon	ɡ ɹ ɪ f ə n
 grift	ɡ ɹ ɪ f t
 grifter	ɡ ɹ ɪ f t ə
 grifting	ɡ ɹ ɪ f t ɪ ŋ
@@ -29804,7 +30020,7 @@ grig	ɡ ɹ ɪ ɡ
 grike	ɡ ɹ a ɪ k
 grill	ɡ ɹ ɪ l
 grillade	ɡ ɹ i j ɑː d
-grillade	ɡ ɹ ɨ l ɑː d
+grillade	ɡ ɹ ɪ l ɑː d
 grillbilly	ɡ ɹ ɪ l b ɪ l i
 grille	ɡ ɹ ɪ l
 grilled	ɡ ɹ ɪ l d
@@ -29983,6 +30199,7 @@ grue	ɡ ɹ uː
 gruel	ɡ ɹ uː ə l
 gruelling	ɡ ɹ ʊ ə l ɪ ŋ
 grues	ɡ ɹ uː z
+gruesome	ɡ ɹ uː s ʌ m
 gruff	ɡ ɹ ʌ f
 gruffish	ɡ ɹ ʌ f ɪ ʃ
 gruit	ɡ ɹ a ɪ t
@@ -30025,7 +30242,7 @@ guadalquivir	ɡ w ɑː d ə l k ɪ v ɪ ə
 guadeloupe	ɡ w ɑː d ə l uː p
 guadiana	ɡ w ɑː d ɪ ɑː n ə
 guaiacum	ɡ w a ɪ ə k ə m
-guaifenesin	ɡ w a ɪ f ɛ n ɨ s ɪ n
+guaifenesin	ɡ w a ɪ f ɛ n ɪ s ɪ n
 guakong	ɡ ʊ ɐ k o ŋ
 guam	ɡ w æ m
 guam	ɡ w ɑː m
@@ -30044,6 +30261,7 @@ guanines	ɡ w ɑː n iː n z
 guano	ɡ w ɑː n ə ʊ
 guanxi	k w a n ʃ i
 guanxi	ɡ w a n ʃ i
+guanylate	ɡ w ɑː n ɪ l e ɪ t
 guarana	ɡ w ə ɹ ɑː n ə
 guaranine	ɡ w ɑː ɹ ə n iː n
 guarantee	ɡ æ ɹ ə n t iː
@@ -30095,6 +30313,10 @@ guffaw	ɡ ə f ɔː
 guhr	ɡ ʊ ə ɹ
 gui	d ʒ iː j uː a ɪ
 gui	ɡ uː i
+guiana	g a ɪ æ n ə
+guiana	g a ɪ ɑː n ə
+guiana	ɡ i æ n ə
+guiana	ɡ i ɑː n ə ,
 guiche	ɡ iː ʃ
 guidance	ɡ a ɪ d ə n s
 guide	ɡ a ɪ d
@@ -30133,6 +30355,7 @@ guiltily	ɡ ɪ l t ɪ l i
 guilting	ɡ ɪ l t ɪ ŋ
 guiltless	ɡ ɪ l t l ə s
 guilts	ɡ ɪ l t s
+guilty	ɡ ɪ l t i
 guimpe	ɡ ɪ m p
 guinea	ɡ ɪ n i
 guinea	ɡ ɪ n iː
@@ -30202,6 +30425,7 @@ gumption	ɡ ʌ m p ʃ ə n
 gums	ɡ ʌ m z
 gumshoe	ɡ ʌ m ʃ uː
 gun	ɡ ʌ n
+guna	ɡ ʊ n ə
 gunai	ɡ ʌ n a ɪ
 gundelet	ɡ ʌ n d ə l ə t
 gunfire	ɡ ʌ n f ʌ ɪ ə
@@ -30260,6 +30484,8 @@ gusle	ɡ ʊ s l ə
 gusset	ɡ ʌ s ɪ t
 gust	ɡ ʌ s t
 gustable	ɡ ʌ s t ə b ə l
+gustatory	ɡ ʌ s t ə t ə ɹ i
+gustatory	ɡ ʌ s t ə t ɹ i
 gusted	ɡ ʌ s t ɪ d
 gustfulness	ɡ ʌ s t f ə l n ə s
 gusting	ɡ ʌ s t ɪ ŋ
@@ -30293,6 +30519,7 @@ guys	ɡ a ɪ z
 guyu	ɡ uː j uː
 guyver	ɡ a ɪ v ə
 guz	ɡ ʌ z
+guze	ɡ j uː z
 guzheng	ɡ uː d͡ʒ ʌ ŋ
 guzman	ɡ u z m ɑ n
 guzzle	ɡ ʌ z ə l
@@ -30305,6 +30532,8 @@ gwyneth	ɡ w ɪ n e θ
 gwyneth	ɡ w ɪ n ə θ
 gwyneth	ɡ w ɪ n ɪ θ
 gwyniad	ɡ w ɪ n iː ɑː ɹ d
+gyaru	ɡ j æ ɹ uː
+gyaru	ɡ j ɑː ɹ uː
 gybe	d͡ʒ a ɪ b
 gylany	ɡ ɪ l ə n i
 gyle	ɡ a ɪ l
@@ -30483,6 +30712,7 @@ hagging	h æ ɡ ɪ ŋ
 haggis	h æ ɡ ɪ s
 haggis	h ɑː d ʒ i s
 haggle	h æ ɡ ə l
+hagiographer	h æ ɡ i ɒ ɡ ɹ ə f ə
 hagiographic	h æ ɡ i o ʊ ɡ ɹ æ f ɪ k
 hagiography	h æ ɡ i ɒ ɡ ɹ ə f i
 hagiolatry	h a ɡ i ɒ l ə t ɹ i
@@ -30513,17 +30743,17 @@ haines	h e ɪ n z
 haint	h e ɪ n t
 haiphong	h a ɪ f ɒ ŋ
 hair	h ɛ ə
-hair	h ɛ ɚ
 hair	h ɛː
 hairbow	h ɛ ə ɹ b ə ʊ
 haircolor	h ɛ ə k ʌ l ɚ
 haircolor	h ɛ ɚ k ʌ l ɚ
+haircut	h ɛ ə ɹ k ʌ t
 hairdo	h ɛ ə d uː
 hairen	h ɛ ə ɹ ə n
 hairpin	h ɛ ə p ɪ n
 hairsbreadth	h ɛ ə ɹ z b ɹ ɛ d θ
 hairshirt	h ɛ ə ʃ ɜː t
-hairy	h ɛ ɚ i
+hairy	h ɛ ə ɹ i
 haitch	h e ɪ t͡ʃ
 haiti	h e ɪ t i
 haitian	h e ɪ ʃ ə n
@@ -30568,8 +30798,8 @@ halfpenny	h ɑː f p ɛ n i
 halfpennyworth	h ɛ ɪ p n ɪ w ə θ
 halfpennyworth	h ɛ ɪ p ə θ
 halfway	h ɑː f w e ɪ
-halibut	h æ l ɨ b ə t
-halibut	h ɒ l ɨ b ə t
+halibut	h æ l ɪ b ə t
+halibut	h ɒ l ɪ b ə t
 halicarnassus	h æ l ɪ k ɑ ɹ n æ s ə s
 halicore	h ə l ɪ k ə ɹ iː
 halide	h e ɪ l a ɪ d
@@ -30582,7 +30812,7 @@ hall	h ɔː l
 hallage	h ɔː l ɪ d͡ʒ
 hallatrow	h æ l ə t ɹ ə ʊ
 hallecret	h æ l ɪ k r ɛ t
-hallelujah	h æ l ɪ l j uː j ə
+hallelujah	h æ l ə l j uː j ə
 hallewell	h æ l ɪ w ɛ l
 halley	h æ l i
 hallmark	h ɔː l m ɑː k
@@ -30668,7 +30898,7 @@ hampton	h æ m p t ə n
 hamsa	h æ m s ə
 hamsa	h ɑ m s ə
 hamstring	h æ m s t ɹ ɪ ŋ
-hamtramck	h æ m t r æ m ɨ k
+hamtramck	h æ m t r æ m ɪ k
 hamulose	h æ m j ʊ l ə ʊ z
 han	h e ɪ n
 han	h æ n
@@ -30700,6 +30930,8 @@ handiwork	h æ n d i w ɜː k
 handkerchief	h æ ŋ k ə t ʃ iː f
 handkerchief	h æ ŋ k ə t ʃ ɪ f
 handlanger	h æ n d l æ ŋ ə
+handle	h æ n d l̩
+handle	h ɛ ə n d l̩
 handlebar	h æ n d ə l b ɑː
 handled	h æ n d l̩ d
 handler	h æ n d l ə
@@ -30815,6 +31047,8 @@ hard	h ɑː d
 hardcore	h ɑː ɹ d k ɔː ɹ
 harden	h ɑː d n̩
 hardened	h ɑː d n̩ d
+hardener	h ɑː d n̩ ə
+hardener	h ɑː d ə n ə
 harder	h ɑː d ə
 hardest	h ɑː d ɪ s t
 hardiment	h ɑː d ɪ m ə n t
@@ -30827,7 +31061,7 @@ hardware	h ɑː d w ɛ ə
 hardy	h ɑː d i
 hare	h ɛ ə
 hare	h ɛ ɚ
-hare	h ɛ ɹ
+hare	h ɛː
 harefield	h ɛː f iː l d
 harem	h ɑː ɹ iː m
 harem	h ɛ ə ɹ ə m
@@ -30872,8 +31106,8 @@ harping	h ɑː p ɪ ŋ
 harpoon	h ɑː p uː n
 harpsichord	h ɑː ɹ p s ɪ k ɔː ɹ d
 harpy	h ɑː p i
-harquebus	h ɑ ɹ k w ɨ b ʌ s
-harquebus	h ɑ ɹ k ɨ b ʌ s
+harquebus	h ɑ ɹ k w ɪ b ʌ s
+harquebus	h ɑ ɹ k ɪ b ʌ s
 harrage	h æ ɹ ɪ d͡ʒ
 harras	h æ ɹ ə s
 harridan	h æ ɹ ɪ d ə n
@@ -30929,7 +31163,7 @@ hasn't	h æ z n̩ t
 hasp	h æ s p
 hasp	h ɑː s p
 hassium	h æ s i ə m
-hassle	h æ s l
+hassle	h æ s l̩
 hassock	h a s ə k
 hast	h æ s t
 hasta	h æ s t ə
@@ -31196,7 +31430,7 @@ hebridean	h ɛ b ɹ ɪ d iː ə n
 hebrides	h ɛ b ɹ ə d iː z
 hecate	h ɛ k ə t i
 hecatomb	h ɛ k ə t uː m
-hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɨ k o ʊ ɹ ɔ n
+hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hechsher	h ɛ k ʃ ə ɹ
 heck	h ɛ k
 hecka	h ɛ k ə
@@ -31384,7 +31618,7 @@ hemodynamic	h i m o ʊ d a ɪ n æ m ɪ k
 hemodynamics	h i m o ʊ d a ɪ n æ m ɪ k s
 hemopoietic	h iː m ə p ɔ ɪ ɛ t ɪ k
 hemorrhage	h ɛ m ə ɹ ɪ d͡ʒ
-hemorrhagiparous	h ɛ m ə r ɨ d͡ʒ ɪ p ə r ə s
+hemorrhagiparous	h ɛ m ə r ɪ d͡ʒ ɪ p ə r ə s
 hemorrhoid	h ɛ m ə ɹ ɔ ɪ d
 hemorrhoid	h ɛ m ɹ ɔ ɪ d
 hemosiderosis	h iː m ə ʊ s ɪ d ə ɹ ə ʊ s ɪ s
@@ -31410,7 +31644,7 @@ hendecasyllabic	h ɛ n d ɛ k ə s ɪ l æ b ɪ k
 hendecasyllable	h ɛ n d ɛ k ə s ɪ l ə b l
 hendecasyllable	h ɛ n d ɪ k ə s ɪ l ə b l
 hendiadys	h ɛ n d a ɪ ə d ɪ s
-hendiatris	h ɛ n d a ɪ ə t ɹ ɨ s
+hendiatris	h ɛ n d a ɪ ə t ɹ ɪ s
 hendon	h ɛ n d ə n
 henge	h ɛ n d͡ʒ
 henna	h ɛ n ə
@@ -31502,7 +31736,7 @@ heritable	h ɛ ɹ ɪ t ə b l̩
 heritage	h ɛ ɹ ɪ t ɪ d͡ʒ
 herman	h ɜː m ə n
 hermaphroditus	h ɚ m æ f ɹ ə d a ɪ t ə s
-hermeneutical	h ɝ m ə n j uː t ɨ k ə l
+hermeneutical	h ɝ m ə n j uː t ɪ k ə l
 hermeneutics	h ɜː ɹ m ə n j uː t ɪ k s
 hermetic	h ə ɹ m ɛ t ɪ k
 hermeticism	h əː m ɛ t ɪ s ɪ z m̩
@@ -31551,6 +31785,7 @@ hertz	h ɜː t s
 herzegovina	h ɛ ə ɹ t s ə ɡ o ʊ v ɪ n ə
 herzegovina	h ɜ ɹ t s ə ɡ o ʊ v iː n ə
 hes	h iː z
+hes	h ɛ s
 hes	h ɛ z
 hesiod	h iː s i ə d
 hesiod	h ɛ s i ə d
@@ -31600,7 +31835,7 @@ heterophone	h ɛ t ə ɹ ə ʊ f ə ʊ n
 heterophony	h ɛ t ə ɹ ɒ f ə n i
 heteroradical	h ɛ t ɜ ɹ ə ɹ æ d ɪ k ə l
 heterorganic	h ɛ t ə ɹ ɔː ɹ ɡ æ n ɪ k
-heteroscedasticity	h ɛ t ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
+heteroscedasticity	h ɛ t ə ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
 heterosexual	h ɛ t ə ɹ ə s ɛ k ʃ u ə l
 heterosexual	h ɛ t ɹ ə s ɛ k ʃ u ə l
 heterotroph	h ɛ t ə ɹ ə ʊ t ɹ ɒ f
@@ -31623,11 +31858,11 @@ hew	h j uː
 hewed	h j uː d
 hewing	h j uː ɪ ŋ
 hewings	h j uː ɪ ŋ z
-hewitt	h j uː ɨ t
+hewitt	h j uː ɪ t
 hewn	h j uː n
 hews	h j uː z
 hex	h ɛ k s
-hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɨ k o ʊ ɹ ɔ n
+hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hexad	h ɛ k s æ d
 hexadecile	h ɛ k s ə d ɛ s a ɪ ɫ
 hexadecimal	h ɛ k s ə d ɛ s ɪ m ə l
@@ -31922,6 +32157,8 @@ hitchy	h ɪ t͡ʃ i
 hithe	h ʌ ɪ ð
 hither	h ɪ ð ə
 hitherto	h ɪ ð ə t uː
+hitman	h ɪ t m æː n
+hitman	h ɪ t m ə n
 hits	h ɪ t s
 hitter	h ɪ t ə ɹ
 hitting	h ɪ t ɪ ŋ
@@ -32000,6 +32237,7 @@ hogshead	h ɒ ɡ z h ɛ d
 hogwarts	h ɒ ɡ w ɔː t s
 hogwash	h ɒ ɡ w ɒ ʃ
 hohenzollern	h ə ʊ ə n z ɒ l ə n
+hohhot	h o ʊ h ɒ t
 hoik	h ɔ ɪ k
 hoise	h ɔ ɪ z
 hoisin	h ɔ ɪ s ɪ n
@@ -32107,7 +32345,7 @@ homie	h ə ʊ m i
 homiletical	h ɒ m ɪ l ɛ t ɪ k ə l
 homily	h ɒ m ɪ l i
 homing	h ə ʊ m ɪ ŋ
-hominy	h ɒ m ɨ n i
+hominy	h ɒ m ɪ n i
 hommage	o ʊ m ɑː ʒ
 hommage	ɒ m ɑː ʒ
 homo	h ɒ m ə ʊ
@@ -32193,6 +32431,7 @@ honeymoon	h ʌ n i m uː n
 honeymooner	h ʌ n i m u n ə
 honeys	h ʌ n i z
 honeysuckle	h ʌ n ɪ s ʌ k ə l
+honfidence	h ʌ n f ɪ d ə n s
 hongbao	h ɒ ŋ b a ʊ
 hongi	h ɒ ŋ i
 hongkong	h ɒ ŋ k ɒ ŋ
@@ -32210,6 +32449,7 @@ honor	ɒ n ə
 honorable	ɒ n ə ɹ ə b l̩
 honorable	ɒ n ɹ ə b l̩
 honorarium	ɒ n ə ɹ ɛ ɹ i ə m
+honoree	ɒ n ə iː
 honorific	ɒ n ə ɹ ɪ f ɪ k
 honorificabilitudinitatibus	ɒ n ə ɹ ɪ f ɪ k ə b ɪ l ɪ t j uː d ɪ n ɪ t e ɪ t ɪ b ə s
 honorificabilitudinity	h ɒ n ɒ ɹ ɪ f ɪ k ə b ɪ l ɪ t j uː d ɪ n ɪ t ɪ
@@ -32238,6 +32478,7 @@ hoofing	h ʊ f ɪ ŋ
 hoofy	h uː f i
 hook	h ʊ k
 hookah	h ʊ k ə
+hookaroon	h ʊ k ə ɹ uː n
 hooked	h ʊ k t
 hooker	h ʊ k ə ɹ
 hooking	h ʊ k ɪ ŋ
@@ -32359,8 +32600,6 @@ horsemen	h ɔː s m ə n
 horsepower	h ɔː s p a ʊ ə
 horseradish	h ɔː s ɹ æ d ɪ ʃ
 horseradished	h ɔː s ɹ æ d ɪ ʃ t
-horses	h ɔ r s ə z
-horses	h ɔ r s ɪ z
 horseshoe	h ɔː s ʃ uː
 horseshoe	h ɔː ʃ uː
 horsetail	h ɔː ɹ s t e ɪ l
@@ -32481,6 +32720,7 @@ hoveller	h ɒ v ə l ə ɹ
 hoven	h o ʊ v ə n
 hoven	h uː v ə n
 hover	h ɒ v ə
+hover	h ʌ v ə
 hoverboard	h ɒ v ə b ɔ ɹ d
 hovercraft	h ɒ v ə k ɹ æ f t
 hovercraft	h ɒ v ə k ɹ ɑː f t
@@ -32665,7 +32905,6 @@ humpback	h ʌ m p b æ k
 humped	h ʌ m p t
 humper	h ʌ m p ə
 humph	h ə m f
-humph	h ʌ m f
 humphrey	h ʌ m f ɹ i
 humping	h ʌ m p ɪ ŋ
 humpings	h ʌ m p ɪ ŋ z
@@ -32805,7 +33044,7 @@ hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ i ə
 hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ ə
 hydrant	h a ɪ d ɹ ə n t
 hydrargyron	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ɒ n
-hydrargyrum	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ə m
+hydrargyrum	h a ɪ d ɹ ɑː ɹ d͡ʒ ɪ ɹ ə m
 hydrate	h a ɪ d ɹ e ɪ t
 hydraulic	h a ɪ d ɹ ɒ l ɪ k
 hydraulicking	h ʌ ɪ d ɹ ɒ l ɪ k ɪ ŋ
@@ -32837,6 +33076,7 @@ hydroponic	h ʌ ɪ d ɹ ə p ɒ n ɪ k
 hydroponics	h a ɪ d ɹ ə ʊ p ɒ n ɪ k s
 hydropsy	h a ɪ d ɹ ɒ p s i
 hydroptic	h a ɪ d ɹ ɒ p t ɪ k
+hydroquinone	h a ɪ d ɹ ə k w ɪ n ə ʊ n
 hydrostatic	h a ɪ d ɹ ə ʊ s t æ t ɪ k
 hydrovolcanic	h a ɪ d ɹ ə v ɒ l k æ n ɪ k
 hydroxamate	h a ɪ d ɹ ɒ k s ə m e ɪ t
@@ -32878,6 +33118,7 @@ hymenopteran	h ʌ ɪ m ɪ n ɒ p t ə ɹ ə n
 hymie	h a ɪ m i
 hymn	h ɪ m
 hymnal	h ɪ m n ə l
+hymnic	h ɪ m n ɪ k
 hymnody	h ɪ m n ə d i
 hyoid	h a ɪ ɔ ɪ d
 hyoidal	h a ɪ ɔ ɪ d ə l
@@ -32936,6 +33177,7 @@ hypermyoglobinemia	h a ɪ p ə m a ɪ ə ʊ ɡ l ə ʊ b ɪ n iː m ɪ ə
 hypernatremia	h a ɪ p ə n ə t ɹ iː m i ə
 hypernatremic	h a ɪ p ə n ə t ɹ iː m ɪ k
 hypernym	h a ɪ p ə n ɪ m
+hyperon	h a ɪ p ə ɹ ɒ n
 hyperoodon	h a ɪ p ə ɹ ə ʊ ə d ɒ n
 hyperparasite	h a ɪ p ə p æ ɹ ə s a ɪ t
 hyperplasia	h a ɪ p ɚ p l e ɪ ʒ ə
@@ -32969,9 +33211,11 @@ hyphenation	h a ɪ f ə n e ɪ ʃ ə n
 hyphy	h a ɪ f iː
 hyping	h a ɪ p ɪ ŋ
 hypnagogic	h ɪ p n ə ɡ ɒ d ʒ ɪ k
+hypnic	h ɪ p n ɪ k
 hypnos	h ɪ p n o ʊ s
 hypnos	h ɪ p n ɒ s
 hypnotic	h ɪ p n ɒ t ɪ k
+hypnotism	h ɪ p n ə t ɪ z ə m
 hypnotist	h ɪ p n ə t ɪ s t
 hypnotize	h ɪ p n ə t a ɪ̯ z
 hypo	h a ɪ p ə ʊ
@@ -32995,6 +33239,7 @@ hypogeum	h ʌ ɪ p ə d͡ʒ iː ə m
 hypoglossal	h ʌ ɪ p ə ʊ ɡ l ɒ s l̩
 hypoglossal	h ʌ ɪ p ə ʊ ɡ l ɒ s ə l
 hypoglycemic	h a ɪ p ə ʊ ɡ l a ɪ s iː m ɪ k
+hypohalous	h a ɪ p ə ʊ h e ɪ l ə s
 hyponatremia	h ʌ ɪ p ə ʊ n ə t ɹ iː m i ə
 hyponym	h a ɪ p ə n ɪ m
 hyponym	h a ɪ p ə ʊ n ɪ m
@@ -33022,6 +33267,7 @@ hypotrichosis	h a ɪ p ə ʊ t ɹ a ɪ k ə ʊ s ɪ s
 hypotrochoid	h a ɪ p ə ʊ t ɹ ə ʊ k ɔ ɪ d
 hypsipyle	h ɪ p s ɪ p ɪ l iː
 hypsometry	h ɪ p s ɒ m ə t ɹ i
+hypural	h a ɪ p j ʊ ə ɹ ə l
 hyraceum	h a ɪ r e ɪ s i ə m
 hyrax	h a ɪ ɹ æ k s
 hyssop	h ɪ s ə p
@@ -33111,7 +33357,7 @@ ichnology	ɪ k n ɒ l ə d͡ʒ ɪ
 ichnusaite	ɪ k n u s ə a ɪ t
 ichor	a ɪ k ɔː
 ichor	ɪ k ə
-ichthyic	ɪ k θ iː ɨ k
+ichthyic	ɪ k θ iː ɪ k
 ichthyology	ɪ k θ i ɒ l ə d͡ʒ i
 ichthyonym	ɪ k θ i ə n ɪ m
 ichthyosaur	ɪ k θ i ə s ɔː ɹ
@@ -33138,7 +33384,7 @@ icosahedra	a ɪ k ɒ s ə h iː d ɹ ə
 icosahedron	a ɪ k o ʊ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɒ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɔ s ə h iː d ɹ ə n
-icositetrachoron	a ɪ k o ʊ s ɨ t ɛ t ɹ ə k o ʊ ɹ ɔ n
+icositetrachoron	a ɪ k o ʊ s ɪ t ɛ t ɹ ə k o ʊ ɹ ɔ n
 icq	a ɪ s iː k j uː
 ictus	ɪ k t uː s
 ictus	ɪ k t ə s
@@ -33169,6 +33415,7 @@ ident	a ɪ d ɛ n t
 identic	a ɪ d ɛ n t ɪ k
 identical	a ɪ d ɛ n t ɪ k l̩
 identical	ɪ d ɛ n t ɪ k l̩
+identically	a ɪ d ɛ n t ɪ k ə l i
 identification	a ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identification	ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identified	a ɪ d ɛ n t ɪ f a ɪ d
@@ -33215,6 +33462,7 @@ idioticon	ɪ d ɪ ə ʊ t ɪ k ə n
 idiotropic	ɪ d ɪ ə t ɹ ə ʊ p ɪ k
 idiotropic	ɪ d ɪ ə ʊ t ɹ ɒ p ɪ k
 idiots	ɪ d iː ə t s
+idjit	ɪ d ʒ ɪ t
 idle	a ɪ d ə l
 idleness	a ɪ d ə l n ə s
 idlesse	a ɪ d l ə s
@@ -33242,6 +33490,7 @@ ifrit	ɪ f ɹ iː t
 ifs	ɪ f s
 iftar	ɪ f t ɑː ɹ
 igbo	iː b ə ʊ
+ight	a ɪ t
 igloo	ɪ ɡ l uː
 ignatius	ɪ ɡ n e ɪ ʃ ə s
 igneous	ɪ ɡ n i ə s
@@ -33389,6 +33638,7 @@ imbue	ɪ m b j uː
 imburse	ɪ m b əː s
 img	ɪ m ɪ d͡ʒ
 imide	a ɪ m a ɪ d
+imine	ɪ m iː n
 imipramine	ɪ m ɪ p ɹ ə m iː n
 immaculate	ɪ m æ k j ə l ɪ t
 immanant	ɪ m ə n ə n t
@@ -33400,6 +33650,7 @@ immarcescible	ɪ m ɑː ɹ s ɛ s ɪ b ə l
 immature	ɪ m ə t j ʊ ə ɹ
 immature	ɪ m ə t͡ʃ ə ɹ
 immature	ɪ m ə t͡ʃ ʊ ə ɹ
+immaturely	ɪ m ə t j ʊ ə ɹ l i
 immaturity	ɪ m ə t͡ʃ ʊ ɹ ɪ t i
 immeability	ɪ m i ə b ɪ l ɪ t i
 immeasurability	ɪ m ɛ ʒ ə ɹ ə b ɪ l ə t i
@@ -33462,6 +33713,7 @@ impactful	ɪ m p æ k t f ə l
 impaction	ɪ m p æ k ʃ ə n
 impactor	ɪ m p æ k t ə
 impair	ɪ m p ɛ ə
+impairment	ɪ m p ɛ ə ɹ m ə n t
 impala	ɪ m p ɑː l ə
 impale	ɪ m p e ɪ l
 impaled	ɪ m p e ɪ l d
@@ -33561,6 +33813,7 @@ implied	ɪ m p l a ɪ d
 implies	ɪ m p l a ɪ z
 implike	ɪ m p l a ɪ k
 implore	ɪ m p l ɔː
+implosion	ɪ m p l ə ʊ ʒ ə n
 imply	ɪ m p l a ɪ
 impolite	ɪ m p ə l a ɪ t
 impolitic	ɪ m p ɒ l ɪ t ɪ k
@@ -33955,6 +34208,7 @@ indirection	ɪ n d ɪ ɹ ɛ k ʃ ə n
 indirectly	ɪ n d a ɪ ɹ ɛ k t l i
 indirectly	ɪ n d ɪ ɹ ɛ k t l i
 indiscovery	ɪ n d ɪ s k ʌ v ə ɹ i
+indiscretion	ɪ n d ɪ s k ɹ ɛ ʃ ə n
 indiscriminate	ɪ n d ɪ s k ɹ ɪ m ɪ n ə t
 indispensable	ɪ n d ɪ s p ɛ n s ə b ə l
 indisputable	ɪ n d ɪ s p j uː t ə b ə ɫ
@@ -34064,6 +34318,7 @@ inexplicable	ɪ n ɪ k s p l ɪ k ə b l̩
 inexpugnable	ɪ n ɛ k s p ʌ ɡ n ə b ə l
 inexpugnable	ɪ n ɪ k s p ʌ ɡ n ə b ə l
 infallible	ɪ n f æ l ɪ b l̩
+infame	ɪ n f e ɪ m
 infamous	ɪ n f ə m ə s
 infamy	ɪ n f ə m i
 infancy	ɪ n f ə n s i
@@ -34099,7 +34354,6 @@ infibulation	ɪ n f ɪ b j ʊ l e ɪ ʃ ə n
 infidel	ɪ n f ə d l̩
 infidel	ɪ n f ə d ɛ l
 infidelity	ɪ n f ɪ d ɛ l ɪ t i
-infidelophobia	ɪ n f ə d ɛ l ə f ə ʊ b i ə
 infiltrate	ɪ n f ɪ l t ɹ e ɪ t
 infiltration	ɪ n f ɪ l t ɹ e ɪ ʃ ə n
 infiltrationism	ɪ n f ɪ l t ɹ e ɪ ʃ ə n ɪ z m̩
@@ -34197,6 +34451,7 @@ ingest	ɪ n d͡ʒ ɛ s t
 ingestion	ɪ n d͡ʒ ɛ s t͡ʃ ə n
 ingle	ɪ ŋ ɡ l̩
 ingle	ɪ ŋ ɡ ə l
+inglenook	ɪ ŋ ɡ ə l n ʊ k
 inglorious	ɪ n ɡ l o ʊ ɹ i ə s
 inglorious	ɪ n ɡ l ɔ ɹ i ə s
 ingot	ɪ ŋ ɡ ə t
@@ -34211,6 +34466,7 @@ ingredient	ɪ n ɡ ɹ iː d i ə n t
 ingression	ɪ n ɡ ɹ ɛ ʃ ə n
 ingrew	ɪ n ɡ r uː
 ingrow	ɪ n ɡ ɹ ə ʊ
+ingrown	ɪ n ɡ ɹ ə ʊ n
 ingrowth	ɪ n ɡ r ə ʊ θ
 inguinal	ɪ ŋ ɡ w ɪ n ə l
 ingurgitate	ɪ n ɡ ɜː d ʒ ɪ t e ɪ t
@@ -34225,13 +34481,17 @@ inhabitiveness	ɪ n h æ b ɪ t ɪ v n ə s
 inhalation	ɪ n h ə l e ɪ ʃ ə n
 inhere	ɪ n h ɪ ə
 inherence	ɪ n h ɪ ə ɹ ə n s
+inherent	ɪ n h ɛ ɹ ə n t
+inherent	ɪ n h ɪ ə ɹ ə n t
 inherit	ɪ n h ɛ ɹ ɪ t
 inheritance	ɪ n h ɛ ɹ ə t ə n s
 inherited	ɪ n h ɛ ɹ ɪ t ɪ d
 inhiation	ɪ n h a ɪ e ɪ ʃ ə n
+inhibit	ɪ n h ɪ b ɪ t
 inhibition	ɪ n h ɪ b ɪ ʃ ə n
 inhibition	ɪ n ɪ b ɪ ʃ ə n
 inhofe	ɪ n h o ʊ f
+inhospitable	ɪ n h ɒ s p ɪ t ə b ə l
 inhuman	ɪ n h j uː m ə n
 inhumane	ɪ n h j uː m e ɪ n
 inhumanly	ɪ n h j uː m ə n l i
@@ -34260,10 +34520,11 @@ injudiciously	ɪ n d͡ʒ ʊ d ɪ ʃ ə s l ɪ
 injunction	ɪ n d͡ʒ ʌ n k ʃ ə n
 injure	ɪ n d ʒ ə
 injured	ɪ n d ʒ ə d
+injuria	ɪ n d ʒ ʊ ə ɹ i ə
 injurious	ɪ n d ʒ ɔː ɹ ɪ ə s
 injurious	ɪ n d ʒ ʊ ə ɹ ɪ ə s
-injury	ɪ n d ʒ ə ɹ i
-injury	ɪ n d ʒ ɹ i
+injury	ɪ n d͡ʒ ə ɹ i
+injury	ɪ n d͡ʒ ɹ i
 ink	ɪ ŋ k
 inker	ɪ ŋ k ə ɹ
 inkhorn	ɪ ŋ k h ɔː ɹ n
@@ -34306,32 +34567,42 @@ innovation	ɪ n ə v e ɪ ʃ ə n
 innovative	ɪ n n ɒ v ə t ɪ v
 innovative	ɪ n ə v ə t ɪ v
 innovative	ɪ n ə ʊ v ə t ɪ v
+innovator	ɪ n ə v e ɪ t ə ɹ
 innovent	ɪ n ə v ɛ n t
 innovented	ɪ n ə v ɛ n t ɪ d
 innovention	ɪ n ə v ɛ n ʃ ə n
 innoventor	ɪ n ə v ɛ n t ə
 inns	ɪ n z
 innuendis	ɪ n j uː ɛ n d iː s
+innuendo	ɪ n j u ɛ n d ə ʊ
 innumerable	ɪ n j uː m ə ɹ ə b ə l
 innumerous	ɪ n n j u m ɝ ə s
+inoculate	ɪ n ɒ k j u l e ɪ t
 inoculation	ɪ n ɒ k j ʊ l e ɪ ʃ ə n
 inoculent	ɪ n ɒ k j ʊ l ə n t
+inodiate	ɪ n ə ʊ d i e ɪ t
 inoppugnable	ɪ n ɘ p ʌ ɡ n ə b ɘ l
 inoptimal	ɪ n ɒ p t ɪ m ə l
+inordinate	ɪ n ɔː d ɪ n ə t
+inorganic	ɪ n ɔː ɡ æ n ɪ k
 inorganity	ɪ n ɔː ɹ ɡ æ n ɪ t i
 inosculate	ɪ n ɒ s k j ʊ l e ɪ t
 inosite	ɪ n ə s ʌ ɪ t
+inositol	ʌ ɪ n ə ʊ s ɪ t ɒ l
 inotropic	ɪ n ə t ɹ ɒ p ɪ k
 inotropic	ɪ n ə t ɹ ə ʊ p ɪ k
 inpat	ɪ n p æ t
+input	ɪ n p ʊ t
 inquest	ɪ ŋ k w ɛ s t
 inquiet	ɪ ŋ k w a ɪ ə t
 inquiline	ɪ ŋ k w ɪ l a ɪ n
 inquinate	ɪ n k w ɪ n e ɪ t
+inquiration	ɪ ŋ k w ɪ ɹ e ɪ ʃ ə n
 inquire	ɪ n k w a ɪ ə
 inquired	ɪ n k w a ɪ ə d
+inquirer	ɪ n k w a ɪ ə ɹ ə ɹ
 inquiries	ɪ n k w a ɪ ə ɹ i z
-inquiry	ɪ n k w a ɪ ə ɹ i
+inquiring	ɪ n k w a ɪ ə ɹ ɪ ŋ
 inquisition	ɪ ŋ k w ɪ z ɪ ʃ ə n
 inquisitive	ɪ ŋ k w ɪ z ə t ɪ v
 inroad	ɪ n ɹ ə ʊ d
@@ -34352,20 +34623,26 @@ insect	ɪ n s ɛ k t
 insectivore	ɪ n s ɛ k t ə v ɔː
 insectivorous	ɪ n s ɛ k t ɪ v ə ɹ ə s
 insects	ɪ n s ɛ k t s
+insecure	ɪ n s ə k j ɔː ɹ
+insecure	ɪ n s ə k j ʊ ə ɹ
 inselberg	ɪ n s ə l b ɜː ɡ
 inseminate	ɪ n s ɛ m ɪ n e ɪ t
+insensate	ɪ n s ɛ n s ə t
 insensible	ɪ n s ɛ n s ɪ b l̩
 inseparable	i n s ɛ p ə ɹ ə b l
 insert	ɪ n s ɜː t
 inserted	ɪ n s ɜː t ɪ d
 insession	ɪ n s ɛ ʃ ə n
+insessorial	ɪ n s ɛ s ɔː ɹ ɪ ə l
 inset	ɪ n s ɛ t
+inship	i n ʃ i p
 inside	ɪ n s a ɪ d
 insides	ɪ n s a ɪ d z
 insidious	ɪ n s ɪ d i ə s
 insidiously	ɪ n s ɪ d i ə s l i
 insight	ɪ n s a ɪ t
 insightful	ɪ n s a ɪ t f ə l
+insignia	ɪ n s ɪ ɡ n i ə
 insignificant	ɪ n s ɪ ɡ n ɪ f ɪ k ə n t
 insinuate	ɪ n s ɪ n j u e ɪ t
 insinuation	ɪ n s ɪ n j u e ɪ ʃ ə n
@@ -34373,8 +34650,10 @@ insipid	ɪ n s ɪ p ɪ d
 insipience	ɪ n s ɪ p i ə n s
 insist	ɪ n s ɪ s t
 insisted	ɪ n s ɪ s t ɪ d
+insistence	ɪ n s ɪ s t ə n s
 insistent	ɪ n s ɪ s t ə n t
 insisting	ɪ n s ɪ s t ɪ ŋ
+insists	ɪ n s ɪ s t s
 insofar	ɪ n s ə ʊ f ɑː ɹ
 insole	ɪ n s ə ʊ l
 insolence	ɪ n s ə l ə n s
@@ -34392,11 +34671,13 @@ inspect	ɪ n s p ɛ k t
 inspection	ɪ n s p ɛ k ʃ ə n
 inspector	ɪ n s p ɛ k t ə
 inspiration	ɪ n s p ə ɹ e ɪ ʃ ə n
+inspirational	ɪ n s p ə ɹ e ɪ ʃ ə n ə l
 inspire	ɪ n s p a ɪ ə ɹ
 inspired	ɪ n s p a ɪ ə d
 inspiring	ɪ n s p a ɪ ə ɹ ɪ ŋ
 inspissate	ɪ n s p ɪ s e ɪ t
 inspo	ɪ n s p ə ʊ
+insta	ɪ n s t ə
 instadeath	ɪ n s t ə d ɛ θ
 instagram	ɪ n s t ə ɡ ɹ æ m
 instagrammable	ɪ n s t ə ɡ r æ m ə b ə l
@@ -34412,7 +34693,9 @@ instantaneous	ɪ n s t ə n t e ɪ n i ə s
 instanter	ɪ n s t a n t ə
 instanter	ɪ n s t æ n t ə
 instantial	ɪ n s t æ n ʃ ə l
+instantially	ɪ n s t æ n ʃ ə l i
 instantiate	ɪ n s t æ n ʃ i e ɪ t
+instantiation	ɪ n s t æ n ʃ i e ɪ ʃ ə n
 instantly	ɪ n s t ə n t l i
 instar	ɪ n s t ɑː
 instate	ɪ n s t e ɪ t
@@ -34425,6 +34708,7 @@ instill	ɪ n s t ɪ l
 instinct	ɪ n s t ɪ ŋ k t
 instinctive	ɪ n s t ɪ ŋ k t ɪ v
 instinctively	ɪ n s t ɪ ŋ k t ɪ v l i
+instincts	ɪ n s t ɪ ŋ k t s
 instinctual	ɪ n s t ɪ ŋ k t j uː ə l
 instinctual	ɪ n s t ɪ ŋ k t͡ʃ uː ə l
 instinctual	ɪ n s t ɪ ŋ k t͡ʃ ə l
@@ -34489,9 +34773,10 @@ insusurration	ɪ n s uː s ə ɹ e ɪ ʃ ə n
 int'resting	ɪ n t ɹ ɛ s t ɪ ŋ
 intact	ɪ n t æ k t
 intaglio	ɪ n t æ l j ə ʊ
+intaglio	ɪ n t ɑ l i ə ʊ
 intaglio	ɪ n t ɑ l j ə ʊ
 intake	ɪ n t e ɪ k
-intangible	ɪ n t a n d ʒ ɪ b l
+intangible	ɪ n t æ n d͡ʒ ɪ b ə l
 intarweb	ɪ n t ɑ ɚ w ɛ b
 intarweb	ɪ n t ɑ ɹ w ɛ b
 intarweb	ɪ n t ɑː w ɛ b
@@ -34518,6 +34803,8 @@ intelligence	ɪ n t ɛ l ɪ d͡ʒ ə n s
 intelligent	ɪ n t ɛ l ɪ d͡ʒ ə n t
 intelligentsia	ɪ n t ɛ l ɪ d͡ʒ ɛ n t s ɪ ə
 intelligentsia	ɪ n t ɛ l ɪ ɡ ɛ n t s ɪ ə
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ə t i
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ɪ t i
 intemperance	ɪ n t ɛ m p ɛ ɹ ə n s
 intempestive	ɪ n t ɛ m p ɛ s t ɪ v
 intempestivity	ɪ n t ɛ m p ɛ s t ɪ v ɪ t ɪ
@@ -34537,7 +34824,7 @@ intention	ɪ n t ɛ n ʃ ə n
 intentional	ɪ n t ɛ n ʃ ə n ə l
 intentions	ɪ n t ɛ n ʃ ə n z
 intentive	ɪ n t ɛ n t ɪ v
-intentively	ɨ n t ɛ n t ɪ v l i
+intentively	ɪ n t ɛ n t ɪ v l i
 intently	ɪ n t ɛ n t l i
 inter	ɪ n t ɜː ɹ
 interabled	ɪ n t ɚ e ɪ b l̩ d
@@ -34547,6 +34834,7 @@ interactive	ɪ n t ə ɹ æ k t ɪ v
 interactor	ɪ n t ə ɹ æ k t ə
 interacts	ɪ n t ə ɹ æ k t s
 interagency	ɪ n t ə ɹ e ɪ d͡ʒ ə n s i
+interaxillary	ɪ n t ə ɹ æ k s ɪ l ə ɹ i
 interbred	ɪ n t ɚ b ɹ ɛ d
 interbreed	ɪ n t e ɹ b ɹ i d
 intercalate	ɪ n t ə k ə l e ɪ t
@@ -34584,7 +34872,7 @@ interference	ɪ n t ə ɹ f ɪ ə ɹ ə n s
 interfrastically	ɪ n t ɚ f ɹ æ s t ɪ k ʌ l i
 interfulgent	ɪ n t ə f ʌ l d ʒ ə n t
 interim	ɪ n t ə ɹ ɪ m
-interior	ɪ n t ɪ ə ɹ iː ə
+interior	ɪ n t ɪ ə ɹ ɪ ə
 interiorscaper	ɪ n t ɪ ə ɹ ɪ ə ɹ s k e ɪ p ə ɹ
 interisland	ɪ n t ə ɹ a ɪ l ə n d
 interjacence	ɪ n t ə ɹ d͡ʒ e ɪ s ə n s
@@ -34599,6 +34887,7 @@ interlard	ɪ n t ə l ɑː d
 interlingua	ɪ n t ə ɹ l ɪ ŋ ɡ w ə
 interlocutor	ɪ n t ə l ɒ k j ʊ t ə
 interlocutory	ɪ n t ə ɹ l ə k j uː t ə ɹ i
+interloper	ɪ n t ə l ə ʊ̯ p ə
 interlude	ɪ n t ə ɹ l j uː d
 interlude	ɪ n t ə ɹ l uː d
 intermarry	ɪ n t ə ɹ m æ ɹ i
@@ -34643,6 +34932,7 @@ interoperability	ɪ n t ə ɹ ɒ p ə ɹ ə b ɪ l ə t i
 interosseus	ɪ n t ə ɹ ɒ s i ə s
 interpellate	ɪ n t ə ɹ p ɛ l e ɪ t
 interpellate	ɪ n t ɜ ɹ p ə l e ɪ t
+interpetiolar	ɪ n t ə ɹ p ɛ t i ə ʊ l ə ɹ
 interphrasally	ɪ n t ɚ f ɹ e ɪ z ʌ l i
 interphrasic	ɪ n t ɚ f ɹ æ s ɪ k
 interphrastic	ɪ n t ɚ f ɹ æ s t ɪ k
@@ -34672,6 +34962,7 @@ intersectionality	ɪ n t ə s ɛ k ʃ ə n æ l ɪ t i
 intersex	ɪ n t ə s ɛ k s
 interslavic	ɪ n t ɚ s l ɑː v ɪ k
 intersow	ɪ n t ə ɹ s ə ʊ
+interspecial	ɪ n t ə s p iː ʃ i ə l
 interspecific	ɪ n t ə s p ə s ɪ f ɪ k
 intersperse	ɪ n t ə ɹ s p ɜː ɹ s
 interstice	ɪ n t ɜː s t ɪ s
@@ -34840,7 +35131,7 @@ invert	ɪ n v ɜː t
 invertebrate	ɪ n v əː t ɪ b r ə t
 invest	ɪ n v ɛ s t
 invested	ɪ n v ɛ s t ɪ d
-investigation	ɪ n v ɛ s t ə ɡ e ɪ ʃ ə n
+investigation	ɪ n v ɛ s t ɪ ɡ e ɪ ʃ ə n
 investigative	ɪ n v ɛ s t ɪ ɡ e ɪ t ɪ v
 investigative	ɪ n v ɛ s t ɪ ɡ ə t ɪ v
 investment	ɪ n v ɛ s m ə n t
@@ -34854,6 +35145,8 @@ invidious	ɪ n v ɪ d i ə s
 invigilator	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ə ɹ
 invigilatrix	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ɹ ɪ k s
 invigorate	ɪ n v ɪ ɡ ə ɹ e ɪ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə t i
+invincible	ɪ n v ɪ n s ə b ə l
 invincible	ɪ n v ɪ n s ɪ b ə l
 inviolable	ɪ n v a ɪ ə l ə b l̩
 inviolate	ɪ n v a ɪ ə l ə t
@@ -34870,6 +35163,7 @@ inviting	ɪ n v a ɪ t ɪ ŋ
 invocation	ɪ n v o ʊ k e ɪ ʃ ə n
 invoice	ɪ n v ɔ ɪ s
 invoiceability	ɪ n v ɔ ɪ s ə b ɪ l ɪ t i
+invoiceable	ɪ n v ɔ ɪ s ə b l̩
 invoke	ɪ n v ə ʊ k
 involucre	ɪ n v ə l uː k ə ɹ
 involuntarily	ɪ n v ɒ l ə n t ɹ ɪ l i
@@ -34888,6 +35182,7 @@ iodide	ɑ ɪ ə d ɑ ɪ d
 iodochlorhydroxyquin	a ɪ ɒ d ə ʊ k l ɔː ɹ h a ɪ d ɹ ɒ k s ɪ k w ɪ n
 iododeoxyuridine	a ɪ ɒ d ə ʊ d iː ɒ k s i j ʊ ə ɹ ɪ d iː n
 iodophenpropit	a ɪ ɒ d ə ʊ f ɛ n p ɹ ə p ɪ t
+iolo	j ɒ l ə ʊ
 ion	a ɪ o ʊ n
 ion	a ɪ ɒ n
 ion	a ɪ ə n
@@ -34900,6 +35195,7 @@ ionization	a ɪ ə n ɪ z e ɪ ʃ ə n
 ionize	a ɪ ə n a ɪ z
 iopidine	a ɪ ɒ p ɪ d iː n
 iopidine	a ɪ ɒ p ɪ d ɪ n
+iota	a ɪ ə ʊ t ə
 iotation	a ɪ ə ʊ t e ɪ ʃ ə n
 iotize	a ɪ ə t a ɪ z
 ipa	a ɪ p iː e ɪ
@@ -34909,9 +35205,12 @@ iphigenia	ɪ f ɪ d͡ʒ iː n ɪ ə
 iphigenia	ɪ f ɪ d͡ʒ ɪ n a ɪ ə
 ipof	a ɪ p ɒ f
 ipof	ɪ p ɒ f
+iproclozide	a ɪ p ɹ ə ʊ k l ə z a ɪ d
 ipsapirone	ɪ p s ə p a ɪ ɹ ə ʊ n
+ipsative	ɪ p s ə t ɪ v
 ipsedixitism	ɪ p s iː d ɪ k s ɪ t ɪ z ə m
 ipseity	ɪ p s iː ɪ t i
+ipsilateral	ɪ p s ɪ l æ t ə ɹ ə l
 ipswich	ɪ p s w ɪ t͡ʃ
 ipu	iː p uː
 iqaluit	ɪ k æ l ʊ ɪ t
@@ -34936,7 +35235,6 @@ ireland	a ɪ ə ɹ l ə n d
 irenarch	a ɪ ɹ ɪ n ɑː ɹ k
 irene	a ɪ ɹ iː n
 irenic	a ɪ ɹ iː n ɪ k
-irenic	a ɪ ɹ ɛ n ɪ k
 iri	a ɪ ɑː ɹ a ɪ
 iridal	ʌ ɪ ɹ ɪ d ə l
 irides	a ɪ ɹ ɪ d i z
@@ -34964,6 +35262,7 @@ irony	a ɪ ə ɹ ə n i
 iroquois	ɪ ɹ ə k w ɔ ɪ
 iroquois	ɪ ɹ ə k ɔ ɪ
 irp	ɜː ɹ p
+irradicate	ɪ ɹ æ d ɪ k e ɪ t
 irrational	ɪ ɹ æ ʃ ə n ə l
 irrawaddy	ɪ ɹ ə w ɑ d i
 irrealis	ɪ ɹ i æ l ɪ s
@@ -35012,6 +35311,7 @@ irritated	ɪ ɹ ɪ t e ɪ t ɪ d
 irritation	ɪ ɹ ɪ t e ɪ ʃ ə n
 irruent	ɪ ɹ ɪ ʊ ə n t
 irrumation	ɪ ɹ ʊ m e i ʃ ə n
+irtysh	ɪ ə ɹ t ɪ ʃ
 irukandji	ɪ ɹ ə k æ n d͡ʒ i
 irv	ɜː v
 irvine	ɜ ɹ v a ɪ n
@@ -35074,6 +35374,8 @@ isleworth	ʌ ɪ z ə l w ɜː θ
 islington	ɪ z l ɪ ŋ t ə n
 islingtonian	ɪ z l ɪ ŋ t ə ʊ n i ə n
 ism	ɪ z ə m
+ismael	ɪ z m e ɪ l
+ismael	ɪ z m e ɪ ə l
 ismahel	ɪ z m ə h ɛ l
 ismaili	ɪ s m ɑː i l i
 ismaili	ɪ s m ʌ ɪ iː l i
@@ -35124,7 +35426,7 @@ israel	ɪ z ɹ i ə l
 israeli	ɪ z ɹ e ɪ l i
 israelite	ɪ z ɹ e ɪ ə l a ɪ t
 israelite	ɪ z ɹ i ə l a ɪ t
-israelite	ɪ z ɹ ɨ l a ɪ t
+israelite	ɪ z ɹ ɪ l a ɪ t
 isro	ɪ s ɹ ə ʊ
 issue	ɪ s j uː
 issue	ɪ ʃ j uː
@@ -35242,6 +35544,7 @@ jabs	d͡ʒ æ b z
 jacal	h ə k ɑː l
 jacana	d͡ʒ æ k ɑː n ə
 jace	d͡ʒ e ɪ s
+jacent	d ʒ e ɪ s ə n t
 jacinda	d͡ʒ ə s ɪ n d ə
 jacinth	d͡ʒ e ɪ s ɪ n θ
 jacinth	d͡ʒ æ s ɪ n θ
@@ -35276,6 +35579,7 @@ jacobite	d͡ʒ æ k ə b a ɪ t
 jacobs	d͡ʒ e ɪ k ə b z
 jacobson	d͡ʒ e ɪ k ə b s ə n
 jaconet	d͡ʒ æ k ə n ɪ t
+jacqueline	d ʒ æ k ə l ɪ n
 jacquerie	ʒ a k ə ɹ i
 jacquerie	ʒ a k ɹ i
 jacques	d͡ʒ æ k
@@ -35427,6 +35731,7 @@ javan	d͡ʒ ɑː v ə n
 javanese	d ʒ ɑː v ə n iː z
 javanka	d͡ʒ ə v ɑː ŋ k ə
 javans	d͡ʒ ɑː v ə n z
+javascript	d ʒ ɑː v ə s k ɹ ɪ p t
 javel	d͡ʒ æ v ə l
 javelin	d͡ʒ æ v ə l ɪ n
 javelina	h a v ə l iː n ə
@@ -35484,7 +35789,7 @@ jeffrey	d͡ʒ ɛ f ɹ i
 jegging	d͡ʒ ɛ ɡ ɪ ŋ
 jeggings	d͡ʒ ɛ ɡ ɪ ŋ z
 jehovah	d͡ʒ ə h o ʊ v ə
-jehovist	d͡ʒ ə h o ʊ v ɨ s t
+jehovist	d͡ʒ ə h o ʊ v ɪ s t
 jehovistic	d͡ʒ i h o ʊ v ɪ s t ɪ k
 jehovistic	d͡ʒ ə h o ʊ v ɪ s t ɪ k
 jejune	d͡ʒ i d ʒ uː n
@@ -35520,6 +35825,7 @@ jeopard	d͡ʒ ɛ p ə ɹ d
 jeopardize	d͡ʒ ɛ p ə d ʌ ɪ z
 jeopardy	d͡ʒ ɛ p ə d i
 jepson	d͡ʒ ɛ p s ə n
+jerboa	d ʒ ɜː ɹ b ə ʊ ə
 jeremiad	d͡ʒ ɛ ɹ ə m a ɪ ə d
 jeremiah	d͡ʒ ɛ ɹ ə m a ɪ ə
 jeremias	d͡ʒ ɛ ɹ ə m a ɪ ə s
@@ -35614,6 +35920,8 @@ jiangshi	d͡ʒ i ɑ ŋ ʃ iː
 jiangwan	d͡ʒ ɑ ŋ w ɑ n
 jiangyin	d͡ʒ ɑ ŋ j ɪ n
 jianzhi	d͡ʒ i æ n d͡ʒ iː
+jianzi	d͡ʒ i æ n d z i
+jianzi	d͡ʒ i æ n d z ə
 jiaozi	d͡ʒ j a ʊ d͡ʒ i
 jib	d͡ʒ ɪ b
 jibber	d͡ʒ ɪ b ə ɹ
@@ -35648,15 +35956,22 @@ jildy	d͡ʒ ɪ l d i
 jilin	d͡ʒ iː l ɪ n
 jill	d͡ʒ ɪ l
 jillion	j ɪ l j ə n
+jilt	d͡ʒ ɪ l t
 jilted	d͡ʒ ɪ l t ɪ d
+jilter	d͡ʒ ɪ l t ə
 jilting	d͡ʒ ɪ l t ɪ ŋ
 jiltings	d͡ʒ ɪ l t ɪ ŋ z
+jilts	d͡ʒ ɪ l t s
 jim	d͡ʒ ɪ m
 jimbo	d͡ʒ ɪ m b ə ʊ
+jimmer	d͡ʒ ɪ m ə ɹ
 jimmie	d͡ʒ ɪ m i
 jimmy	d͡ʒ ɪ m i
 jimps	d͡ʒ ɪ m p s
+jin	d͡ʒ ɪ n
 jinan	d͡ʒ iː n ɑː n
+jing'an	d͡ʒ ɪ ŋ æ n
+jing'an	d͡ʒ ɪ ŋ ɑ n
 jingal	d͡ʒ ɪ n ɡ ɔː l
 jingal	d͡ʒ ɪ n ɡ ə l
 jingle	d͡ʒ ɪ ŋ l ɛ
@@ -35665,38 +35980,49 @@ jingle	d͡ʒ ɪ ŋ ɡ l̩
 jingly	d͡ʒ ɪ ŋ ɡ l i
 jingo	d͡ʒ ɪ ŋ ɡ ə ʊ
 jingoish	d ʒ ɪ ŋ ɡ ə ʊ ɪ ʃ
+jingoism	d͡ʒ ɪ ŋ ɡ ə ʊ ɪ z ə m
 jingoistic	d͡ʒ ɪ ŋ ɡ ə ʊ ɪ s t ɪ k
 jingpo	d͡ʒ ɪ ŋ p o ʊ
+jingxin	d͡ʒ ɪ ŋ ʃ iː n
 jingzhe	t͡ʃ i ŋ t͡ʃ ʌ
+jingzhou	d͡ʒ ɪ ŋ d͡ʒ o ʊ
 jinhua	d͡ʒ ɪ n h w ɑː
 jink	d͡ʒ ɪ ŋ k
 jinker	d ʒ ɪ ŋ k ə
 jinks	d͡ʒ ɪ ŋ k s
 jinn	d͡ʒ ɪ n
 jinricksha	d͡ʒ ɪ n ɹ ɪ k ʃ ə
+jinrickshaw	d͡ʒ ɪ n ɹ ɪ k ʃ ɔː
 jinriksha	d͡ʒ ɪ n ɹ ɪ k ʃ ə
 jinsha	t͡ɕ i n ʃ ɑː
 jint	d͡ʒ a ɪ n t
 jinx	d͡ʒ ɪ ŋ k s
 jipijapa	h i p i h ɑ p ə
 jiqui	h iː k iː
+jirga	d ʒ ɪ ə ɡ ə
 jislaaik	j ɪ s l a ɪ k
+jism	d͡ʒ ɪ z ə m
 jit	d͡ʒ ɪ t
 jitter	d͡ʒ ɪ t ə ɹ
 jitterbug	d͡ʒ ɪ t ə ɹ b ʌ ɡ
+jittery	d͡ʒ ɪ t ɹ i
 jive	d͡ʒ a ɪ v
 jived	d͡ʒ a ɪ v d
 jives	d͡ʒ a ɪ v z
+jiving	d͡ʒ a ɪ v ɪ ŋ
 jizz	d͡ʒ ɪ z
 jnana	d ʒ ə n ɑː n ə
 jo	d͡ʒ ə ʊ
 joab	d͡ʒ ə ʊ æ b
+joachim	d͡ʒ ə ʊ ə k ɪ m
 joan	d͡ʒ ə ʊ n
 joanna	d͡ʒ ə ʊ æ n ə
 joanne	d͡ʒ ə ʊ n
 joanne	d͡ʒ ə ʊ æ n
 joanne	ʒ o ʊ n
 joao	d͡ʒ o ʊ a ʊ
+joaquin	h w ɑ k iː n
+joaquin	w ɑ k iː n
 job	d͡ʒ ɒ b
 job	d͡ʒ ə ʊ b
 jobation	d͡ʒ ə ʊ b e ɪ ʃ ə n
@@ -35730,6 +36056,7 @@ joggle	d͡ʒ ɒ ɡ ə l
 joh	d͡ʒ ə ʊ
 johanna	d͡ʒ ə ʊ h æ n ə
 johanna	d͡ʒ ə ʊ æ n ə
+johannes	d ʒ ə ʊ h æ n ɪ s
 johannesburg	d͡ʒ o ʊ h æ n ɪ s b ɜː r ɡ
 johannine	d͡ʒ ə ʊ h æ n a ɪ n
 johar	d ʒ ə ʊ h ɑː
@@ -35793,6 +36120,7 @@ joss	d ʒ ɒ s
 josser	d͡ʒ ɒ s ə ɹ
 jostle	d͡ʒ ɒ s ə l
 josue	d͡ʒ ɒ s j u iː
+josue	h o ʊ s w e ɪ
 jot	d͡ʒ ɒ t
 jota	h o ʊ t ə
 jotation	d͡ʒ ə ʊ t e ɪ ʃ ə n
@@ -35938,6 +36266,7 @@ jumping	d͡ʒ ʌ m p ɪ ŋ
 jumpings	d͡ʒ ʌ m p ɪ ŋ z
 jumps	d͡ʒ ʌ m p s
 jumpy	d͡ʒ ʌ m p i
+jun	d ʒ ʌ n
 juncate	d͡ʒ ʌ ŋ k ɪ t
 junco	d͡ʒ ʌ ŋ k ə ʊ
 junction	d͡ʒ ʌ ŋ k ʃ ə n
@@ -35968,6 +36297,7 @@ jupe	d͡ʒ uː p
 jupe	ʒ uː p
 jupon	d͡ʒ u p ɒ n
 jura	d͡ʒ ʊ ə ɹ ə
+jural	d ʒ ʊ ə ɹ ə l
 jurat	d͡ʒ ʊ ə ɹ æ t
 jurat	ʒ ʊ ə ɹ æ
 jurator	d͡ʒ ʊ r e ɪ t ə r
@@ -35992,7 +36322,7 @@ justice	d͡ʒ ʌ s t ɪ s
 justiciar	d͡ʒ ʌ s t ɪ s i ɑː ɹ
 justifiability	d͡ʒ ʌ s t ɪ f a ɪ ə b ɪ l ɪ t ɪ
 justification	d͡ʒ ʌ s t ɪ f ɪ k e ɪ ʃ ə n
-justificatory	d͡ʒ ʌ s t ɨ f ə k e ɪ t ə ɹ i
+justificatory	d͡ʒ ʌ s t ɪ f ə k e ɪ t ə ɹ i
 justified	d͡ʒ ʌ s t ɪ f a ɪ d
 justify	d͡ʒ ʌ s t ɪ f a ɪ
 justin	d͡ʒ ʌ s t ɪ n
@@ -36016,6 +36346,7 @@ juxtapose	d͡ʒ ʌ k s t ə p ə ʊ z
 juxtaposit	d͡ʒ ʌ k s t ə p ɒ z ɪ t
 juxtaposition	d͡ʒ ʌ k s t ə p ə z ɪ ʃ ə n
 juxtology	d͡ʒ ʌ k s t ɑ l ə d͡ʒ i
+jwics	d ʒ e ɪ w ɪ k s
 jy	d͡ʒ a ɪ
 jynges	d͡ʒ ɪ n d͡ʒ iː z
 jynges	d͡ʒ ɪ n d͡ʒ ɪ z
@@ -36023,6 +36354,7 @@ jyngine	d͡ʒ ɪ n d͡ʒ a ɪ n
 jynx	d͡ʒ ɪ ŋ k s
 jyothis	d͡ʒ o ʊ t ɪ s
 jäger	j e ɪ ɡ ə
+jägermeister	j e ɪ ɡ ə r m a ɪ s t ə r
 jèrriais	ʒ ɛ ɹ i e ɪ
 jõgeva	j ə ʊ ɡ ɪ v ə
 jõgeva	j ʊ ɡ ɪ v ə
@@ -36094,7 +36426,7 @@ kakistocracy	k a k ɪ s t ɒ k ɹ ə s ɪ
 kakuro	k ɑː k ʊ ə ɹ ə ʊ
 kalamazoo	k æ l ə m ə z uː
 kalanchoe	k æ l ə n k o ʊ ɪ
-kalarippayattu	k a ɭ ə ɾ i pː a j ə tː ɨ
+kalarippayattu	k a ɭ ə ɾ i pː a j ə tː ɪ
 kalashnikov	k ə l æ ʃ n ɪ k ɒ f
 kale	k e ɪ l
 kale	k e ɪ l i
@@ -36136,6 +36468,7 @@ kangchenjunga	k ʌ ŋ t͡ʃ ə n d͡ʒ ʌ ŋ ɡ ə
 kangding	k ɒ ŋ d ɪ ŋ
 kanghui	k ɒ ŋ h w i
 kangling	k æ ŋ ɡ ə l ɪ ŋ ɡ
+kango	k ɑ ŋ ɡ o ʊ
 kangri	k æ ŋ ɡ ɹ i
 kangxi	k ɑ ŋ ʃ iː
 kanigget	k ə n ɪ ɡ ə t
@@ -36222,6 +36555,7 @@ kashered	k æ ʃ ə d
 kashering	k æ ʃ ə ɹ ɪ ŋ
 kashers	k æ ʃ ə z
 kashmiri	k æ ʃ m i ɹ i
+kashrut	k ɑː ʃ ɹ uː t
 kashubian	k ə ʃ uː b ɪ ə n
 kastom	k ɑː s t ɒ m
 kasundi	k ə s ʊ n d i
@@ -36380,33 +36714,46 @@ kerala	k ɛ ɹ ə l ə
 keratin	k ɛ r ə t ɪ n
 keratinization	k ə ɹ æ t ɪ n a ɪ z e ɪ ʃ ə n
 keratinize	k ɛ r ə t n a ɪ z
+keratomileusis	k ɛ ɹ ə t ə ʊ m a ɪ l j uː s ɪ s
 keratophyte	k ɛ ɹ ə t ə ʊ f a ɪ t
+keratosis	k ɛ ɹ ə t ə ʊ s ɪ s
 kerb	k ɜː b
 kerberos	k ɜː b ə ɹ ə s
 kerby	k ɜː b i
 kercher	k ɜː ɹ t͡ʃ ə ɹ
+kerchief	k ɜː t ʃ iː f
+kerchief	k ɜː t ʃ ɪ f
 kerching	k ə t͡ʃ ɪ ŋ
+kereru	k ɛ ɹ ə ɹ uː
 kerf	k ɜː ɹ f
 kerflooey	k ə ɹ f l uː i
 kerfuffle	k ə f ʌ f ə l
 kerikeri	k ɛ ɹ iː k ɛ ɹ iː
 keriorrhea	k ɛ ɹ ɪ ə ɹ iː ə
+kermit	k ɜː m ɪ t
 kern	k ɜː n
 kernahan	k ɜː ɹ n ə h ə n
 kernel	k ɜː n ə l
 kernicterus	k ɜː n ɪ k t ə ɹ ə s
 kerning	k ɜː n ɪ ŋ
 kernow	k ɜː n ə ʊ
+kerosene	k ɛ ɹ ə s iː n
 kerplunk	k ə ɹ p l ʌ ŋ k
+kerr	k ɛ ə
+kerr	k ɜː
 kerry	k ɛ ɹ i
 kers	k ɜː ɹ z
+kersey	k ɜː z i
 kerseymere	k əː z ɪ m ɪ ə
 kershaw	k ə r ʃ ɔː r
 kersley	k ɜː z l i
+kerygma	k ə ɹ ɪ ɡ m ə
 kesar	k e ɪ s ə
 kesar	k e ɪ z ə
 kesteven	k ɛ s t ə v ə n
+kestrel	k ɛ s t ɹ ə l
 keswick	k ɛ z ɪ k
+keszthely	k ɛ s t e ɪ
 ket	k ɛ t
 ketamine	k iː t ə m iː n
 ketamine	k ɛ t ə m ɪ n
@@ -36418,6 +36765,7 @@ ketogenic	k iː t ə ʊ d͡ʒ ɛ n ɪ k
 ketone	k iː t ə ʊ n
 ketosis	k iː t ə ʊ s ɪ s
 kettell	k ɛ t ə l
+kettering	k ɛ t ə ɹ ɪ ŋ
 kettle	k ɛ t ə l
 kev	k ɛ v
 kevaughn	k ə v ɔː n
@@ -36425,6 +36773,7 @@ kevin	k ɛ v ə n
 kevin	k ɛ v ɪ n
 kevlar	k ɛ v l ɑː
 kevorkian	k ɛ v ɔ ɹ k iː ɛ n
+kevvy	k ɛ v i
 kew	k j u ʊ̯
 kew	k j uː
 kewl	k j uː l
@@ -36443,17 +36792,34 @@ keynesianism	k e ɪ n z i ə n ɪ z m̩
 keynesianist	k e ɪ n z i ə n ɪ s t
 keynsham	k e ɪ n ʃ ə m
 keypad	k iː p æ d
+keys	k iː z
 keystone	k iː s t ə ʊ n
 keyword	k iː w ɜː d
 kez	k ɛ z
+khabarovsk	k ɑː b ə ɹ ɒ f s k
 khachapuri	h ɑː t ʃ ə p uː ɹ i
 khachaturian	k ɑː t ʃ ə t ʊ ə ɹ i ə n
+khachkar	h ɑ t͡ʃ k ɑ ɹ
 khadija	x ə d iː d͡ʒ ə
+khaki	k ɑː k i
+khaleesi	k ə l iː s i
 khamenei	k ɑː m ə n e ɪ iː
+khamsin	k æ m s i n
+khamsin	k æ m s ɪ n
 khan	k ɑː n
 khanate	k ɑː n e ɪ t
 khanjar	k a n d͡ʒ ə
 khanji	k ɑː n d͡ʒ i
+khariboli	k a ɹ iː b o ʊ ɫ iː
+kharkiv	h ɑ ɹ k i v
+kharkiv	h ɑ ɹ k ɪ v
+kharkiv	h ɑː k iː v
+kharkiv	h ɑː k ɪ v
+kharkiv	k ɑ ɹ k i v
+kharkiv	k ɑ ɹ k ɪ v
+kharkiv	k ɑː k iː v
+kharkiv	k ɑː k ɪ v
+kharkiv	x ɑː k iː v
 kharkov	k ɑː k ə v
 kharkov	x ɑː k ə v
 khartoum	k ɑː ɹ t uː m
@@ -36462,13 +36828,19 @@ khata	k ɑ t ɑ
 khatyrkite	k ə t ɪ ə ɹ k a ɪ t
 khayyamian	k a ɪ j æ m i ə n
 khayyamian	k a ɪ j ɑː m i ə n
+khazar	k ə z ɑː
 khazi	k ɑː z i
 khediva	k ə d iː v ə
+khedive	k ə d iː v
 khedivial	k ə d ɪ v i ə l
 khene	k ɛː n
+kherson	h ɜː ɹ s ɔː n
+kherson	k ɜː ɹ s ɔː n
+kherson	x ɜː ɹ s ɔː n
 khichdi	k ɪ t͡ʃ d i
 khimar	k ɪ m ɑː ɹ
 khimar	x ɪ m ɑː ɹ
+khitmatgar	k ɪ t m ə t ɡ ɑː
 khiva	k iː v ə
 khmelnytskyi	k ə m e l l n ɪ t s k i
 khmelnytskyi	x ə m e l l n ɪ t s k i
@@ -36480,19 +36852,26 @@ khoisan	k ɔ ɪ s ɑː n
 kholop	k ə l o ʊ p
 khomeini	k ɒ m e ɪ n i
 khomeini	k ə ʊ m e ɪ n i
+khoomei	h o ʊ m e ɪ
+khoomei	k o ʊ m i
+khoomei	k u m i
 khotanese	k ə ʊ t ə n iː z
 khu	k uː
 khud	k ʌ d
+khufi	k uː f i
 khukhrain	k ʊ k ɹ ɛː n
+khula	k uː l ɑː
 khutbah	k ʊ t b ə
 khutor	k uː t ɔː ɹ
 khutor	x uː t ɔː ɹ
 khyber	k a ɪ b ə ɹ
 ki	k iː
+kiai	k iː a ɪ
 kiang	k i æ ŋ
 kiang	k i ɑ ŋ
 kiang	k j æ ŋ
 kiang	k j ɑ ŋ
+kiasi	k ɪ ɑ̃ s îː
 kiasu	k i ɑː s uː
 kibbeh	k ɪ b i
 kibble	k ɪ b ə l
@@ -36535,6 +36914,8 @@ kieselguhr	k iː z ə l ɡ ʊ ə
 kiev	k iː ɛ f
 kiev	k iː ɛ v
 kiev	k iː ɪ v
+kiev	k j ɛ f
+kiev	k j ɛ v
 kievan	k iː ɛ f ə n
 kievan	k iː ɛ v ə n
 kif	k iː f
@@ -36547,30 +36928,42 @@ kikoi	k i k ɔ i
 kikongo	k ɪ k ɒ ŋ ɡ ə ʊ
 kilburn	k ɪ l b əː n
 kildare	k ɪ l d ɛ ə
+kile	k a ɪ l
+kilim	k iː l ɪ m
+kilim	k ɪ l iː m
 kilimanjaro	k ɪ l ə m ə n d͡ʒ ɑ ɹ o ʊ
 kilimanjaro	k ɪ l ɪ m ə n d͡ʒ ɑː ɹ ə ʊ
 kilkenny	k ɪ l k ɛ n i
+kill	k ɪ l
 killable	k ɪ l ə b ə l
+killam	k ɪ l ə m
 killdeer	k ɪ l d ɪ ə
 killed	k ɪ l d
+killer	k ɪ l ə ɹ
 killing	k ɪ l ɪ ŋ
 kills	k ɪ l z
+killurin	k ɪ l ʊ ə ɹ ɪ n
 kilmallock	k ɪ l m æ l ə k
 kiln	k ɪ l n
 kilncadzow	k ɪ l k e ɪ ɡ i
+kilo	k iː l ə ʊ
 kilobase	k ɪ l ə b e ɪ s
+kilogram	k ɪ l ə ɡ ɹ æ m
 kilometer	k ɪ l ɒ m ɪ t ə
 kilometer	k ɪ l ə m iː t ə
 kilometre	k ɪ l ɒ m ɪ t ə
 kilometre	k ɪ l ə m iː t ə
 kilopond	k ɪ l ə p ɒ n d
 kilos	k iː l ə ʊ z
+kilroy	k ɪ l ɹ ɔ ɪ
 kilt	k ɪ l t
 kilter	k ɪ l t ə
 kiltie	k ɪ l t iː
 kilton	k ɪ l t ə n
+kilwinning	k ɪ l w ɪ n ɪ ŋ
 kim	k ɪ m
 kimmy	k ɪ m i
+kimnel	k ɪ m n ə l
 kin	k ɪ n
 kinara	k ɪ n ɑː ɹ ə
 kinase	k a ɪ n e ɪ z
@@ -36598,6 +36991,7 @@ kinematic	k a ɪ n ɪ m æ t ɪ k
 kinematic	k ɪ n ɪ m æ t ɪ k
 kines	k a ɪ n z
 kineses	k a ɪ n z ɪ z
+kinesics	k ɪ n iː s ɪ k s
 kinesiology	k ə n i z i ɔ l ə d͡ʒ ɪ
 kinesis	k ə n iː s ɪ s
 kinesthetic	k ɪ n ɪ s θ ɛ t ɪ k
@@ -36650,9 +37044,9 @@ kippens	k ɪ p ə n z
 kipper	k ɪ p ə ɹ
 kirby	k ɜː b i
 kirghiz	k ɜː ɡ ɪ z
-kiribati	k iː ɹ ɨ b æ s
-kiribati	k iː ɹ ɨ b ɑ s
-kiribati	k iː ɹ ɨ b ɑ t i
+kiribati	k iː ɹ ɪ b æ s
+kiribati	k iː ɹ ɪ b ɑ s
+kiribati	k iː ɹ ɪ b ɑ t i
 kirigami	k ɪ ɹ ɪ ɡ ɑː m ɪ
 kiritimati	k ə ɹ ɪ s m ə s
 kirk	k ɜː k
@@ -36662,6 +37056,7 @@ kirkcudbright	k ə k uː b ɹ i
 kirkheaton	k ə r k h iː t ə n
 kirkwood	k ɝ k w ʊ d
 kirkyard	k əː k j ɑː d
+kirmess	k ɜː ɹ m ə s
 kirpan	k ɪ ə ɹ p ɑː n
 kirsch	k ɜː ɹ ʃ
 kirsch	k ɪ ə ɹ ʃ
@@ -36778,6 +37173,7 @@ knapweed	n æ p w iː d
 knar	n ɑː ɹ
 knarr	n ɔː ɹ
 knarred	n ɑː ɹ d
+knarry	n ɑː ɹ i
 knave	n e ɪ v
 knavery	n e ɪ v ə ɹ i
 knaves	n e ɪ v z
@@ -36850,6 +37246,7 @@ knockout	n ɒ k a ʊ t
 knoll	n ə ʊ l
 knollys	n o ʊ l z
 knook	n ʊ k
+knork	n ɔː k
 knosp	n ɒ s p
 knot	n ɒ t
 knots	n ɒ t s
@@ -36871,6 +37268,7 @@ knuff	n ʌ f
 knur	n ɜː ɹ
 knurl	n ɜː l
 knurly	n ɜː ɹ l i
+knurry	n ɜː ɹ i
 knuth	k ə n uː θ
 knysna	n a ɪ z n ə
 ko	k ə ʊ
@@ -36913,7 +37311,7 @@ kolkata	k ɔː l k ɑː t ə
 kolkhoz	k ə l k ɒ z
 kolkhozy	k ə l k ɒ z ɪ
 kolo	k ə ʊ l ə ʊ
-kolyma	k ə l ɨ m a
+kolyma	k ə l ɪ m a
 kombu	k ɒ m b uː
 komi	k o ʊ m i
 komodo	k ə ʊ m ə ʊ d ə ʊ
@@ -36972,6 +37370,7 @@ kraken	k ɹ e ɪ k ə n
 kraken	k ɹ æ k ə n
 kraken	k ɹ ɑː k ə n
 kramatorsk	k ɹ æ m ə t ɔː s k
+krang	k ɹ æ ŋ
 kratos	k ɹ a t ɒ s
 kraut	k ɹ a ʊ t
 kremlin	k ɹ e m l ɪ n
@@ -37038,6 +37437,7 @@ kurd	k ɜː ɹ d
 kurdish	k ɜː ɹ d ɪ ʃ
 kurgan	k ʊ ə ɡ ɑː n
 kuroshio	k ʊ ə ɹ ə ʊ ʃ iː ə ʊ
+kurow	k uː ɹ a ʊ
 kurt	k ɜː t
 kuru	k ʊ ɹ uː
 kurukh	k ʊ r ʊ x
@@ -37049,26 +37449,35 @@ kutcha	k ʌ t ʃ ə
 kutenai	k uː t ə n e ɪ
 kuvasz	k u v a s
 kuvasz	k u v ɑ s
+kuwait	k j uː w e ɪ t
 kuybyshev	k uː ɪ b ɪ ʃ ɛ v
+kvass	k v ɑː s
 kvell	k v ɛ l
+kvetch	k v ɛ t͡ʃ
 kwaito	k w a ɪ t o ʊ
+kwanza	k w ɑː n z ə
 kwanzaa	k w ɑ n z ə
 kwashiorkor	k w æ ʃ i ɔː k ɔː
 kwashiorkor	k w ɒ ʃ i ɔː k ɔː
+kwedini	k w iː d ɪ n i
 kwok	k w ɔ k
 kyat	k iː ɑː t
 kye	k a ɪ
 kye	k j e ɪ
 kyiv	k iː v
 kyiv	k iː ɪ v
+kyiv	k j ɪ v
 kyivan	k iː ɪ v ə n
 kyke	k a ɪ k
 kyla	k a ɪ l ə
 kyle	k a ɪ l
 kylie	k a ɪ l i
 kylix	k a ɪ l ɪ k s
+kyloe	k ʌ ɪ l ə
 kylym	k ɪ l ɪ m
+kynodesme	k a ɪ n ə ʊ d ɛ z m i
 kyphotone	k a ɪ f ə t ə ʊ n
+kyra	k a ɪ ɹ ə
 kyrgyz	k ɜː ɹ ɡ ɪ z
 kyrgyz	k ɪ ə ɹ ɡ ɪ z
 kyrgyzstan	k ɛː ɹ ɡ ɪ s t ɑː n
@@ -37081,6 +37490,7 @@ kyushu	k j uː ʃ uː
 königsberg	k ɜː n ɪ ɡ z b ɜː ɡ
 kümmelweck	k y m ə l v ɛ k
 kümüx	k y m y ʃ
+künstlerroman	k ʊ n s t l ə ɹ ə ʊ m ɑː n
 kırklareli	k ɝ k l ə ɹ ɛ l i
 l	l
 l	ɛ l
@@ -37203,7 +37613,7 @@ lagerstätte	l ɑː ɡ ə ʃ t ɛ t ə
 laggard	l æ ɡ ə d
 laggy	l æ ɡ i
 lagid	l æ d͡ʒ ɪ d
-lagids	l æ d͡ʒ ɨ d z
+lagids	l æ d͡ʒ ɪ d z
 lagniappe	l æ n j æ p
 lagomorphic	l æ ɡ ə m ɔ ɹ f ɪ k
 lagoon	l ə ɡ uː n
@@ -37212,6 +37622,8 @@ lagopodes	l ə ɡ ə ʊ p ə ʊ d z
 lagopus	l ə ɡ ə ʊ p ə s
 lagos	l e ɪ ɡ ɒ s
 lagtime	l æ ɡ t a ɪ m
+lagune	l ə ɡ j uː n
+lagune	l ə ɡ uː n
 lah	l ɑ
 lahar	l ɑ h ɑ ɹ
 lahore	l ə h ɔː r
@@ -37444,15 +37856,14 @@ lardy	l ɑː d i
 lare	l ɛ ə ɹ
 laredo	l ə r e ɪ d o ʊ
 large	l ɑː d͡ʒ
-largely	l ɑ ɹ d͡ʒ l i
+largely	l ɑː d͡ʒ l i
 largeness	l ɑː d͡ʒ n ə s
 larger	l ɑː d͡ʒ ə
-largess	l ɑː d͡ʒ ɛ s
-largess	l ɑː ʒ ɛ s
-largesse	l ɑː d͡ʒ ɛ s
+largesse	l ɑː d ʒ ɛ s
 largest	l ɑː d͡ʒ ɪ s t
 lariat	l æ ɹ ɪ ə t
 larissa	l ə ɹ ɪ s ə
+larixinic	l æ ɹ ɪ k s ɪ n ɪ k
 lark	l ɑː k
 larnax	l ɑː n æ k s
 larne	l ɑː ɹ n
@@ -37464,10 +37875,12 @@ larry	l æ ɹ i
 lart	l ɑː ɹ t
 larva	l ɑː v ə
 larvae	l ɑː v i
+larve	l ɑː ɹ v
 laryngeal	l ə ɹ ɪ n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n ʒ i ə l
 larynges	l ə ɹ ɪ n d͡ʒ iː z
 laryngismus	l æ ɹ ɪ n d͡ʒ ɪ z m ə s
+laryngitis	l æ ɹ ɪ n d͡ʒ a ɪ t ɪ s
 larynx	l a ɹ ɪ ŋ k s
 las	l ɑː z
 lasagna	l ə s ɑ n j ə
@@ -37563,6 +37976,7 @@ latium	l e ɪ ʃ i ə m
 lative	l e ɪ t ɪ v
 latke	l ɑː t k i
 latke	l ɑː t k ə
+latona	l ə t ə ʊ n ə
 latreutic	l ə t ɹ uː t ɪ k
 latria	l ə t ɹ a ɪ ə
 latrine	l ə t ɹ iː n
@@ -37616,7 +38030,9 @@ laundromat	l ɔː n d ɹ ə m æ t
 laundromat	l ɔː n d ɹ ə ʊ m æ t
 laundry	l ɔː n d ɹ i
 laura	l ɔː ɹ ə
+laureate	l ɒ ɹ i e ɪ t
 laureate	l ɒ ɹ i ə t
+laureate	l ɔː ɹ i e ɪ t
 laureate	l ɔː ɹ i ə t
 laureation	l ɔː ɹ i e ɪ ʃ ə n
 laurel	l ɒ ɹ ə l
@@ -37820,6 +38236,7 @@ lebanon	l ɛ b ə n ə n
 lebensraum	l eː b ə n s ɹ a ʊ m
 lebensräume	l eː b ə z n ʁ ɔ ɪ m ə
 lebenswelt	l eː b ə n z v ɛ l t
+lecce	l ɛ t ʃ e ɪ
 lech	l ɛ k
 lech	l ɛ t͡ʃ
 lechayim	l ə h a ɪ ɪ m
@@ -37838,6 +38255,7 @@ lectin	l ɛ k t ɪ n
 lectinological	l ɛ k t ɪ n ə l ɒ d͡ʒ ɪ k ə l
 lectinologist	l ɛ k t ɪ n ɒ l ə d͡ʒ ɪ s t
 lection	l ɛ k ʃ ə n
+lector	l ɛ k t ə ɹ
 lecture	l ɛ k t͡ʃ ə
 lecturer	l ɛ k t ʃ ə ɹ ə
 lectures	l ɛ k t͡ʃ ə z
@@ -37876,7 +38294,7 @@ lefty	l ɛ f t i
 leg	l ɛ ɡ
 legacy	l ɛ ɡ ə s i
 legal	l iː ɡ ə l
-legal	l ɨ ɡ æ l
+legal	l ɪ ɡ æ l
 legalize	l iː ɡ ə l a ɪ z
 legally	l iː ɡ ə l i
 legate	l ɛ ɡ ə t
@@ -37920,6 +38338,7 @@ leguleian	l ɛ ɡ j ʊ l iː ə n
 legume	l ə ɡ j uː m
 legume	l ɛ ɡ j uː m
 legume	l ɪ ɡ j uː m
+legumen	l ɪ ɡ j uː m ə n
 legumes	l ɛ ɡ j uː m z
 legumes	l ɪ ɡ j uː m z
 legwork	l ɛ ɡ w əː k
@@ -37980,7 +38399,8 @@ length	l ɛ ŋ k θ
 lengthen	l ɛ ŋ k θ ə n
 lengthening	l ɛ ŋ k θ n ɪ ŋ
 lengthening	l ɛ ŋ k θ ə n ɪ ŋ
-lengthman	l ɛ ŋ θ m ə n
+lengthman	l ɛ ŋ θ m n̩
+lengthsman	l ɛ ŋ θ s m n̩
 lenient	l iː n i ə n t
 lenify	l iː n ɪ f a ɪ
 lenify	l ɛ n ɪ f a ɪ
@@ -37997,6 +38417,7 @@ lenite	l iː n a ɪ t
 lenite	l ə n a ɪ t
 lenition	l iː n ɪ ʃ ə n
 lenition	l ɪ n ɪ ʃ ə n
+lenity	l ɛ n ɪ t i
 lennon	l ɛ n ə n
 lens	l ɛ n z
 lenses	l ɛ n z ɪ z
@@ -38092,6 +38513,7 @@ lettuce	l ɛ t ɪ s
 leu	l e ɪ uː
 leuchars	l uː k ə ɹ z
 leuchars	l uː x ə ɹ s
+leucinemia	l j uː s ɪ n iː m i ə
 leucoderm	l uː k ə d ɝ m
 leucodermic	l uː k ə d ɜː m ɪ k
 leucophanite	l j uː k ɒ f ə n a ɪ t
@@ -38128,8 +38550,8 @@ leveret	l ɛ v ə ɹ ɪ t
 leveret	l ɛ v ɹ ɪ t
 leverpostej	l e ɪ v ə ɹ p ɒ s t a ɪ
 levet	l ɛ v ɪ t
-levetiracetam	l ɛ v ɨ t ɪ r æ s ɨ t æ m
-levi	l iː v a ɪ
+levetiracetam	l ɛ v ɪ t ɪ r æ s ɪ t æ m
+levi	l iː v a j
 leviathan	l ə v a ɪ ə θ ə n
 levidrome	l iː v a ɪ d ɹ ə ʊ m
 levidrome	l iː v ɪ d ɹ ə ʊ m
@@ -38182,10 +38604,7 @@ liability	l a ɪ ə b ɪ l ɪ t i
 liable	l a ɪ̯ ə b ə l
 liaise	l iː e ɪ z
 liaison	l a ɪ e ɪ z ɒ n
-liaison	l a ɪ e ɪ z ə n
-liaison	l i e ɪ z ɒ n
 liaison	l i e ɪ z ɒ̃
-liaison	l i e ɪ z ə n
 liam	l iː ə m
 liana	l iː ɑː n ə
 liangpi	l i æ ŋ p iː
@@ -38259,7 +38678,6 @@ licorice	l ɪ k ə ɹ ɪ s
 licorice	l ɪ k ə ɹ ɪ ʃ
 lictor	l ɪ k t ə
 lid	l ɪ d
-liddat	l a ɪ d ɛ t
 lidge	l ɪ d͡ʒ
 lido	l a ɪ d ə ʊ
 lido	l iː d ə ʊ
@@ -38338,6 +38756,8 @@ ligma	l ɪ ɡ m ə
 lignify	l ɪ ɡ n ɪ f a ɪ
 lignite	l ɪ ɡ n a ɪ̯ t
 lignocaine	l ɪ ɡ n ə ʊ k e ɪ n
+lignose	l ɪ ɡ n ə ʊ s
+lignose	l ɪ ɡ n ə ʊ z
 ligula	l ɪ ɡ j ʊ l ə
 liguria	l ɪ ɡ j ʊ ə ɹ i ə
 lihou	l iː uː
@@ -38445,6 +38865,7 @@ lindsey	l ɪ n z i
 lindworm	l ɪ n d w ɜː ɹ m
 line	l a ɪ n
 lineage	l ɪ n i ɪ d͡ʒ
+lineages	l ɪ n i ɪ d ʒ ɪ z
 lineal	l ɪ n iː ə l
 lineament	l ɪ n i ə m ə n t
 linear	l ɪ n i ə
@@ -38694,7 +39115,6 @@ llama	l ɑː m ə
 llandeilo	h l æ n d a ɪ l ə ʊ
 llandudno	l æ n d ɪ d n o ʊ
 llanegwad	ɬ æ n ɛ ɡ w ə d
-llaneilian	ɬ a n eː l ɪ a n
 llanero	l j ɑː n ɛː ɹ ə ʊ
 llanero	l ɑː n ɛː ɹ ə ʊ
 llanfyllin	ɬ æ n v ʌ ɬ ɪ n
@@ -38705,7 +39125,6 @@ llano	l æ n ə ʊ
 llanrumney	h l æ n ɹ ʌ m n i
 llanrwst	h l æ n ɹ uː s t
 llansamlet	ɬ æ n s æ m l ə t
-llanymynech	ɬ æ n ə m ʌ n ɛ x
 llewelyn	l uː ɛ l ɪ n
 llewelyn	l ə w ɛ l ɪ n
 lloyd	l ɔ ɪ d
@@ -38746,6 +39165,7 @@ lobster	l ɒ b s t ə
 lobsterman	l ɒ b s t ə ɹ m ə n
 lobsterwoman	l ɒ b s t ə ɹ w ʊ m ə n
 lobule	l ɒ b j uː l
+loc	l ə ʊ k
 local	l ə ʊ k l̩
 locale	l ə ʊ k ɑː l
 localism	l ə ʊ k ə l ɪ z ə m
@@ -38805,6 +39225,7 @@ loeffler	l ɜː f l ə ɹ
 loess	l ə ʊ ɪ s
 loess	l ɜː s
 loft	l ɒ f t
+lofton	l ɒ f t ə n
 lofty	l ɒ f t i
 log	l ɒ ɡ
 logarithmancy	l ɒ ɡ ə ɹ ɪ ð m ə n s i
@@ -38866,12 +39287,12 @@ lojban	l ɒ ʒ b æ n
 loki	l ə ʊ k i
 lol	l ɒ l
 lol	l ɔː l
-lol	ɛ l ə u ɛ l
 lol	ɛ l ə ʊ ɛ l
 lola	l ə ʊ l ə
 lolita	l ə ʊ l l i t ə
 loll	l ɒ l
 lollapalooza	l ɒ l ə p ə l uː z ə
+lollard	l ɒ l ɑː ɹ d
 lollipop	l ɒ l i p ɒ p
 lollop	l ɒ l ə p
 lollygag	l ɒ l ɪ ɡ æ ɡ
@@ -38894,6 +39315,7 @@ loneness	l ə ʊ n n ə s
 lonesome	l ə ʊ n s ə m
 long	l ɒ ŋ
 long	l ɔː ŋ
+long	l ʊ ŋ
 longan	l ɒ ŋ ɡ ə n
 longanimity	l ɒ ŋ ɡ ə n ɪ m ɪ t i
 longbow	l ɒ ŋ b ə ʊ
@@ -39087,6 +39509,7 @@ lovage	l ʌ v ɪ d͡ʒ
 lovanenty	l ə ʊ v ə n ɛ n t i
 lovastatin	l ə ʊ v a s t ə t ɪ n
 lovastatin	l ə ʊ v ə s t a t ɪ n
+love	l ʊ v
 love	l ʌ v
 lovecraftian	l ʌ v k ɹ æ f t i ə n
 loved	l ʌ v d
@@ -39207,7 +39630,6 @@ luftwaffe	l ʊ f t w ɑ f ə
 lug	l ʌ ɡ
 luganda	l uː ɡ æ n d ə
 luganda	l uː ɡ ɑː n d ə
-luge	l uː d ʒ
 luged	l uː ʒ d
 luger	l uː ɡ ə ɹ
 luger	l uː ʒ ə ɹ
@@ -39303,6 +39725,7 @@ lupine	l uː p a ɪ n
 lupine	l uː p ɪ n
 lupulin	l u p j ə l ɪ n
 lupus	l uː p ə s
+lur	l ʊ ə ɹ
 lure	l j ʊ ə
 lure	l ɔː ɹ
 lure	l ɜː
@@ -39371,6 +39794,7 @@ luxurious	l ʌ ɡ z j ʊ ə ɹ ɪ ə s
 luxurious	l ʌ ɡ ʒ ʊ ə ɹ ɪ ə s
 luxury	l ʌ k ʃ ə ɹ i
 lviv	l ə v iː v
+lyam	l a ɪ ə m
 lycan	l a ɪ k ə n
 lycanthrope	l a ɪ k æ n θ ɹ o ʊ p
 lycanthrope	l a ɪ k ə n θ ɹ o ʊ p
@@ -39417,6 +39841,7 @@ lyra	l a ɪ ɹ ə
 lyra	l ɪ ə ɹ ə
 lyre	l a ɪ ə
 lyric	l ɪ ɹ ɪ k
+lyrical	l ɪ ɹ ɪ k ə l
 lyricist	l ɪ ɹ ɪ s ɪ s t
 lyrics	l ɪ ɹ ɪ k s
 lyrid	l a ɪ ɹ ɪ d
@@ -39460,7 +39885,7 @@ macajuel	m æ k ə w ɛ l
 macajuel	m ɑ k ɑ w ɛ l
 macanese	m æ k ə n i z
 macaque	m ə k æ k
-macaque	m ə k ɒ k
+macaque	m ə k ɑː k
 macarena	m æ k ə ɹ a ɪ n ə
 macaron	m æ k ə ɹ ɒ n
 macaronesia	m a k ə ɹ ə n iː ʒ ə
@@ -39511,6 +39936,7 @@ machismo	m ə k ɪ z m ə ʊ
 macho	m æ t͡ʃ ə ʊ
 machoness	m ɑ t ʃ ə ʊ n ə s
 macilent	m a s ɪ l ə n t
+macitentan	m æ s ɪ t ɛ n t æ n
 mack	m æ k
 mackem	m a k ə m
 mackerel	m æ k ɹ ə l
@@ -39531,6 +39957,8 @@ macon	m e ɪ k ə n
 macon	m ɑː k ɒ̃
 maconochie	m ə k ɒ n ə k i
 maconochie	m ə k ɒ n ə x i
+macquarie	m ə k w ɑː r i
+macquarie	m ə k w ɔː r i
 macra	m æ k ɹ ə
 macramé	m æ k ɹ ə m e ɪ
 macramé	m ə k ɹ ɑː m e ɪ
@@ -39561,6 +39989,7 @@ macrovirus	m æ k ɹ o ʊ v a ɪ ɹ ə s
 macs	m æ k s
 macspaunday	m ə k s p ɔː n d e ɪ
 mactate	m æ k t e ɪ t
+macula	m æ k j ʊ l ə
 maculature	m æ k j ʊ l ə t j ʊ ə ɹ
 maculature	m æ k j ʊ l ə t͡ʃ ə ɹ
 maculele	m ɑː k u l e ɪ l e ɪ
@@ -39644,6 +40073,7 @@ maggot	m æ ɡ ə t
 maggots	m æ ɡ ə t s
 maggoty	m æ ɡ ə t i
 maghreb	m ɑː ɡ ɹ ɛ b
+maghreb	m ʌ ɡ ɹ ə b
 maghull	m ə ɡ ʌ l
 magi	m e ɪ d͡ʒ a ɪ
 magi	m e ɪ ɡ a ɪ
@@ -39835,8 +40265,8 @@ malagash	m æ l ə ɡ æ ʃ
 malagasy	m æ l ə ɡ e ɪ z i
 malagasy	m æ l ə ɡ æ s i
 malagueta	m a l ə ɡ ɛ t ə
+malai	m ə l a ɪ
 malaise	m æ l e ɪ z
-malaise	m ə l e ɪ z
 malamute	m æ l ə m j uː t
 malapert	m a l ə p əː t
 malapert	m æ l ə p ɜː t
@@ -39863,9 +40293,9 @@ malcolm	m æ l k ə m
 malcontent	m a l k ə n t ɛ n t
 mald	m ɔː l d
 mald	m ə ʊ l d
-maldives	m ɒ l d iː v s
-maldives	m ɔː l d a ɪ v s
-maldives	m ɔː l d iː v s
+maldives	m ɒ l d iː v z
+maldives	m ɔː l d a ɪ v z
+maldives	m ɔː l d iː v z
 male	m e ɪ l
 maledight	m æ l ə d a ɪ t
 malefic	m ə l ɛ f ɪ k
@@ -39931,6 +40361,7 @@ malodor	m æ l ə ʊ d ə ɹ
 malodorous	m æ l ə ʊ d ə ɹ ə s
 malta	m ɔː l t ə
 maltalent	m æ l t æ l ə n t
+maltaxation	m æ l t æ k s e ɪ ʃ ə n
 maltese	m ɒ l t iː z
 maltese	m ɔː l t iː z
 maltitol	m ɔː l t ə t ɑ l
@@ -40000,6 +40431,7 @@ manchuria	m æ n t͡ʃ ʊ ə ɹ i ə
 manchurian	m æ n t͡ʃ ʊ ə ɹ i ə n
 mancia	m æ n t͡ʃ ə
 mancipatory	m æ n s ɪ p e ɪ t ə ɹ i
+manciple	m æ n s ɪ p ə l
 mancunian	m a n k j uː n ɪ ə n
 mand	m æ n d
 mand	m ɑː n d
@@ -40014,6 +40446,7 @@ mandate	m æ n d e ɪ t
 mandatory	m æ n d ə t ə ɹ i
 mandela	m æ n d ɛ l ə
 mandement	m ɑː n d m ə n t
+mandeville	m æ n d ə v ɪ l
 mandible	m æ n d ɪ b ə l
 mandibles	m æ n d ə b ə l z
 mandibles	m æ n d ɪ b ə l z
@@ -40104,6 +40537,7 @@ manitoba	m æ n ɪ t ə ʊ b ə
 manitou	m a n ɪ t uː
 manitowoc	m æ n ɪ t ə w ɔː k
 manizer	m æ n a ɪ z ə ɹ
+manjuristics	m æ n d͡ʒ ə ɹ ɪ s t ɪ k s
 mank	m æ ŋ k
 mankind	m æ n k a ɪ n d
 mankiw	m æ n k j uː
@@ -40116,7 +40550,7 @@ manna	m æ n ə
 manned	m æ n d
 mannequin	m æ n ə k ɪ n
 manner	m æ n ə
-mannerism	˞ m æ n ə ɹ ɪ z ə m
+mannerism	m æ n ə ɹ ɪ z ə m
 mannish	m æ n ɪ ʃ
 mannopeptimycin	m n æ ə ʊ p ɛ p t ɪ m a ɪ s ɪ n
 manoeuvre	m ə n uː v ə
@@ -40135,6 +40569,7 @@ manship	m æ n ʃ ɪ p
 mansi	m æ n s i
 mansi	m ɑː n s i
 mansion	m æ n t͡ʃ ə n
+mansion	m æ n ʃ ə n
 manslot	m a n z l ɒ t
 mansonia	m æ n s ə ʊ n i ə
 mansplain	m a n s p l e ɪ n
@@ -40200,6 +40635,7 @@ maple	m e ɪ p l̩
 mapping	m æ p ɪ ŋ
 maprotiline	m ə p ɹ ə ʊ t ɪ l iː n
 maps	m æ p s
+mapuche	m ə p uː t ʃ e ɪ
 maputo	m ə p uː t ə ʊ
 maquette	m æ k ɛ t
 maquillage	m a k ɪ j ɑː ʒ
@@ -40239,7 +40675,7 @@ marches	m ɑː t͡ʃ ɪ z
 marches	m ɒ ɹ t͡ʃ ə z
 marching	m ɑː t͡ʃ ɪ ŋ
 marchioness	m ɑ ɹ ʃ ə n ɛ s
-marchioness	m ɑ ɹ ʃ ə n ɨ s
+marchioness	m ɑ ɹ ʃ ə n ɪ s
 marchland	m ɑː t͡ʃ l æ n d
 marchpane	m ɑː t ʃ p e ɪ n
 marcia	m ɑː ʃ ə
@@ -40300,8 +40736,8 @@ marinate	m æ ɹ ɪ n e ɪ t
 marine	m ə ɹ iː n
 mariner	m æ ɹ ɪ n ə
 marinette	m ɛ ɹ i n e t
-mario	m a ɹ iː ə ʊ
-mario	m ɑː ɹ iː ə ʊ
+mario	m a ɹ i ə ʊ
+mario	m ɑː ɹ i ə ʊ
 mariolatrous	m æ ɹ i ɒ l ə t ɹ ə s
 mariolatry	m ɛː ɹ i ɒ l ə t ɹ i
 marionette	m æ ɹ i ə n ɛ t
@@ -40331,6 +40767,7 @@ marks	m ɑː k s
 markstone	m ɑː k s t ə ʊ n
 markup	m ɑː ɹ k ʌ p
 markworthy	m ɑː k w ɜː ð i
+markèd	m ɑː k ɪ d
 marl	m ɑː l
 marlborough	m ɑː ɹ l b ɹ ə
 marlborough	m ɔː l b ɹ ə
@@ -40430,7 +40867,6 @@ maréchaussée	m a ɹ e ɪ ʃ ə ʊ s e ɪ
 masaccio	m æ s æ t͡ʃ i o ʊ
 masala	m ə s ɑː l ə
 masc	m æ s k
-masc	m ɑː s k
 mascara	m ə s k ɑː ɹ ə
 mascaron	m æ s k ə ɹ ɒ n
 mascarpone	m æ s k ə ɹ p ə ʊ n i
@@ -40611,6 +41047,7 @@ maturate	m æ t͡ʃ ə ɹ e ɪ t
 mature	m ə t j ʊ ə
 mature	m ə t͡ʃ ɔː
 mature	m ə t͡ʃ ʊ ə
+maturely	m ə t j ʊ ə ɹ l i
 maturity	m ə t j ʊ ə ɹ ə t i
 maturity	m ə t͡ʃ ʊ ə ɹ ə t i
 matutinal	m æ t j ʊ t a ɪ n l̩
@@ -40691,7 +41128,6 @@ maykop	m a ɪ k ɒ p
 mayn't	m e ɪ n t
 mayn't	m e ɪ ə n t
 maynooth	m ə n uː θ
-mayo	m e ɪ o ʊ
 mayo	m e ɪ ə ʊ
 mayonnaise	m e ɪ ə n e ɪ z
 mayor	m e ɪ ə
@@ -40720,6 +41156,7 @@ mcclusky	m ə k l ʌ s k i
 mccobb	m ə k ɑ b
 mcconaughey	m ə k k ɒ n ə h e ɪ̯
 mccoy	m ə k ɔ ɪ
+mccrum	m ɪ k ɹ ʌ m
 mcdonald	m ə k d ɒ n ə l d
 mcghie	m ɪ ɡ iː
 mcgough	m ə ɡ j uː
@@ -40772,6 +41209,7 @@ meant	m ɛ n t
 meantime	m iː n t a ɪ m
 meanwhile	m iː n w a ɪ l
 mear	m ɪ ə ɹ
+measle	m iː z ə l
 measles	m iː z ə l z
 measlings	m iː z l ɪ ŋ z
 measly	m iː z l i
@@ -40880,6 +41318,7 @@ medullary	m ɛ d͡ʒ u l ɛ ɹ i
 medusa	m ɪ d j uː s ə
 medusa	m ɪ d j uː z ə
 medusoid	m ə d j uː z ɔ ɪ d
+medway	m ɛ d w e ɪ
 meed	m iː d
 meedless	m iː d l ə s
 meef	m iː f
@@ -40943,6 +41382,7 @@ meghalaya	m e ɪ ɡ ɑː l ə j ə
 meghan	m e ɪ ɡ ə n
 meghan	m iː ɡ ə n
 meghan	m ɛ ɡ ə n
+meghna	m e ɡ n a
 megiddo	m ə ɡ ɪ d ə ʊ
 megillah	m ə ɡ ɪ l ə
 megilp	m ə ɡ ɪ l p
@@ -40983,7 +41423,7 @@ melee	m ɛ l e ɪ
 melee	m ɛ l i
 melena	m ə l iː n ə
 melena	m ɪ l iː n ə
-melete	m ɛ l ɨ t i
+melete	m ɛ l ɪ t i
 melic	m ɛ l ɪ k
 melilot	m ɛ l ɪ l ɒ t
 melinda	m ə l ɪ n d ə
@@ -41005,7 +41445,7 @@ mellon	m ɛ l ɒ n
 mellow	m ɛ l ə ʊ
 melly	m ɛ l i
 melodeon	m ɪ l ə ʊ d ɪ ə n
-melodic	m ɨ l ɒ d ɪ k
+melodic	m ɪ l ɒ d ɪ k
 melodious	m ə l ə ʊ d i ə s
 melodrama	m ɛ l ə d ɹ ɑː m ə
 melodramata	m ɛ l ə d ɹ ɑː m ə t ə
@@ -41079,16 +41519,18 @@ mendoza	m ɛ n d o ʊ z ə
 menelaus	m ɛ n ɪ l e ɪ ə s
 menendez	m ə n ɛ n d ɛ z
 mengzhou	m ʌ ŋ d͡ʒ o ʊ
+menhaden	m ɛ n h e ɪ d ə n
 menhir	m ɛ n h ɪ ə
 menial	m iː n i ə l
 meningeal	m ɪ n ɪ n d͡ʒ i ə l
+meningitis	m ɛ n ɪ n d ʒ a ɪ t ɪ s
 meninx	m iː n ɪ ŋ k s
 meniscus	m ə n ɪ s k ə s
 meniscus	m ɛ n ɪ s k ə s
 mennish	m ɛ n ɪ ʃ
 menobranch	m ɛ n ə b ɹ æ ŋ k
-menoetius	m ɨ n iː ʃ i ə s
-menoetius	m ɨ n iː ʃ ə s
+menoetius	m ɪ n iː ʃ i ə s
+menoetius	m ɪ n iː ʃ ə s
 menopause	m ɛ n o ʊ p ɔː z
 menopause	m ɛ n ə p ɔː z
 menorah	m ɪ n ɔː ɹ ə
@@ -41145,6 +41587,7 @@ mercaptopurine	m ɜː k a p t ə ʊ p j ɔː ɹ iː n
 mercaptopurine	m ɜː k a p t ə ʊ p j ʊ ə ɹ iː n
 mercator	m ə k e ɪ t ə
 mercator	m ɜː k e ɪ t ə
+merce	m ɜː ɹ s
 merced	m ɜː r s ɛ d
 mercedes	m ə s e ɪ d i z
 mercenary	m ɜː s ə n ə ɹ i
@@ -41372,6 +41815,7 @@ metempsychosis	m ɛ t ə m s ʌ ɪ k ə ʊ s ɪ s
 meteor	m iː t ɪ ɔː
 meteor	m iː t ɪ ə
 meteoric	m iː t i ɒ ɹ ɪ k
+meteorical	m iː t i ɒ ɹ ɪ k ə l
 meteorite	m iː t ɪ ə ɹ a ɪ t
 meteoritics	m iː t ɪ ə ɹ ɪ t ɪ k s
 meteoroidal	m iː t ɪ ə ɹ ɔ ɪ d l̩
@@ -41405,6 +41849,7 @@ methimazole	m ɪ θ ɪ m ə z ə ʊ l
 methinks	m ɪ θ ɪ ŋ k s
 methionine	m ɪ θ ʌ ɪ ə n iː n
 methionine	m ɪ θ ʌ ɪ ə n ɪ n
+methioninemia	m ə θ a ɪ ə n ɪ n iː m i ə
 method	m ɛ θ ə d
 methodist	m ɛ θ ə d ɪ s t
 methodology	m ɛ θ ə d ɒ l ə d͡ʒ i
@@ -41440,7 +41885,6 @@ metical	m ɛ t ɪ k ɑː l
 metings	m iː t ɪ ŋ z
 metis	m e ɪ t iː
 metis	m e ɪ t iː s
-metis	m iː t ɨ s
 metis	m iː t ɪ s
 metoclopramide	m ɛ t ə k l ə ʊ p ɹ ə m ʌ ɪ d
 metonym	m ɛ t ə n ɪ m
@@ -41476,6 +41920,7 @@ metz	m ɛ t s
 metzian	m ɛ t s ɪ ə n
 meu	m j uː
 meum	m iː ə m
+meuse	m j uː z
 meute	m j uː t
 mevushal	m ɪ v uː ʃ ɑː l
 mevushal	m ɪ v ʊ ʃ ə l
@@ -41483,7 +41928,6 @@ mew	m j uː
 mewl	m j uː l
 mews	m j uː z
 mexicali	m ɛ k s ɪ k æ l i
-mexican	m ɛ k s ə k ə n
 mexican	m ɛ k s ɪ k ə n
 mexico	m ɛ k s ɪ k ə ʊ
 mexicoke	m ɛ k s ɪ k ə ʊ k
@@ -41506,6 +41950,7 @@ mi'kmaq	m ɪ ɡ m ɔː
 mi'kmaq	m ɪ ɡ ə m ɒ k
 mia	m iː ə
 miami	m a ɪ æ m i
+miami	m a ɪ æ m ə
 miasma	m a ɪ æ z m ə
 miasma	m i æ z m ə
 miasmatic	m a ɪ ə z m æ t ɪ k
@@ -41584,6 +42029,7 @@ micturate	m ɪ k t͡ʃ ə ɹ e ɪ t
 miculek	m ɪ t͡ʃ ə l ɛ k
 mid	m ɪ d
 midazolam	m ʌ ɪ d e ɪ z ə ʊ l a m
+midbroad	m ɪ d b ɹ ɔː d
 midday	m ɪ d d e ɪ
 middelmannetjie	m ɪ d ə l m a n ə k i
 middelmannetjie	m ɪ d ə l m a n ə t ʃ i
@@ -41896,6 +42342,8 @@ mirrors	m ɪ ɹ ə z
 mirrour	m ɪ ɹ ə
 mirrour	m ɪ ɹ ɚ
 mirth	m ɜː θ
+mirthless	m ɝ θ l ə s
+mirthless	m ɝ θ l ɪ s
 miry	m a ɪ ə ɹ i
 mirza	m əː z ə
 mirza	m ɪ ə z ə
@@ -41933,8 +42381,8 @@ mischanceful	m ɪ s t͡ʃ æ n s f ə l
 mischanceful	m ɪ s t͡ʃ ɑː n s f ə l
 mischaracterization	m ɪ s k æ ɹ ə k t ə ɹ a ɪ z e ɪ ʃ ə n
 mischevious	m ɪ s t͡ʃ iː v i ə s
-mischief	m ɪ s t ʃ iː f
-mischief	m ɪ ʃ t ʃ iː f
+mischief	m ɪ s t͡ʃ iː f
+mischief	m ɪ ʃ t͡ʃ iː f
 mischieve	m ɪ s t ʃ iː v
 mischievious	m ɪ s t͡ʃ iː v i ə s
 mischievous	m ɪ s t͡ʃ ə v ə s
@@ -41976,6 +42424,7 @@ miserabilism	m ɪ z ɹ ə b ə l ɪ z ə m
 miserabilist	m ɪ z ə ɹ ə b ə l ɪ s t
 miserable	m ɪ z ə ɹ ə b ə l
 miserabler	m ɪ z ɹ ə b ə l ə ɹ
+miserere	m ɪ z ə ɹ ɛ ə ɹ i
 misericordia	m ɪ s ə ɹ ɪ k ɔː ɹ d i ə
 miserly	m a ɪ z ə ɹ l i
 misery	m ɪ z ə ɹ ɪ
@@ -42063,7 +42512,7 @@ misregard	m ɪ s ɹ ɪ ɡ ɑː ɹ d
 misregister	m ɪ s ɹ ɛ d͡ʒ ɪ s t ə ɹ
 misremember	m ɪ s ɹ ɪ m ɛ m b ə
 misrepair	m ɪ s ɹ ɪ p ɛ ə ɹ
-misrepresentation	m ɪ s ɹ ɛ p ɹ ɨ z ɛ n t e ɪ ʃ ə n
+misrepresentation	m ɪ s ɹ ɛ p ɹ ɪ z ɛ n t e ɪ ʃ ə n
 misrespect	m ɪ s ɹ ɪ s p ɛ k t
 misrule	m ɪ s ɹ uː l
 miss	m ɪ s
@@ -42291,6 +42740,7 @@ moffie	m ɒ f i
 moffitt	m ɒ f ɪ t
 mofo	m ə ʊ f ə ʊ
 mofussil	m ə ʊ f ʌ s ə l
+mog	m ɒ ɡ
 moggach	m ɒ ɡ ə x
 moggy	m ɒ ɡ i
 mogollon	m o ʊ ɡ ə j o ʊ n
@@ -42357,7 +42807,7 @@ molestation	m ə ʊ l ɪ s t e ɪ ʃ ə n
 molester	m ə l ɛ s t ə ɹ
 moliminous	m ə ʊ l ɪ m ɪ n ə s
 molina	m ɵ l i n ə
-molineux	m ɒ l ɨ n j uː
+molineux	m ɒ l ɪ n j uː
 moll	m ɒ l
 mollie	m ɒ l i
 mollie	m ɒ l ɪ
@@ -42413,6 +42863,7 @@ moncton	m ʌ ŋ k t ə n
 monday	m ʌ n d e ɪ
 monday	m ʌ n d i
 mondegreen	m ɒ n d ə ɡ ɹ iː n
+mondial	m ɒ n d i ə l
 monet	m o ʊ n e ɪ
 monetary	m ʌ n ɪ t ə ɹ i
 monetary	m ʌ n ɪ t ɹ i
@@ -42553,6 +43004,7 @@ montenegro	m ɒ n t ɪ n ɛ ɡ ɹ ə ʊ
 monterey	m ɒ n t ə ɹ e ɪ
 montero	m ɒ n t ɛ ə ɹ o ʊ
 monterrey	m ɒ n t ə ɹ e ɪ
+montes	m ɒ n t i z
 montevideo	m ɒ n t ɪ v ɪ d e ɪ ə ʊ
 montezuma	m ɒ n t ɪ z uː m ə
 montferrat	m ɒ n t f ə ɹ a t
@@ -42562,6 +43014,7 @@ montgomeryshire	m ɒ n t ɡ ʌ m ɹ i ʃ ɪ ə ɹ
 month	m ʌ n θ
 monthly	m ʌ n θ l i
 months	m ʌ n θ s
+montiform	m ɒ n t ɪ f ɔː m
 montjuïc	m ɒ n t ʒ uː iː k
 montpelier	m ɒ n t p iː l ɪ ə
 montpellier	m ɒ n p ɛ l i e ɪ
@@ -42575,6 +43028,7 @@ monument	m ɒ n j ʊ m ə n t
 monumental	m ɒ n j ʊ m ɛ n t ə l
 monumentally	m ɒ n j ʊ m ɛ n t ə l i
 monuments	m ɒ n j ʊ m ə n t s
+monyash	m ɒ n iː æ ʃ
 monégasque	m ɒ n ə ɡ a s k
 monégasque	m ɒ n ɪ ɡ a s k
 moo	m uː
@@ -42601,6 +43055,8 @@ moon	m uː n
 moonbat	m uː n b æ t
 mooncake	m uː n k e ɪ k
 mooncalf	m uː n k ɑː f
+moonflask	m uː n f l æ s k
+moonflask	m uː n f l ɑː s k
 moonflower	m uː n f l a ʊ ə
 moong	m ʊ ŋ
 moonlit	m uː n l ɪ t
@@ -42963,6 +43419,7 @@ mses	m ɪ z ə z
 mss	m ɪ z ə z
 mth	ɛ m θ
 mthwakazi	ə m t w ɑː k ɑː z i
+mtskheta	m ə t s k e ɪ t ə
 mtso	m ɛ t s ə ʊ
 mu	m j uː
 mu	m uː
@@ -43019,7 +43476,7 @@ muggy	m ʌ ɡ i
 mugham	m u ɡ ɑ m
 mugient	m j uː d͡ʒ i ə n t
 mugient	m j uː d͡ʒ ə n t
-mugwort	m ʌ ɡ w əː t
+mugwort	m ʌ ɡ w ɜː t
 mugwump	m ʌ ɡ w ʌ m p
 mugwumps	m ʌ ɡ w ʌ m p s
 muh	m ə
@@ -43059,7 +43516,7 @@ muleteer	m j uː l ə t ɪ ə ɹ
 mulga	m ʌ l ɡ ə
 mulgrave	m ʌ l ɡ ɹ e ɪ v
 mulhouse	m ə l uː z
-muliebral	m j uː l ɨ iː b ɹ ə l
+muliebral	m j uː l ɪ iː b ɹ ə l
 muliebrity	m j uː l ɪ ɛ b ɹ ɪ t i
 mulier	m j uː l ɪ ə
 mull	m ʌ l
@@ -43073,7 +43530,7 @@ mullered	m ʊ l ə ɹ d
 mullet	m ʌ l ə t
 mullet	m ʌ l ɪ t
 mulligan	m ʌ l ɪ ɡ ə n
-mulligatawny	m ʌ l ɨ ɡ ə t ɔː n i
+mulligatawny	m ʌ l ɪ ɡ ə t ɔː n i
 mullins	m ʌ l ɪ n z
 mullion	m ʌ l i ə n
 multibillion	m ʌ l t i b ɪ l j ə n
@@ -43126,7 +43583,7 @@ mumble	m ʌ m b ə l
 mumchance	m ʌ m t ʃ ɑː n s
 mummer	m ʌ m ə
 mummer	m ʌ m ɚ
-mummerset	m ʌ m ə ɹ s ɛ t
+mummerset	m ʌ m ə s ɛ t
 mummiform	m ʌ m ɪ f ɔː m
 mummy	m ʌ m i
 mump	m ʌ m p
@@ -43135,6 +43592,7 @@ mun	m ʌ n
 munch	m ʌ n t ʃ
 munchies	m ʌ n t͡ʃ i z
 munchkin	m ʌ n ʃ k ɪ n
+muncie	m ʌ n s i
 mund	m ʊ n d
 mund	m ʌ n d
 mundane	m ʌ n d e ɪ n
@@ -43145,13 +43603,18 @@ mung	m uː ŋ
 mung	m ʌ ŋ
 mungaree	m ʌ n d ʒ ɑː ɹ i
 munge	m ʌ n d͡ʒ
+munged	m ʌ n d͡ʒ d
+munged	m ʌ ŋ d
 munger	m ʌ n d͡ʒ ə
+munger	m ʌ ŋ ə
+munging	m ʌ n d͡ʒ ɪ ŋ
+munging	m ʌ ŋ ɪ ŋ
 munich	m j uː n ɪ k
 municipal	m j u n ɪ s ɪ p ə l
 municipality	m j ʊ n ɪ s ɪ p æ l ɪ t i
 municipium	m j uː n ɪ s ɪ p ɪ ə m
 munificence	m j uː n ɪ f ɪ s ə n s
-munificent	m j u n ɪ f ɨ s n̩ t
+munificent	m j u n ɪ f ɪ s n̩ t
 muniment	m j uː n ɪ m ə n t
 munira	m uː n ɪ ə ɹ ə
 munite	m j uː n a ɪ t
@@ -43285,6 +43748,7 @@ mussed	m ʌ s t
 mussel	m ʌ s ə l
 musselburgh	m ʌ s ə l b ə ɹ ə
 mussitate	m ʌ s ɪ t e ɪ t
+mussitation	m ʌ s ɪ t e ɪ ʃ n̩
 mussolini	m ʊ s ə l iː n i
 mussuck	m ʌ s ə k
 mussulman	m ʌ s ə l m ə n
@@ -43381,6 +43845,7 @@ myoclonus	m a ɪ o ʊ k l o ʊ n ə s
 myofilament	m a ɪ o ʊ f ɪ l ə m ə n t
 myogenic	m ʌ ɪ ə d ʒ ɛ n ɪ k
 myoglobinemia	m a ɪ ə ʊ ɡ l ə ʊ b ɪ n iː m ɪ ə
+myokine	m a ɪ ə ʊ k a ɪ n
 myology	m ʌ ɪ ɒ l ə d ʒ i
 myometrium	m a ɪ ə ʊ m iː t ɹ i ə m
 myopia	m a ɪ ə ʊ p ɪ ə
@@ -43493,7 +43958,7 @@ nacho	n æ t͡ʃ ə ʊ
 nachos	n æ t ʃ ə ʊ z
 nachos	n ɑ x ə s
 nack	n æ k
-nackawic	n æ k ɘ w ɪ k
+nackawic	n æ k ə w ɪ k
 nacogdoches	n æ k ə d o ʊ t͡ʃ ɪ s
 nacre	n e ɪ k ə
 nacreous	n e ɪ k ɹ i ə s
@@ -43820,6 +44285,7 @@ neave	n iː v
 neb	n ɛ b
 nebbiolo	n ɛ b ɪ ə ʊ l ə ʊ
 nebbish	n ɛ b ɪ ʃ
+nebentan	n ə b ɛ n t æ n
 nebracetam	n ə b ɹ æ s ɪ t æ m
 nebris	n ɛ b ɹ ɪ s
 nebuchadnezzar	n ɛ b j ʊ k ə d n ɛ z ə
@@ -43855,8 +44321,8 @@ neckwear	n ɛ k w ɛ ɚ
 necrectomy	n ə k ɹ ɛ k t ə m i
 necrocracy	n ɛ k ɹ ɒ k ɹ ə s i
 necrology	n ɛ k ɹ ɒ l ə d ʒ i
-necrolysis	n ɘ k ɹ ɔ l ə s ə s
-necrolysis	n ɘ k ɹ ɔ l ə s ɪ s
+necrolysis	n ə k ɹ ɔ l ə s ə s
+necrolysis	n ə k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ɪ s ɪ s
 necromancer	n e k ɹ ə ʊ m æ n s ə
@@ -43879,7 +44345,7 @@ necropsy	n ɛ k ɹ ɒ p s i
 necropsy	n ɪ k ɹ ɒ p s i
 necrosectomy	n ɛ k ɹ o ʊ z ɛ k t ə m i
 nectar	n ɛ k t ə
-nectarine	n ɛ k t ə ɹ i n
+nectarine	n ɛ k t ə ɹ iː n
 ned	n ɛ d
 neddy	n ɛ d i
 neds	n ɛ d z
@@ -44147,6 +44613,7 @@ neville	n ɛ v ə l
 nevin	n ɛ v ɪ n
 nevirapine	n ɪ v ʌ ɪ ɹ ə p iː n
 nevis	n iː v ɪ s
+nevus	n iː v ə s
 new	n j uː
 newall	n uː ə l
 newark	n j uː ə k
@@ -44889,6 +45356,7 @@ numbered	n ʌ m b ə d
 numberous	n ʌ m b ə ɹ ə s
 numberous	n ʌ m b ɹ ə s
 numbers	n ʌ m b ə z
+numby	n ʌ m i
 numchuck	n ʌ m t͡ʃ ʌ k
 numen	n j uː m ə n
 numeral	n j uː m ə ɹ ə l
@@ -45071,10 +45539,9 @@ obedience	ə ʊ b iː d ɪ ə n s
 obedient	ə b iː d ɪ ə n t
 obedient	ə ʊ b iː d ɪ ə n t
 obediential	ə ʊ b iː d i ɛ n ʃ ə l
-obeisance	o ʊ b e ɪ s ə n s
-obeisance	o ʊ b iː s ə n s
 obeisance	ə b e ɪ s ə n s
 obeisance	ə b iː s ə n s
+obeisance	ə ʊ b e ɪ s ə n s
 obeli	ɒ b ɪ l a ɪ
 obelisk	ɒ b ə l ɪ s k
 obelized	ɒ b ə l a ɪ z d
@@ -45146,6 +45613,8 @@ oblique	ə b l iː k
 obliquity	ə b l ɪ k w ɪ t i
 oblite	ə b l a ɪ t
 obliterate	ə b l ɪ t ə ɹ e ɪ t
+obliterate	ə b l ɪ t ə ɹ ə t
+obliterated	ə b l ɪ t ə ɹ e ɪ t ɪ d
 obliviality	ə b l ɪ v i æ l ɪ t i
 oblivion	ə b l ɪ v iː ə n
 oblivious	ə b l ɪ v iː ə s
@@ -45355,7 +45824,6 @@ octogenary	ɒ k t ɒ d͡ʒ ɪ n ə r i
 octogram	ɒ k t o ʊ ɡ ɹ æ m
 octogram	ɒ k t ə ɡ ɹ æ m
 octopawn	ɒ k t ə p ɔː n
-octopodes	ɒ k t ɒ p ə d iː z
 octopus	ɒ k t ə p ə s
 octopus	ɒ k t ə p ʊ s
 octosyllabic	ɒ k t ə ʊ s ɪ l æ b ɪ k
@@ -45411,7 +45879,7 @@ odysseus	o ʊ d ɪ s i ə s
 odysseus	o ʊ d ɪ s j uː s
 odysseus	ə d ɪ s j uː s
 odyssey	ɒ d ə s i
-odyssey	ɒ d ɨ s i
+odyssey	ɒ d ɪ s i
 oe	o i
 oe	ɔ ɪ
 oe	ə ʊ
@@ -45475,6 +45943,7 @@ officer	ɒ f ə s ə
 officer	ɒ f ɪ s ə
 officers	ɒ f ɪ s ə z
 offices	ɒ f ɪ s ɪ z
+officetel	ɒ f ɪ s t ɛ l
 officey	ɒ f ɪ s i
 official	ə f ɪ ʃ ə l
 officialdom	ə f ɪ ʃ ə l d ə m
@@ -45526,7 +45995,6 @@ ogonek	ɒ ɡ ɒ n ɛ k
 ogonek	ə ʊ ɡ ə n ɛ k
 ogre	ə ʊ ɡ ə
 ogreishly	ə ʊ ɡ ə ɹ ɪ ʃ l i
-ogress	ə ʊ ɡ ɹ ə s
 ogress	ə ʊ ɡ ɹ ɛ s
 ogry	ə ʊ ɡ ɹ i
 ogun	ə ʊ ɡ ə n
@@ -45898,6 +46366,7 @@ ophthalmia	ɒ f θ æ l m i ə
 ophthalmia	ɒ p θ æ l m i ə
 ophthalmic	ɒ f θ a l m ɪ k
 ophthalmic	ɒ p θ a l m ɪ k
+ophthalmitis	ɒ f θ æ l m a ɪ t ɪ s
 ophthalmologist	ɒ f θ æ l m ɒ l ə d͡ʒ ɪ s t
 ophthalmology	ɒ f θ æ l m ɒ l ə d͡ʒ i
 ophthalmology	ɒ f θ ə l m ɒ l ə d͡ʒ i
@@ -45983,6 +46452,7 @@ optimistic	ɒ p t ɪ m ɪ s t ɪ k
 optimize	ɒ p t ɪ m a ɪ z
 optimum	ɒ p t ɪ m ə m
 option	ɒ p ʃ ə n
+optional	ɒ p ʃ ə n ə l
 optoacoustic	ɒ p t ə ʊ ə k uː s t ɪ k
 optocoupler	ɒ p t ə ʊ k ʌ p l ə
 optoelectronics	ɒ p t ə ʊ iː l ɛ k t ɹ ɒ n ɪ k s
@@ -46231,6 +46701,8 @@ orthopteroid	ɔː θ ɒ p t ə ɹ ɔ ɪ d
 orthopyroxene	ɔː θ ə ʊ p a ɪ ɹ ɒ k s iː n
 orthoquartzite	ɔː θ ə ʊ k w ɔː t s a ɪ t
 orthorhombic	ɔː ɹ θ ə ɹ ɒ m b ɪ k
+orthosexual	ɔː ɹ θ ə s ɛ k s j u ə l
+orthosexual	ɔː ɹ θ ə s ɛ k ʃ u ə l
 ortolan	ɔː t ə l æ n
 ortolan	ɔː t ə l ə n
 orvietan	ɔː v ɪ e ɪ t ə n
@@ -46295,7 +46767,7 @@ ossicone	ɒ s ɪ k ə ʊ n
 ossifier	ɒ s ɪ f a ɪ ə ɹ
 ossifrage	ɒ s ɪ f ɹ ɪ d͡ʒ
 ossify	ɒ s ɪ f a ɪ
-ossining	ɒ s ɨ n ɪ ŋ
+ossining	ɒ s ɪ n ɪ ŋ
 ossuarium	ɒ s j u ɛ ə ɹ i ə m
 ostend	ɒ s t ɛ n d
 ostensible	ɒ s t ɛ n s ɪ b ə l
@@ -46317,6 +46789,8 @@ ostiary	ɒ s t i ə ɹ i
 ostiary	ɒ s t͡ʃ ə ɹ i
 ostinato	ɒ s t ɪ n ɑ t o ʊ
 ostler	ɒ s l ə
+ostracean	ɒ s t ɹ e ɪ ʃ i ə n
+ostracean	ɒ s t ɹ e ɪ ʃ ə n
 ostracism	ɒ s t ɹ ə s ɪ z ə m
 ostracize	ɒ s t ɹ ə s a ɪ z
 ostracon	ɒ s t ɹ ə k ɒ n
@@ -46325,6 +46799,7 @@ ostrich	ɒ s t ɹ ɪ d͡ʒ
 ostrich	ɒ s t ɹ ɪ t͡ʃ
 ostrichism	ɒ s t ɹ ɪ t ʃ ɪ z ə m
 ostrobogulous	ɒ s t ɹ ə ʊ b ɒ ɡ j ʊ l ə s
+ostrogoth	ɒ s t r ə ɡ ɒ θ
 oswaldtwistle	ɒ z ə l t w ɪ z ə l
 oswego	ɒ s w iː ɡ o ʊ
 otacousticon	ə ʊ t ə k uː s t ɪ k ɒ n
@@ -46337,7 +46812,7 @@ othering	ʌ ð ə ɹ ɪ ŋ
 othering	ʌ ð ɹ ɪ ŋ
 others	ʌ ð ə z
 othersome	ʌ ð ə s ə m
-otherwhere	ʌ ð ə w ɛː
+otherwhere	ʌ ð ə ɹ w ɛː ɹ
 otherwise	ʌ ð ə w a ɪ z
 otic	ɒ t ɪ k
 otic	ə ʊ t ɪ k
@@ -46396,6 +46871,9 @@ ounce	a ʊ n s
 ounces	a ʊ n s ɪ z
 ouphe	a ʊ f
 ouphe	uː f
+ouppy	o ʊ ʌ p i
+ouppy	u p i
+ouppy	ʌ p i
 our	a ʊ ɚ
 our	æ ɔ ə
 our	ɐː
@@ -46635,7 +47113,7 @@ overridden	ə ʊ v ə ɹ ɪ d ə n
 override	ə ʊ v ə ɹ a ɪ d
 overriding	ə ʊ v ə ɹ ɹ a ɪ d ɪ ŋ
 overrode	ə ʊ v ə ɹ ə ʊ d
-overrule	ə ʊ v ə ɹ ɹ uː l
+overrule	ə ʊ v ə ɹ uː l
 overrun	ə ʊ v ə ɹ ʌ n
 oversanguine	ə ʊ v ə s a ŋ ɡ w ɪ n
 overscent	ə ʊ v ə s ɛ n t
@@ -46650,7 +47128,7 @@ overshadow	ə ʊ v ə ʃ æ d ə ʊ
 overshorten	ə ʊ v ə ʃ ɔː t ə n
 overshot	ə ʊ v ə ʃ ɒ t
 overside	ə ʊ v ə ɹ s a ɪ d
-oversight	o ʊ v ə ɹ s a ɪ t
+oversight	ə ʊ v ə s a ɪ t
 oversit	ə ʊ v ə ɹ s ɪ t
 overskirt	ə ʊ v ə s k ɜː t
 oversleep	ə ʊ v ə ɹ s l iː p
@@ -46686,6 +47164,7 @@ overtax	ə ʊ v ə ɹ t æ k s
 overthrow	ə ʊ v ə θ ɹ ə ʊ
 overthrowal	ə ʊ v ə θ ɹ ə ʊ ə l
 overthwart	ə ʊ v ə θ w ɔː t
+overtime	ə ʊ v ə t a ɪ m
 overton	ə ʊ v ə t ə n
 overtone	ə ʊ v ə t ə ʊ n
 overtop	ə ʊ v ə ɹ t ɒ p
@@ -46734,6 +47213,7 @@ owie	a ʊ w iː
 owing	ə ʊ ɪ ŋ
 owl	a ʊ l
 owler	a ʊ l ə
+owlet	a ʊ l ə t
 owlful	a ʊ l f l̩
 owlful	a ʊ l f ʊ l
 owling	a ʊ l ɪ ŋ
@@ -46903,6 +47383,7 @@ paedo	p iː d ə ʊ
 paedobaptism	p iː d ə ʊ b a p t ɪ z ə m
 paedomorphic	p iː d ə ʊ m ɔː f ɪ k
 paedophile	p e d ə f ɑ e l
+paedophile	p iː d ə f a ɪ l
 paedophile	p ɛ d ə ʉ f ɑ e l
 paedophilophile	p iː d ə ʊ f ɪ l ə ʊ f a ɪ l
 paedopsychology	p iː d ə ʊ p s a ɪ k ɒ l ə d͡ʒ ɪ
@@ -46976,6 +47457,7 @@ pair	p ɛ ə ɹ
 pairs	p ɛ ə z
 paisa	p a ɪ s ə
 paise	p a ɪ s ə
+paise	p e ɪ z
 paisley	p e ɪ z l i
 pakeha	p aː k e h aː
 pakeha	p aː k ə h aː
@@ -47197,6 +47679,7 @@ pandour	p æ n d ɔː ɹ
 pandour	p æ n d ʊ ə ɹ
 pane	p e ɪ n
 paned	p e ɪ n d
+paneer	p ə n iː ɹ
 panegyric	p æ n ə d͡ʒ a ɪ ɹ ɪ k
 panegyric	p æ n ə d͡ʒ ɪ ɹ ɪ k
 panegyrically	p a n ɪ d͡ʒ ɪ ɹ ɪ k l i
@@ -47350,6 +47833,7 @@ papillon	p æ p i ɒ n
 papillon	p æ p ɪ j ɒ̃
 papillon	p æ p ɪ l ɒ n
 papillon	p ə p ɪ l i ə n
+papio	p e ɪ p iː o ʊ
 papish	p e ɪ p ɪ ʃ
 papist	p e ɪ p ɪ s t
 papistical	p ə p ɪ s t ɪ k ə l
@@ -47357,7 +47841,7 @@ papoose	p ə p uː s
 pappardelle	p æ p ɑː d ɛ l e ɪ
 pappy	p æ p i
 paprika	p æ p ɹ iː k ə
-paprika	p æ p ɹ ɨ k ə
+paprika	p æ p ɹ ɪ k ə
 paprika	p ə p ɹ iː k ə
 papula	p æ p j ʊ l ə
 papyri	p æ p ɚ a ɪ
@@ -47387,6 +47871,7 @@ paracrine	p æ ɹ ə k ɹ ɪ n
 parade	p ə r ɑː d
 parade	p ə ɹ e ɪ d
 parades	p ə ɹ e ɪ d z
+paradiastole	p æ r ə d a ɪ æ s t ə l i
 paradiddle	p æ ɹ ə d ɪ d ə l
 paradigm	p æ ɹ ə d a ɪ m
 paradigma	p æ ɹ ə d ɪ ɡ m a
@@ -47524,6 +48009,7 @@ parenthetical	p æ ɹ ə n θ ɛ t ɪ k l̩
 parenthetically	p æ ɹ ə n θ ɛ t ɪ k l i
 parenting	p ɛ ə ɹ ə n t ɪ ŋ
 parents	p ɛ ə ɹ ə n t s
+pareo	p ɑː ɹ i ə ʊ
 parergy	p æ ɹ ə ɹ d͡ʒ i
 paresis	p ə ɹ iː s ɪ s
 paresthesis	p ə ɹ iː s θ ɪ s ɪ s
@@ -47680,7 +48166,7 @@ paschal	p a s k ə l
 pasco	p æ s k ə ʊ
 pash	p æ ʃ
 pasha	p æ ʃ ə
-pashes	p æ ʃ ɨ z
+pashes	p æ ʃ ɪ z
 pashto	p æ ʃ t ə ʊ
 pashto	p ʌ ʃ t ə ʊ
 pasifika	p ʌ s ɪ f ɪ k ʌ
@@ -47707,8 +48193,6 @@ passengers	p æ s ə n d͡ʒ ə z
 passepied	p æ s p i e ɪ
 passer	p ɑː s ə ɹ
 passerine	p æ s ə ɹ a ɪ n
-passerine	p æ s ə ɹ iː n
-passerine	p æ s ə ɹ ə n
 passes	p ɑː s ɪ z
 passible	p a s ɪ b ə l
 passim	p æ s ɪ m
@@ -47913,7 +48397,7 @@ pawnshop	p ɔː n ʃ ɒ p
 pawpaw	p ɔː p ɔː
 pawprint	p ɔː p ɹ ɪ n t
 paws	p ɔː z
-pawtucket	p ə t ʌ k ɨ t
+pawtucket	p ə t ʌ k ɪ t
 pax	p æ k s
 paxis	p æ k s ɪ s
 pay	p e ɪ
@@ -48194,7 +48678,7 @@ pendragon	p ɛ n d ɹ æ ɡ ə n
 pends	p ɛ n d z
 pendulum	p ɛ n d͡ʒ ə l ə m
 pendulum	p ɪ n d͡ʒ ə l ə m
-penelope	p ɨ n ɛ l ə p i
+penelope	p ɪ n ɛ l ə p i
 peneplain	p iː n ɪ p l e ɪ n
 peneplain	p ɛ n ɪ p l e ɪ n
 penes	p iː n iː z
@@ -48225,6 +48709,7 @@ peninsula	p ɛ n ɪ n s j ʊ l ə
 peninsular	p ə n ɪ n s j ə l ə ɹ
 peninsular	p ɛ n ɪ n s j ʊ l ə ɹ
 penis	p iː n ɪ s
+penises	p iː n ɪ s ɪ z
 penitent	p ɛ n ɪ t ə n t
 penitential	p ɛ n ɪ t ɛ n ʃ ə l
 penitentiary	p ɛ n ɪ t ɛ n ʃ ə ɹ i
@@ -48529,6 +49014,7 @@ perniones	p ɜː n i ə ʊ n iː z
 perniosis	p ɜː n i ə ʊ s ɪ s
 pernoctate	p ɜː n ɒ k t e ɪ t
 pernoctation	p ɜː n ɒ k t e ɪ ʃ n̩
+pernod	p ɛ ə n ə ʊ
 peroneal	p ɛː ɹ ə n iː ə l
 peroneus	p ɛ ɹ ə ʊ n iː ə s
 peroration	p ɛ ɹ ɒ ɹ e ɪ ʃ ə n
@@ -48605,6 +49091,7 @@ personal	p ɜː s ə n ə l
 personality	p ɜː s ə n æ l ə t ɪ
 personalization	p ɜː s ə n ə l a ɪ z e ɪ ʃ ə n
 personally	p ɜː s n ə l i
+personally	p ɜː s ə n ə l i
 personator	p ɜː ɹ s ə n e ɪ t ə ɹ
 personhood	p ɝ s ə n h ʊ d
 personification	p ɚ s ɑ n ə f ə k e ɪ ʃ ə n
@@ -48714,7 +49201,7 @@ peterborough	p iː t ə ɹ b ɹ ə
 petersham	p iː t ə ʃ ə m
 peterview	p iː t ɚ v j uː
 pethidine	p ɛ θ ɪ d iː n
-petiole	p ɛ t ɪ ə ʊ l
+petiole	p ɛ t i ə ʊ l
 petit	p ə t iː
 petit	p ɛ t i
 petite	p ə t iː t
@@ -48738,6 +49225,7 @@ petrol	p ɛ t ɹ ə l
 petrology	p ɪ t ɹ ɒ l ə d͡ʒ i
 petronel	p ɛ t ɹ ə n ə l
 petropavl	p ɛ t ɹ ə p ɑː v ə l
+petrophilic	p ɛ t ɹ ə f ɪ l ɪ k
 petrosal	p ɪ t ɹ ə ʊ s l̩
 petrosal	p ɪ t ɹ ə ʊ s ə l
 petrosyan	p ɛ t ɹ ə ʊ s i ə n
@@ -48775,7 +49263,6 @@ pfeffernuss	f ɛ f ə n uː s
 pfeffernusse	p f ɛ f ə ɹ n uː s ə
 pfennig	p f ɛ n ɪ ɡ
 pff	p͡fː
-pfft	p͡ɸː t
 phablet	f æ b l ɪ t
 phac	p iː h æ k
 phacelia	f ə s iː l i ə
@@ -48863,6 +49350,7 @@ phatic	f æ t ɪ k
 phaëthon	f e ɪ ə t ə n
 phaëthon	f e ɪ ə θ ə n
 pheasant	f ɛ z ə n t
+pheic	f e ɪ k
 phelonion	f ə l ə ʊ n i ə n
 phelps	f ɛ l p s
 phencyclidine	f ɛ n s a ɪ k l ɪ d iː n
@@ -49107,6 +49595,7 @@ phthalic	f θ æ l ɪ k
 phthisis	f θ a ɪ s ɪ s
 phthisis	t a ɪ s ɪ s
 phthonus	θ o ʊ n ə s
+phub	f ʌ b
 phugoid	f j uː ɡ ɔ ɪ d
 phuket	p uː k ɛ t
 phumdi	f u m d i
@@ -49183,6 +49672,7 @@ pice	p a ɪ s
 picene	p a ɪ s iː n
 piceous	p a ɪ s iː ə s
 piceous	p ɪ s ɪ ə s
+picidae	p ɪ s ə d iː
 pick	p ɪ k
 pickaninny	p ɪ k ə n ɪ n i
 picked	p ɪ k t
@@ -49708,6 +50198,7 @@ plasterly	p l ɑː s t ə ɹ l i
 plastic	p l æ s t ɪ k
 plastic	p l ɑː s t ɪ k
 plastically	p l a s t ɪ k l i
+plastician	p l æ s t ɪ ʃ ə n
 plasticizer	p l æ s t ɪ s a ɪ z ə
 plastron	p l æ s t ɹ ə n
 plat	p l æ t
@@ -49803,7 +50294,7 @@ pleb	p l ɛ b
 plebe	p l iː b
 plebeian	p l i b iː ə n
 plebeian	p l ɛ b iː ə n
-plebiscite	p l ɛ b ɨ s a ɪ t
+plebiscite	p l ɛ b ɪ s a ɪ t
 plebs	p l ɛ b z
 pleck	p l ɛ k
 plectile	p l ɛ k t a ɪ l
@@ -50187,6 +50678,8 @@ pollard	p ɒ l ə d
 polled	p ə ʊ l d
 pollen	p ɒ l ə n
 pollicate	p ɒ l ɪ k e ɪ t
+pollinate	p ɒ l ɪ n e ɪ t
+pollination	p ɒ l ɪ n e ɪ ʃ ə n
 pollinator	p ɒ l ɪ n e ɪ t ə ɹ
 pollinivore	p ɒ l ɪ n ɪ v ɔː ɹ
 pollinosis	p ɒ l ə n ə ʊ s ɪ s
@@ -50218,7 +50711,7 @@ polyamory	p ɒ l i æ m ə ɹ i
 polyarch	p ɒ l i ɑː k
 polyaxial	p ɒ l i æ k s i ə l
 polychaete	p ɒ l ɪ k iː t
-polychoron	p ɔ l ɨ k o ʊ ɹ ɔ n
+polychoron	p ɔ l ɪ k o ʊ ɹ ɔ n
 polychrest	p ɒ l ɪ k ɹ ɛ s t
 polychromatic	p ɒ l i k ɹ ə ʊ m æ t ɪ k
 polycratic	p ɒ l ɪ k ɹ a t ɪ k
@@ -50269,7 +50762,7 @@ polynya	p ə ʊ l ɪ n j ə
 polyol	p ɒ l ɪ ɒ l
 polyp	p ɒ l ɪ p
 polypantheism	p ɒ l i p æ n θ i ɪ z ə m
-polyphemus	p ɒ l ɨ f iː m ə s
+polyphemus	p ɒ l ɪ f iː m ə s
 polyphiloprogenitive	p ɒ l ɪ f ɪ l ə p ɹ ə d͡ʒ ɛ n ɪ t ɪ v
 polyphonic	p ɒ l ɪ f ɒ n ɪ k
 polyphony	p ə l ɪ f ə n i
@@ -50304,6 +50797,7 @@ polyzoary	p ɒ l i z ə ʊ ə ɹ i
 polyzoary	p ɒ l i z ə ʊ ə ɹ iː z
 polyzoic	p ɒ l i z ə ʊ ɪ k
 polyzoon	p ɒ l i z ə ʊ ɒ n
+polzeath	p ɒ l z iː θ
 pom	p ɒ m
 pomace	p ɒ m ɪ s
 pomace	p ʌ m ɪ s
@@ -50538,6 +51032,8 @@ portuguese	p ɔː t͡ʃ ə ɡ iː z
 portulent	p ɔː ɹ t j ə l ə n t
 portus	p ɔː t ə s
 pory	p ɔː ɹ i
+pos	p ɒ z
+pos	p ə ʊ z
 pose	p ə ʊ z
 posed	p ə ʊ z d
 posedown	p ə ʊ z d a ʊ n
@@ -50582,6 +51078,7 @@ possessorship	p ə z ɛ s ə ɹ ʃ ɪ p
 posset	p ɒ s ɪ t
 possibilities	p ɒ s ɪ b ɪ l i t i z
 possibility	p ɒ s ɪ b ɪ l ɪ t i
+possible	p ɒ s ə b l̩
 possible	p ɒ s ɪ b l̩
 possibly	p ɒ s ɪ b l i
 posslq	p ɒ s l̩ k j uː
@@ -50785,6 +51282,7 @@ prague	p ɹ ɑː ɡ
 prahok	p ɹ ə h ɒ k
 praia	p ɹ a ɪ ə
 prairial	p ɹ ɛː ɹ ɪ ə l
+prairies	p ɹ ɛ ə ɹ i z
 praise	p ɹ e ɪ z
 praised	p ɹ e ɪ z d
 praiser	p ɹ e ɪ z ə ɹ
@@ -50950,9 +51448,9 @@ preengage	p r iː ɪ n ɡ e ɪ d͡ʒ
 preeternity	p ɹ iː ɪ t ɜː ɹ n ɪ t i
 preface	p ɹ ɛ f ə s
 preface	p ɹ ɛ f ɪ s
-prefect	p ɹ ɪ f ɛ k t
+prefect	p ɹ iː f ɛ k t
 prefecture	p ɹ iː f ɛ k t j ʊ ə
-prefecture	p ɹ iː f ɛ k t ʃ ə
+prefecture	p ɹ iː f ɛ k t͡ʃ ə
 prefer	p ɹ ɪ f ɜː
 preferable	p ɹ ɛ f ə ɹ ə b ə l
 preferably	p ɹ ə f ɜː ɹ ə b l i
@@ -50999,6 +51497,8 @@ premalignant	p ɹ i m ə l ɪ ɡ n ə n t
 premarin	p ɹ ɛ m ə ɹ ɪ n
 premature	p ɹ ɛ m ə t j ə
 premature	p ɹ ɛ m ə t j ʊ ə
+prematurely	p ɹ iː m ə t j ʊ ə ɹ l i
+prematurely	p ɹ ɛ m ə t j ʊ ə ɹ l i
 premeditate	p r iː m ɛ d ɪ t e ɪ t
 premenstrual	p ɹ iː m ɛ n s t ɹ ʊ l
 premenstrual	p ɹ iː m ɛ n s t ɹ ʊ ə l
@@ -51038,11 +51538,9 @@ prepared	p ɹ ɪ p ɛ ə d
 preparing	p ɹ ɪ p ɛ ə ɹ ɪ ŋ
 prepend	p ɹ ɪ p ɛ n d
 prepense	p ɹ ɪ p ɛ n s
-preplied	p ɹ ɪ p l a ɪ d
-preplies	p ɹ ɪ p l a ɪ z
-preply	p ɹ iː p l a ɪ
 preponderance	p ɹ ɪ p ɒ n d ə ɹ ə n s
 preponderance	p ɹ ɪ p ɒ n d ɹ ə n s
+preported	p ɹ ɪ p ɔː t ɪ d
 prepose	p ɹ iː p ə ʊ z
 preposition	p ɹ iː p ə z ɪ ʃ ə n
 preposition	p ɹ ɛ p ə z ɪ ʃ ə n
@@ -51363,6 +51861,7 @@ prndl	p ɹ ɪ n d l̩
 pro	p ɹ ə ʊ
 proa	p ɹ ə ʊ ə
 proactive	p ɹ ə ʊ æ k t ɪ v
+proactively	p ɹ ə ʊ æ k t ɪ v l i
 prob'ly	p ɹ ɒ b l i
 probability	p ɹ ɒ b ə b ɪ l ɪ t i
 probable	p ɹ ɒ b ə b l̩
@@ -51509,7 +52008,7 @@ proggie	p ɹ ɒ ɡ i
 prognathous	p r ɑ ɡ n e ɪ θ ə s
 prognathous	p r ɑ ɡ n ə θ ə s
 prognoses	p ɹ ɒ ɡ n ə ʊ s iː z
-prognoses	p ɹ ɒ ɡ n ə ʊ z ə s
+prognoses	p ɹ ɒ ɡ n ə ʊ z ɪ z
 prognosis	p ɹ ɒ ɡ n ə ʊ s iː z
 prognosis	p ɹ ɒ ɡ n ə ʊ s ɪ s
 prognostic	p ɹ ɒ ɡ n ɒ s t ɪ k
@@ -51894,6 +52393,7 @@ provision	p ɹ ə v ɪ ʒ ə n
 provisional	p ɹ ə v ɪ ʒ ə n ə l
 provisions	p ɹ ə v ɪ ʒ ə n z
 proviso	p ɹ ə v a ɪ z o ʊ
+provisor	p ɹ ə v a ɪ z ə ɹ
 provisory	p ɹ ə v a ɪ z ə ɹ i
 provo	p ɹ ə ʊ v ə ʊ
 provocate	p ɹ ə v ɒ k e ɪ t
@@ -52107,6 +52607,7 @@ pubeless	p j uː b l ə s
 puberty	p j uː b ə t i
 pubes	p j uː b i z
 pubes	p j uː b z
+pubescence	p j uː b ɛ s ə n s
 pubescent	p j ʊ b ɛ s ə n t
 pubic	p j uː b ɪ k
 pubikini	p j uː b ɪ k iː n i
@@ -52249,6 +52750,7 @@ pultaceous	p ʌ l t e ɪ ʃ ə s
 pulverulent	p ʌ l v ɛ ɹ j ə l ə n t
 puma	p j uː m ə
 puma	p uː m ə
+pumicate	p j uː m ɪ k e ɪ t
 pumice	p ʌ m ɪ s
 pummel	p ʌ m ə l
 pump	p ʌ m p
@@ -52325,6 +52827,7 @@ punxsutawney	p ʌ ŋ k s ə t ɔː n i
 puny	p j uː n i
 pup	p ʌ p
 pupa	p j uː p ə
+pupal	p j uː p ə l
 pupe	p j u p
 pupil	p j uː p ə l
 pupils	p j uː p ə l z
@@ -52383,7 +52886,8 @@ purportion	p ə p ɔː ʃ ə n
 purpose	p ɜː p ə s
 purposed	p əː p ə s t
 purposedly	p ɜː ɹ p ə s ɪ d l i
-purposeful	p ɜː ɹ p ə s f ə l
+purposeful	p ɜː p ə s f ə l
+purposefully	p ɜː p ə s f ə l i
 purposely	p ɜː p ə s l i
 purposes	p ɜː p ə s ɪ z
 purposive	p əː p ə s ɪ v
@@ -52573,6 +53077,7 @@ python	p a ɪ θ ə n
 pythonista	p a ɪ θ ə n ɪ s t ə
 pythons	p a ɪ θ ə n z
 pyx	p ɪ k s
+pyxis	p ɪ k s ɪ s
 pâté	p æ t e ɪ
 pædion	p iː d ɪ ɒ n
 pædomorphic	p iː d ə m ɔː f ɪ k
@@ -52613,6 +53118,7 @@ qingdao	t͡ʃ ɪ ŋ d a ʊ
 qinghai	t͡ʃ ɪ ŋ h a ɪ
 qinghaosu	t͡ʃ ɪ ŋ h a ʊ s uː
 qingpu	t͡ʃ ɪ ŋ p u
+qingsongite	t͡ʃ ɪ ŋ s ɒ ŋ a ɪ t
 qinpu	t͡ʃ ɪ n p uː
 qipao	t͡ʃ iː p a ʊ
 qiqihar	t ʃ iː t ʃ iː h ɑː
@@ -52683,8 +53189,8 @@ quahog	k w ə ʊ h ɒ ɡ
 quahog	k ə ʊ h ɒ ɡ
 quaich	k w e ɪ k
 quaich	k w e ɪ x
-quail	k w e ɪ l
-quail	k w e ɪ ə l
+quail	kʷ e ɪ l
+quail	kʷ e ɪ ə l
 quailed	k w e ɪ l d
 quailing	k w e ɪ l ɪ ŋ
 quailings	k w e ɪ l ɪ ŋ z
@@ -52732,6 +53238,9 @@ quantitative	k w ɒ n t ə t ɪ v
 quantitative	k w ɒ n t ɪ t ə t ɪ v
 quantities	k w ɒ n t ɪ t i z
 quantity	k w ɒ n t ɪ t i
+quantivalence	k w ɒ n t ɪ v ə l ə n s
+quantivalency	k w ɒ n t ɪ v l ə n s i
+quantivalency	k w ɒ n t ɪ v ə l ə n s i
 quantized	k w ɒ n t ʌ ɪ z d
 quantum	k w ɒ n t ə m
 quantumly	k w ɒ n t ə m l i
@@ -52819,7 +53328,7 @@ quenya	kʷ w ɛ ɲ j a
 quercetin	k w ɜː ɹ s ɪ t ɪ n
 quercine	k w ɜː s a ɪ n
 quercine	k w ɜː s ɪ n
-quercitin	k w ɜ ɹ s ɨ t ɨ n
+quercitin	k w ɜ ɹ s ɪ t ɪ n
 querencia	k ɛ ɹ ɛ n s ɪ ə
 querent	k w ɚ ɛ n t
 querimonious	k w ɛ ɹ ɪ m ə ʊ n ɪ ə s
@@ -52936,6 +53445,7 @@ quinnat	k w ɪ n ə t
 quinoa	k iː n w ɑː
 quinoa	k iː n ə ʊ ə
 quinolone	k w ɪ n ə l ə ʊ n
+quinone	k w ɪ n ə ʊ n
 quinquagenarian	k w ɪ ŋ k w ə d͡ʒ ɪ n ɛ ə ɹ ɪ ə n
 quinquagenary	k w ɪ ŋ k w æ d͡ʒ ɪ n ə r i
 quinquagenary	k w ɪ ŋ k w ə d͡ʒ iː n ə ɹ i
@@ -52962,9 +53472,9 @@ quintation	k w ɪ n t e ɪ ʃ ə n
 quinte	k w ɪ n t i
 quinte	k ɛ̃ t
 quintessence	k w ɪ n t ɛ s ə n s
-quintessence	k w ɪ n t ɛ s ɨ n s
-quintessential	k w ɪ n t ə s ɛ n ʃ ə l
-quintessentially	k w ɪ n t ɛ s ɛ n t͡ʃ ə l i
+quintessence	k w ɪ n t ɛ s ɪ n s
+quintessential	k w ɪ n t ɪ s ɛ n ʃ ə l
+quintessentially	k w ɪ n t ɪ s ɛ n ʃ ə l i
 quintet	k w ɪ n t ɛ t
 quintillion	k w ɪ n t ɪ l j ə n
 quintillionth	k w ɪ n t ɪ l i ə n θ
@@ -53007,7 +53517,7 @@ quizzacious	k w ɪ z e ɪ ʃ ə s
 quizzaciously	k w ɪ z e ɪ ʃ ə s l i
 quizzical	k w ɪ z ɪ k ə l
 qujing	t͡ʃ uː d͡ʒ ɪ ŋ
-qulin	k j uː l ɨ n
+qulin	k j uː l ɪ n
 qumran	k ʊ m ɹ ɑː n
 quo	k w ə ʊ
 quoad	k w o ʊ æ d
@@ -53078,6 +53588,7 @@ racer	ɹ e ɪ s ə
 races	ɹ e ɪ s ɪ z
 racetrack	ɹ e ɪ s t ɹ æ k
 rach	ɹ e ɪ t͡ʃ
+rach	ɹ æ t ʃ
 rachel	ɹ e ɪ t͡ʃ ə l
 rachis	ɹ e ɪ k ɪ s
 rachitic	ɹ ə k ɪ t ɪ k
@@ -53294,6 +53805,7 @@ rang	ɹ æ ŋ
 range	ɹ e ɪ n d͡ʒ
 ranger	ɹ e ɪ n d͡ʒ ə ɹ
 ranges	ɹ e ɪ n d͡ʒ ɪ z
+rangifer	r æ n d ʒ ɪ f ə ɹ
 rangiora	ɹ a ŋ ɡ i ɔː ɹ ə
 rangle	ɹ æ ŋ ɡ l̩
 rangoli	ɹ a ŋ ɡ ə ʊ l i
@@ -53327,6 +53839,7 @@ raper	ɹ e ɪ p ə ɹ
 raphae	ɹ e ɪ f iː
 raphael	ɹ æ f e ɪ ɛ l
 raphael	ɹ æ f ɪ ə l
+raphanus	r æ f ə n ə s
 raphe	ɹ e ɪ f i
 rapid	ɹ æ p ɪ d
 rapidity	ɹ ə p ɪ d ɪ t i
@@ -53467,6 +53980,7 @@ razorback	ɹ e ɪ z ə b æ k
 razz	ɹ æ z
 razzmatazz	ɹ æ z m ə t æ z
 raï	ɹ a ɪ
+raï	ɹ ʌ iː
 re	ɹ e ɪ
 re	ɹ iː
 reaccept	ɹ i ə k s e p t
@@ -53492,6 +54006,7 @@ readiness	ɹ ɛ d i n ə s
 reading	ɹ i d i ŋ
 reading	ɹ iː d ɪ ŋ
 reading	ɹ ɛ d ɪ ŋ
+readmission	ɹ iː æ d m ɪ ʃ ə n
 readout	ɹ iː d a ʊ t
 reads	ɹ iː d z
 ready	ɹ ɛ d i
@@ -53505,6 +54020,7 @@ reaganomics	r e ɪ ɡ ə n ɒ m ɪ k s
 reagent	ɹ i e ɪ d͡ʒ ə n t
 reak	ɹ iː k
 real	ɹ e ɪ ɑː l
+real	ɹ i ɯ
 real	ɹ iː l
 real	ɹ iː ə l
 real	ɹ ɪ ə̯ l
@@ -53548,6 +54064,7 @@ reard	ɹ ɛː d
 reard	ɹ ɪː d
 reared	ɹ ɪ ə d
 rearguard	ɹ ɪ ə ɹ ɡ ɑ ɹ d
+rearview	ɹ ɪ ə v j uː
 rearward	ɹ ɪ ə w ɜː d
 reason	ɹ iː z ə n
 reasonable	ɹ iː z n ə b ə l
@@ -53614,7 +54131,7 @@ recapitulate	ɹ iː k ə p ɪ t ʃ ʊ l e ɪ t
 recapitulation	ɹ iː k ə p ɪ t j ʊ l e ɪ ʃ ə n
 recatholicization	ɹ iː k ə θ ɒ l ɪ s ʌ ɪ z e ɪ ʃ ə n
 recce	ɹ ɛ k i
-recede	ɹ ɨ s iː d
+recede	ɹ ɪ s iː d
 receipt	ɹ ɪ s iː t
 receive	ɹ ɪ s iː v
 received	ɹ ɪ s iː v d
@@ -53777,7 +54294,7 @@ redden	ɹ ɛ d n̩
 reddest	ɹ ɛ d ɪ s t
 reddish	ɹ ɛ d ɪ ʃ
 reddishness	ɹ ɛ d ɪ ʃ n ə s
-reddit	r ɛ d ɪ t
+reddit	ɹ ɛ d ɪ t
 reddition	ɹ ə d ɪ ʃ ə n
 redditor	ɹ ɛ d ɪ t ə ɹ
 reddy	ɹ ɛ d i
@@ -53785,7 +54302,7 @@ rede	ɹ iː d
 redebug	ɹ iː d iː b ʌ ɡ
 redeem	ɹ ɪ d iː m
 redeliver	ɹ iː d ɪ l ɪ v ə ɹ
-redemption	ɹ ɪ d ɛ m ʃ ə n
+redemption	ɹ ɪ d ɛ m p ʃ ə n
 redemptory	ɹ ɪ d ɛ m p t ə ɹ i
 redesign	ɹ iː d ɪ z a ɪ n
 redesmouth	ɹ iː d z m ə θ
@@ -53914,6 +54431,7 @@ reflet	ɹ ə f l e ɪ
 reflexible	ɹ ɪ f l ɛ k s ɪ b ə l
 reflexion	ɹ ɪ f l ɛ k ʃ ə n
 reflexive	ɹ ə f l ɛ k s ɪ v
+refluent	ɹ ɛ f l u ə n t
 reflux	ɹ iː f l ʌ k s
 refold	ɹ iː f o ʊ l d
 reforecast	ɹ iː f ɔː k ɑː s t
@@ -54086,6 +54604,7 @@ reinstate	ɹ iː ɪ n s t e ɪ t
 reinter	ɹ iː ɪ n t ɝ
 reird	ɹ ɪ ə d
 reisz	ɹ a ɪ s
+reit	ɹ iː t
 reiter	ɹ ʌ ɪ t ə
 reiterant	ɹ i ɪ t ɝ ə n t
 reiterate	ɹ i ɪ t ə ɹ e ɪ t
@@ -54279,6 +54798,7 @@ renaissance	ɹ ɛ n ə s ɒ̃ n s
 renal	ɹ iː n ə l
 renaldo	ɹ ɪ n æ l d ə ʊ
 renaldo	ɹ ɪ n ɑ l d ə ʊ
+renarrative	ɹ iː n æ ɹ ə t ɪ v
 renascence	ɹ ɪ n a s ə n s
 renascence	ɹ ɪ n e ɪ s ə n s
 renascent	ɹ ɪ n e ɪ s ə n t
@@ -54417,7 +54937,7 @@ represented	ɹ ɛ p ɹ ɪ z ɛ n t ɪ d
 representing	ɹ ɛ p ɹ ɪ z ɛ n t ɪ ŋ
 repress	ɹ ə p ɹ ɛ s
 repressed	ɹ i p ɹ ɛ s t
-repressed	ɹ ɨ p ɹ ɛ s t
+repressed	ɹ ɪ p ɹ ɛ s t
 reprieve	ɹ ɪ p ɹ iː v
 reprimand	ɹ ɛ p ɹ ɪ m ɑː n d
 reprinted	ɹ iː p ɹ ɪ n t ɪ d
@@ -54468,9 +54988,8 @@ request	ɹ ɪ k w ɛ s t
 requested	ɹ ɪ k w ɛ s t ɪ d
 requeue	ɹ iː k j uː
 requicken	r iː k w ɪ k ə n
+requiem	ɹ ɛ k w i ə m
 requiem	ɹ ɛ k w i ɛ m
-requiem	ɹ ɛ k w ɪ ə m
-requiem	ɹ ɛː k w i ə m
 requiescat	ɹ ɛ k w ɪ ɛ s k æ t
 require	ɹ ɪ k w a ɪ ə
 required	ɹ ɪ k w a ɪ ə d
@@ -54499,6 +55018,8 @@ rerun	ɹ iː ɹ ʌ n
 res	ɹ e ɪ z
 res	ɹ ɛ z
 resalute	ɹ iː s ə l uː t
+resched	ɹ iː s k ɛ d
+resched	ɹ iː ʃ ɛ d
 reschedule	ɹ iː s k ɛ d j uː l
 reschedule	ɹ iː s k ɛ d͡ʒ uː l
 reschedule	ɹ iː ʃ ɛ d j uː l
@@ -54509,8 +55030,8 @@ rescrutiny	ɹ iː s k ɹ uː t ɪ n i
 rescue	ɹ ɛ s k j uː
 rescued	ɹ ɛ s k j uː d
 rese	ɹ iː z
-research	ɹ iː s ɜː t ʃ
-research	ɹ ɪ s ɜː t ʃ
+research	ɹ iː s ɜː t͡ʃ
+research	ɹ ɪ s ɜː t͡ʃ
 researcher	ɹ ɪ s ɜː t͡ʃ ə
 researches	ɹ ɪ s ɜː t͡ʃ ɪ z
 reseat	ɹ iː s iː t
@@ -54581,8 +55102,8 @@ resonance	ɹ ɛ z ə n ə n s
 resonant	ɹ ɛ z ə n ə n t
 resonate	ɹ ɛ z ə n e ɪ t
 resorbable	ɹ ɪ z ɔː ɹ b ə b ə l
+resorcinol	ɹ ə z ɔː ɹ s ɪ n ɒ l
 resort	ɹ iː s ɔ ɹ t
-resort	ɹ ɨ z ɔ ɹ t
 resound	ɹ iː s a ʊ n d
 resound	ɹ ɪ s a ʊ n d
 resound	ɹ ɪ z a ʊ n d
@@ -54621,7 +55142,9 @@ resplendence	ɹ ɪ s p l ɛ n d ə n s
 resplendent	ɹ ɪ s p l ɛ n d ə n t
 respond	ɹ iː s p ɒ n d
 respond	ɹ ə s p ɒ n d
+respond	ɹ ɪ s p ɒ n d
 responded	ɹ ə s p ɒ n d ɪ d
+responded	ɹ ɪ s p ɒ n d ɪ d
 respondee	ɹ ɪ s p ɒ n d iː
 respondence	ɹ ɪ s p ɒ n d ə n s
 responder	ɹ ə s p ɒ n d ə
@@ -54743,7 +55266,7 @@ reticuloid	ɹ ɪ t ɪ k j ʊ l ɔ ɪ d
 retina	ɹ ɛ t ɪ n ə
 retinaculum	r ɛ t ɪ n æ k j ʊ l ə m
 retinal	ɹ ɛ t ɪ n ə l
-retinopathy	ɹ ɛ t ɨ n ɑː p ə θ i
+retinopathy	ɹ ɛ t ɪ n ɑː p ə θ i
 retinue	ɹ ɛ t ɪ n j uː
 retiral	ɹ ɪ t ʌ ɪ ə ɹ ə l
 retire	ɹ ə t a ɪ ə ɹ
@@ -54844,8 +55367,8 @@ reverberate	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ t
 reverberation	ɹ i v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ə v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ ʃ ə n
-reverberative	ɹ ə v ɜː b ə ɹ ə t ɪ v
 reverberative	ɹ ə v ɜː b ɹ ə t ɪ v
+reverberative	ɹ ɪ v ɜː b ə ɹ ə t ɪ v
 revere	ɹ ə v iː ɹ
 revered	ɹ ɪ v ɪ ə d
 reverence	ɹ ɛ v ə ɹ ə n s
@@ -54863,7 +55386,7 @@ reversion	ɹ ɪ v ɜː ʒ ə n̩
 reversionary	ɹ ɪ v ɜː ɹ ʒ ə n ə ɹ i
 reversionary	ɹ ɪ v ɜː ɹ ʒ ə n ɹ i
 revert	ɹ iː v ɜː t
-revert	ɹ ɨ v ɜː t
+revert	ɹ ɪ v ɜː t
 revertent	ɹ ɪ v ɜː ɹ t ə n t
 revertible	ɹ ɪ v ɜː t ɪ b l̩
 revest	ɹ iː v ɛ s t
@@ -55089,7 +55612,6 @@ rictus	ɹ ɪ k t ə s
 rictus	ɹ ɪ k t ʊ s
 rid	ɹ ɪ d
 riddance	ɹ ɪ d ə n s
-ridden	ɹ ɪ d n̩
 riddle	ɹ ɪ d ə l
 riddled	ɹ ɪ d ə l d
 ride	ɹ a ɪ d
@@ -55334,6 +55856,7 @@ rochester	ɹ ɒ t͡ʃ ɪ s t ə
 rochet	ɹ ɒ t ʃ ɪ t
 rock	ɹ ɒ k
 rockabilly	ɹ ɒ k ə b ɪ l i
+rockall	ɹ ɒ k ɔː l
 rocker	ɹ ɒ k ə ɹ
 rockery	ɹ ɒ k ə ɹ i
 rocket	ɹ ɒ k ɪ t
@@ -55430,6 +55953,7 @@ romanization	ɹ ə ʊ m ə n a ɪ z e ɪ ʃ ə n
 romans	ɹ ə ʊ m ə n z
 romansch	ɹ ə ʊ m a n ʃ
 romantic	ɹ ə ʊ m æ n t ɪ k
+romanticism	ɹ ə ʊ m æ n t ɪ s ɪ z ə m
 romaphobia	ɹ o ʊ m ə f o ʊ b i ə
 romaphobia	ɹ ə ʊ m ə f ə ʊ b i ə
 romaunt	ɹ ə m ɔː n t
@@ -55511,7 +56035,7 @@ roration	r ə ʊ r e ɪ ʃ ə n
 rore	ɹ ɔː
 roriferous	ɹ o ʊ ɹ ɪ f ɚ ə s
 roriferous	ɹ ə ʊ ɹ ɪ f ə ɹ ə s
-rorqual	ɹ ɒ ɹ k w ə l
+rorqual	ɹ ɔː k w ə l
 rort	ɹ ɔː ɹ t
 rorty	ɹ ɔː t i
 rory	ɹ o ə ɹ i
@@ -55709,6 +56233,7 @@ rubescent	ɹ uː b ɛ s ə n t
 rubicon	ɹ uː b ɪ k ɒ n
 rubicund	ɹ uː b ɪ k ə n d
 rubidium	ɹ uː b ɪ d i ə m
+rubigo	ɹ uː b a ɪ ɡ ə ʊ
 rubin	ɹ uː b ɪ n
 ruble	ɹ uː b ə l
 rubric	ɹ uː b ɹ ɪ k
@@ -55812,7 +56337,7 @@ runned	ɹ ʌ n d
 runnel	ɹ ʌ n l
 runnel	ɹ ʌ n ə l
 runner	ɹ ʌ n ə
-running	ɹ ʌ n ɪ ŋ
+running	ɹ ʌ n i ŋ
 runny	ɹ ʌ n i
 runout	ɹ ʌ n a ʊ t
 runs	ɹ ʌ n z
@@ -55852,6 +56377,8 @@ russet	ɹ ʌ s ɪ t
 russia	ɹ ʌ ʃ ə
 russian	ɹ ʌ ʃ ə n
 russias	ɹ ʌ ʃ ə s
+russify	ɹ uː s ɪ f a ɪ̯
+russify	ɹ ʌ s ɪ f a ɪ̯
 russki	ɹ ʌ s k i
 russophilia	ɹ ʌ s ə f ɪ l i ə
 russophobe	ɹ ʌ s ə ʊ f ə ʊ b
@@ -55902,6 +56429,8 @@ rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ɒ l ɪ t ə
 rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ə l a ɪ t ə
 rzeszów	ʒ ɛ ʃ uː f
 réaumur	ɹ e ɪ ə ʊ m j ʊ ə ɹ
+résumé	ɹ ɛ z j ʊ m e ɪ
+résumé	ɹ ɪ z j uː m e ɪ
 röntgen	ɹ ɜː n t ɡ ə n
 rösti	ɹ ɒ s t ɪ
 rösti	ɹ ɜː s t ɪ
@@ -55940,8 +56469,6 @@ sable	s e ɪ b ə l
 sable	s e ɪ b ɫ
 sables	s e ɪ b ə l z
 sabot	s æ b ə ʊ
-sabotage	s æ b ɒ t ɑː ʒ
-sabotage	s æ b ɒ t ɪ d͡ʒ
 sabotage	s æ b ə t ɑː ʒ
 saboteur	s æ b ə t ɜː ɹ
 saboteur	s æ b ə t ʊ ə ɹ
@@ -56108,7 +56635,7 @@ salak	s ə l æ k
 salamanca	s æ l ə m æ ŋ k ə
 salamander	s æ l ə m æ n d ə
 salamander	s æ l ə m ɑː n d ə
-salary	s æ l ɚ i
+salary	s æ l ə ɹ i
 salaryman	s æ l ə ɹ i m æ n
 salat	s ə l ɑː t
 salateen	s a l ə t iː n
@@ -56150,7 +56677,7 @@ salination	s æ l ə n e ɪ ʃ ə n
 saline	s e ɪ l a ɪ n
 salinely	s ə l iː n l i
 salinification	s ə l ɪ n ə f ə k e ɪ ʃ ə n
-saliniform	s ə l ɪ n ɨ f ɒ ɹ m
+saliniform	s ə l ɪ n ɪ f ɒ ɹ m
 salinity	s e ɪ l ɪ n ə t i
 salinize	s æ l ɪ n a ɪ z
 salipenter	s æ l ɪ p ɛ n t ə
@@ -56160,7 +56687,7 @@ salique	s ə l iː k
 salishan	s e ɪ l ɪ ʃ ə n
 saliva	s ə l a ɪ v ə
 salivant	s æ l ə v ə n t
-salivarium	s æ l ɨ v ɛ ɹ iː ə m
+salivarium	s æ l ɪ v ɛ ɹ iː ə m
 salivary	s æ l ɪ v ə ɹ i
 salivary	s ə l a ɪ v ə ɹ i
 salivate	s æ l ɪ v e ɪ t
@@ -56258,6 +56785,8 @@ sammamish	s ə m æ m ɪ ʃ
 sammy	s æ m i
 samnite	s æ m n a ɪ t
 samoa	s ə m ə ʊ ə
+samogitia	s a m ə ʊ ɡ iː ʃ ə
+samogitian	s a m ə ʊ ɡ iː ʃ ə n
 samos	s e ɪ m ɒ s
 samosata	s ə m ɒ s ə t ə
 samothracian	s æ m ə ʊ θ ɹ e ɪ ʃ i ə n
@@ -56270,6 +56799,7 @@ samp	s a m p
 sampa	s æ m p ə
 samphire	s æ m f a ɪ ə ɹ
 samphire	s æ m f ə ɹ
+sample	s æ m p ə l
 sample	s ɑː m p ə l
 sampler	s a m p l ɚ
 sampler	s a m p ə l ɚ
@@ -56383,6 +56913,7 @@ sapphic	s æ f ɪ k
 sapphire	s æ f a ɪ̯ ə ɹ
 sapphism	s æ f ɪ z m̩
 sappho	s æ f ə ʊ
+sappie	s æ p i
 sappy	s æ p i
 sapropel	s a p ɹ ə ʊ p ɛ l
 saprophyte	s æ p ɹ ə ʊ f a ɪ t
@@ -56676,7 +57207,7 @@ scarify	s k ɑː ɹ ɪ f a ɪ
 scaring	s k ɛː ɹ ɪ ŋ
 scarlet	s k ɑː l ɪ t
 scarp	s k ɑː p
-scarper	s k ɑː ɹ p ə ɹ
+scarper	s k ɑː p ə
 scarred	s k ɑː ɹ d
 scarry	s k ɑː ɹ i
 scars	s k ɑː ɹ z
@@ -56721,11 +57252,13 @@ sceptic	s k ɛ p t ɪ k
 sceptral	s ɛ p t ɹ ə l
 sceptre	s ɛ p t ə
 scetavajasse	ʃ e ɪ t ə v a ɪ ɑː s e ɪ
+schachter	ʃ æ k t ɚ
 schadenfreude	ʃ ɑː d ə n f ɹ ɔ ɪ d ə
 schappe	ʃ æ p
 schappe	ʃ ɑ p ə
 scharnhorst	ʃ ɑː ɹ n h ɔː ɹ s t
 schatz	ʃ æ t s
+sched	s k ɛ d͡ʒ
 schediaphilia	s k ɛ d i ə f ɪ l i ə
 schedule	s k ɛ d j uː l
 schedule	s k ɛ d ʒ uː l
@@ -56791,6 +57324,7 @@ schloop	ʃ l uː p
 schloopy	ʃ l uː p i
 schlub	ʃ l ʌ b
 schlubby	ʃ l ʌ b i
+schlump	ʃ l ʌ m p
 schmaltz	ʃ m ɒ l t s
 schmaltzy	ʃ m ɒ l t s i
 schmear	ʃ m ɪ ə ɹ
@@ -56854,6 +57388,7 @@ scialytic	s ʌ ɪ ə l ɪ t ɪ k
 sciamachy	s ʌ ɪ æ m ə k i
 sciapod	s ʌ ɪ ə p ɒ d
 sciatheric	s a ɪ ə θ ɛ ɹ ɪ k
+sciatic	s a ɪ æ t ɪ k
 sciatica	s a ɪ æ t ɪ k ə
 scicli	ʃ i k l i
 science	s a ɪ ə n s
@@ -56959,13 +57494,13 @@ scotchka	s k ɒ t ʃ k ə
 scotchman	s k ɒ t͡ʃ m ə n
 scoter	s k ə ʊ t ə
 scotia	s k o ʊ ʃ ə
+scotia	s k ə ʊ ʃ ə
 scotland	s k ɒ t l ə n d
 scotoma	s k ə t o ʊ m ə
 scotopic	s k ə ʊ t ɒ p ɪ k
 scots	s k ɒ t s
 scott	s k ɒ t
 scottish	s k ɒ t ɪ ʃ
-scotus	s k o ʊ t ə s
 scoundrel	s k a ʊ̯ n d ɹ ə l
 scour	s k a ʊ ə
 scourer	s k a ʊ ɹ ə
@@ -57149,7 +57684,7 @@ seals	s iː l z
 seam	s iː m
 seaman	s iː m ə n
 seamanship	s iː m ə n ʃ ɪ p
-seamen	s iː m ə n
+seamen	s iː m ɛ n
 seaming	s iː m ɪ ŋ
 seams	s iː m z
 seamus	ʃ e ɪ m ə s
@@ -57506,7 +58041,7 @@ senegal	s ɛ n ɪ ɡ ɑː l
 senegal	s ɛ n ɪ ɡ ɔː l
 senegalese	s ɛ n ə ɡ ə l iː z
 senesce	s ə n ɛ s
-senescence	s ɨ n ɛ s ə n s
+senescence	s ɪ n ɛ s ə n s
 seneschal	s ɛ n ə ʃ ə l
 senex	s ɛ n ɛ k s
 sengi	s ɛ ŋ ɡ i
@@ -57638,6 +58173,7 @@ sequester	s ɪ k w ɛ s t ə
 sequestrate	s iː k w ə s t ɹ e ɪ t
 sequestrator	s iː k w ə s t ɹ e ɪ t ə ɹ
 sequin	s iː k w ɪ n
+sequined	s iː k w ɪ n d
 sequoia	s ə k w ɔ ɪ ə
 sequuntur	s ɛ k w ʊ n t ʊ ə
 serac	s ɛ ɹ æ k
@@ -57675,7 +58211,6 @@ sericulture	s ɛ ɹ ɪ k ʌ l t ʃ ə
 seriema	s ɛ ɹ ɪ iː m ə
 series	s ɪ ə ɹ iː z
 serif	s ə ɹ i f
-serif	s ɛ ɹ ə f
 serif	s ɛ ɹ ɪ f
 seriocomical	s ɪ ə ɹ i ə ʊ k ɒ m ɪ k ə l
 serious	s ɪ ə ɹ ɪ ə s
@@ -57751,6 +58286,7 @@ setebos	s ɛ t ɛ b ʌ s
 setfast	s ɛ t f ɑː s t
 seth	s ɛ θ
 setiferous	s iː t ɪ f ə ɹ ə s
+setiger	s iː t ɪ d ʒ ə ɹ
 setim	s iː t ɪ m
 setpoint	s ɛ t p ɔ ɪ n t
 setpoints	s ɛ t p ɔ ɪ n t s
@@ -57780,7 +58316,7 @@ sevastopol	s ɛ v ə s t o ʊ p ə l
 seven	s ɛ v ə n
 sevennight	s ɛ v ə n n ɑ ɪ t
 seventeenth	s ɛ v ə n t iː n θ
-seventh	s ɛ v ə n θ
+seventh	s ɛ v n θ
 seventieth	s ɛ v n t i ə θ
 seventy	s ɛ v ə n t i
 several	s ɛ v ə ɹ ə l
@@ -57799,6 +58335,8 @@ sewed	s ə ʊ d
 sewell	s u ə l
 sewer	s j uː ə
 sewer	s ə ʊ ə
+sewerage	s uː ə ɹ ɪ d͡ʒ
+sewerage	s uː ɹ ɪ d͡ʒ
 sewing	s ə ʊ ɪ ŋ
 sewn	s ə ʊ n
 sex	s ɛ k s
@@ -58045,6 +58583,7 @@ sheathbill	ʃ iː θ b ɪ l
 sheathe	ʃ iː ð
 sheathed	ʃ iː ð d
 sheathed	ʃ iː θ t
+sheaths	ʃ iː ð z
 sheathy	ʃ iː θ i
 sheave	ʃ iː v
 sheba	ʃ iː b ə
@@ -58074,6 +58613,7 @@ sheet	ʃ iː t
 sheets	ʃ iː t s
 sheffield	ʃ ɛ f iː l d
 sheik	ʃ e ɪ k
+sheik	ʃ i k
 sheikdom	ʃ e ɪ k d ə m
 sheikdom	ʃ iː k d ə m
 sheila	ʃ iː l ə
@@ -58106,6 +58646,7 @@ shelves	ʃ ɛ l v z
 shemagh	ʃ ə m ɑː ɡ
 shemagh	ʃ ə m ɑː ɣ
 shemaiah	ʃ ɛ m ɛ j ɑː
+shen	ʃ ɛ n
 shenanigan	ʃ ə n æ n ɪ ɡ ə n
 shenanigans	ʃ ɪ n æ n ɪ ɡ ə n z
 shend	ʃ ɛ n d
@@ -58323,8 +58864,8 @@ shooter	ʃ uː t ə ɹ
 shooting	ʃ uː t ɪ ŋ
 shootout	ʃ uː t a ʊ t
 shoots	ʃ uː t s
-shop	ʃ o p
-shopkeeper	ʃ ɒ p k iː p ə
+shop	ʃ ɒ p
+shopkeeper	ʃ ɒ p k iː p ɚ
 shoplet	ʃ ɒ p l ə t
 shoplift	ʃ ɒ p l ɪ f t
 shopper	ʃ ɒ p ə
@@ -58397,8 +58938,8 @@ shreddy	ʃ ɹ ɛ d i
 shrek	ʃ ɹ ɛ k
 shrew	ʃ ɹ uː
 shrewd	ʃ ɹ uː d
-shrewsbury	ʃ ɹ uː z b ɹ ɪ
-shrewsbury	ʃ ɹ ə ʊ z b ɹ ɪ
+shrewsbury	ʃ ɹ uː z b ɹ i
+shrewsbury	ʃ ɹ ə ʊ z b ɹ i
 shriek	ʃ ɹ iː k
 shrieky	ʃ ɹ iː k i
 shrieval	ʃ ɹ iː v ə l
@@ -58464,9 +59005,9 @@ shunt	ʃ ʌ n t
 shuntak	ʃ ʌ n t æ k
 shunto	ʃ ʊ n t o ʊ
 shup	ʃ ʌ p
-shuriken	ʃ uː ɹ ɨ k ə n
-shuriken	ʃ ɝ ɨ k ə n
-shuriken	ʃ ʊ ə ɹ ɨ k ə n
+shuriken	ʃ uː ɹ ɪ k ə n
+shuriken	ʃ ɝ ɪ k ə n
+shuriken	ʃ ʊ ə ɹ ɪ k ə n
 shush	ʃ ʊ ʃ
 shush	ʃ ʌ ʃ
 shuswap	ʃ uː ʃ w ɑː p
@@ -58513,13 +59054,15 @@ sic	s ɪ k
 siccawei	s ɪː k ɑː w e ɪ
 siccawei	s ɪː k ə w e ɪ
 sice	s a ɪ s
+sicel	s ɪ k ə l
+sicel	s ɪ s ə l
 sich	s iː t͡ʃ
 sichuan	s ɛ t͡ʃ w ɑ n
 sichuan	s ɛ ʃ w ɑ n
 sichuan	s ɪ t͡ʃ w ɑ n
 sicilia	s ɪ s ɪ l j ə
 sicilicus	s ɪ s ɪ l ɪ k ə s
-sicily	s ɪ s ɨ l i
+sicily	s ɪ s ɪ l i
 sick	s ɪ k
 sickbed	s ɪ k b ɛ d
 sicken	s ɪ k ə n
@@ -58538,6 +59081,7 @@ sidcup	s ɪ d k ʌ p
 siddur	s ɪ d ʊ ə
 side	s a ɪ d
 sideburns	s a ɪ d b ɜː ɹ n z
+sidecar	s a ɪ d k ɑ ɹ
 sidekick	s a ɪ d k ɪ k
 sideline	s a ɪ d l a ɪ n
 sidequest	s a ɪ d k w ɛ s t
@@ -58713,7 +59257,7 @@ simoom	s ɪ m uː m
 simp	s ɪ m p
 simpatico	s ɪ m p a t ɪ k ə ʊ
 simper	s ɪ m p ə
-simple	s ɪ m p ə l
+simple	s ɪ m p l̩
 simpler	s ɪ m p l ə
 simpler	s ɪ m p l̩ ə
 simplest	s ɪ m p l ə s t
@@ -58732,6 +59276,7 @@ simply	s ɪ m p l i
 simpson	s ɪ m p s ə n
 simul	s ɪ m ə l
 simulacrum	s i m j ə l e ɪ k ɹ ə m
+simulant	s ɪ m j ʊ l ə n t
 simular	s ɪ m j ʊ l ə ɹ
 simulate	s ɪ m j ʊ l e ɪ t
 simulate	s ɪ m j ʊ l ɪ t
@@ -59043,6 +59588,7 @@ skoliosexual	s k o ʊ l i o ʊ s ɛ k ʃ u ə l
 skookum	s k uː k ə m
 skoosh	s k u ʃ
 skopje	s k ɔ p j ɛ
+skopostheorie	s k ə ʊ p ə ʊ s t e ɪ ə ɹ iː
 skoracki	s k ə ɹ æ k i
 skraeling	s k ɹ e ɪ l ɪ ŋ
 skrike	s k ɹ a ɪ k
@@ -59161,6 +59707,7 @@ sleazy	s l iː z i
 sleb	s l ɛ b
 sled	s l ɛ d
 sledge	s l ɛ d͡ʒ
+sledgehammer	s l ɛ d͡ʒ h æ m ə
 sledger	s l ɛ d͡ʒ ə ɹ
 sleek	s l iː k
 sleekly	s l iː k l i
@@ -59273,10 +59820,12 @@ slope	s l ə ʊ p
 sloping	s l ə ʊ p ɪ ŋ
 sloppy	s l ɒ p i
 slopy	s l ə ʊ p i
+slosh	s l ɒ ʃ
 sloshed	s l ɒ ʃ t
 sloshy	s l ɒ ʃ i
 slot	s l ɒ t
 sloth	s l ə ʊ θ
+slothen	s l ə ʊ θ ə n
 slouch	s l a ʊ t͡ʃ
 slough	s l a ʊ
 slough	s l ʌ f
@@ -59464,6 +60013,7 @@ snack	s n æ k
 snacker	s n æ k ə ɹ
 snackery	s n æ k ə ɹ iː
 snacky	s n æ k i
+snaefell	s n e ɪ f ɛ l
 snaffle	s n æ f ə l
 snafu	s n æ f uː
 snafu	s n ɑː f uː
@@ -59679,6 +60229,7 @@ sodcast	s ɒ d k æ s t
 sodcast	s ɒ d k ɑː s t
 sodden	s ɒ d ə n
 sodger	s ɒ d ʒ ə
+sodiasm	s ə ʊ d ɪ ə z ə m
 sodium	s ə ʊ d ɪ ə m
 sodom	s ɒ d ə m
 sodomise	s ɒ d ə m a ɪ z
@@ -59713,11 +60264,12 @@ sohcahtoa	s ɒ k ə t o ʊ ə
 soho	s ə ʊ h ə ʊ
 soigneur	s w ʌ n j ɜː
 soigné	s w ɑː n j e ɪ
-soil	s ɔ ɪ l
+soil	s ɔ ɪ l̩
 soilage	s ɔ ɪ l ɪ d͡ʒ
 soilure	s ɔ ɪ l j ə
 soilure	s ɔ ɪ l j ʊ ə
 soiree	s w ɑː ɹ e ɪ
+soja	s ə ʊ d ʒ ə
 sojourn	s ɒ d͡ʒ ə n
 sojourn	s ɒ d͡ʒ ɜː n
 sojourn	s ə ʊ d͡ʒ ɜː n
@@ -59754,6 +60306,7 @@ solely	s ə ʊ l l i
 solemn	s ɒ l ə m
 solemnity	s ə l ɛ m n ɪ t i
 solemnly	s ɒ l ə m l i
+solen	s ə ʊ l ə n
 solent	s ə ʊ l ə n t
 soleus	s ə l iː ə s
 soleus	s ə ʊ l iː ə s
@@ -60135,6 +60688,7 @@ sparql	s p ɑː k ə l
 sparring	s p ɑː ɹ ɪ ŋ
 sparrow	s p æ ɹ ə ʊ
 sparse	s p ɑː s
+sparsentan	s p ɑː ɹ s ɛ n t æ n
 sparta	s p ɑː ɹ t ə
 spartacus	s p ɑː t ə k ə s
 spartan	s p ɑː ɹ t ə n
@@ -60145,6 +60699,8 @@ spasmodic	s p æ z m ɒ d ɪ k
 spastic	s p a s t ɪ k
 spat	s p æ t
 spatchcock	s p æ t͡ʃ k ɒ k
+spatchcocked	s p æ t͡ʃ k ɒ k t
+spatchcocking	s p æ t͡ʃ k ɒ k ɪ ŋ
 spate	s p e ɪ t
 spathal	s p e ɪ ð ə l
 spathe	s p e ɪ ð
@@ -60269,6 +60825,7 @@ spending	s p ɛ n d ɪ ŋ
 spendthrift	s p ɛ n d θ ɹ ɪ f t
 spenser	s p ɛ n s ə ɹ
 spent	s p ɛ n t
+sperage	s p ɛ ɹ ɪ d ʒ
 sperate	s p ɪ ə ɹ ə t
 sperge	s p ɜː ɹ d͡ʒ
 sperm	s p ɜː m
@@ -60329,6 +60886,7 @@ spider	s p a ɪ̯ d ə
 spiderling	s p a ɪ d ə l ɪ ŋ
 spiderweb	s p a ɪ̯ d ə w ɛ b
 spidey	s p a ɪ d i
+spie	s p a ɪ
 spiedie	s p iː d i
 spiel	s p iː l
 spiel	ʃ p iː l
@@ -60404,11 +60962,11 @@ spiritualism	s p ɪ ɹ ɪ t j u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ ə l ɪ z ə m
 spirituality	s p ɪ ɹ ə t͡ʃ u æ l ə t ɪ
-spirocheticidal	s p a ɪ r o ʊ k i t ɨ s a ɪ d ə l
+spirocheticidal	s p a ɪ r o ʊ k i t ɪ s a ɪ d ə l
 spirochetocidal	s p a ɪ r o ʊ k i t ə s a ɪ d ə l
-spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɨ s ɨ s
-spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɨ k
-spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɨ k
+spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɪ s ɪ s
+spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɪ k
+spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɪ k
 spirometer	s p ʌ ɪ ɹ ɒ m ɪ t ə
 spironolactone	s p ʌ ɪ ɹ ə n ə ʊ l æ k t ə ʊ n
 spirulina	s p a ɪ ɹ ə l iː n ə
@@ -60484,6 +61042,7 @@ spondulicks	s p ɒ n d j uː l ɪ k s
 spondylosis	s p ɒ n d ɪ l ə ʊ s ɪ s
 sponge	s p ʌ n d͡ʒ
 spongy	s p ʌ n d͡ʒ i
+sponk	s p ɒ ŋ k
 sponsor	s p ɒ n s ə
 spontaneity	s p ɒ n t ə n e ɪ ə t i
 spontaneous	s p ɒ n t e ɪ n i ə s
@@ -60542,8 +61101,8 @@ spotter	s p ɒ t ə
 spouge	s p uː d͡ʒ
 spousal	s p a ʊ z ə l
 spouse	s p a ʊ s
-spouses	s p a ʊ s ɨ z
-spouses	s p a ʊ z ɨ z
+spouses	s p a ʊ s ɪ z
+spouses	s p a ʊ z ɪ z
 spout	s p a ʊ t
 spouty	s p a ʊ t i
 sprachbund	s p ɹ ɑː k b ʊ n d
@@ -60745,7 +61304,6 @@ stabbed	s t æ b d
 stabbing	s t æ b ɪ ŋ
 stabenow	s t æ b ɪ n a ʊ
 stabiliment	s t ə b ɪ l ɪ m ə n t
-stability	s t ə b ɪ l ɪ d i
 stability	s t ə b ɪ l ɪ t i
 stabilization	s t e ɪ b ə l a ɪ z e ɪ ʃ ə n
 stabilization	s t e ɪ b ə l ɪ z e ɪ ʃ ə n
@@ -60903,7 +61461,7 @@ starvation	s t ɑː v e ɪ ʃ ə n
 starve	s t ɑː v
 starven	s t ɑː v ə n
 starving	s t ɑː v ɪ ŋ
-stary	s t ɛ ə ɹ ɨ
+stary	s t ɛ ə ɹ ɪ
 stash	s t æ ʃ
 stasi	s t ɑː z i
 stasi	ʃ t ɑː z i
@@ -60953,6 +61511,8 @@ statue	s t æ t j uː
 statue	s t æ t͡ʃ uː
 statuesque	s t a t j ʊ ɛ s k
 statuesque	s t a t ʃ ʊ ɛ s k
+statuette	s t æ t j u ɛ t
+statuette	s t æ t ʃ u ɛ t
 statuminate	s t ə t j uː m ɪ n e ɪ t
 statuminate	s t ə t uː m ɪ n e ɪ t
 stature	s t æ t͡ʃ ə
@@ -61175,7 +61735,8 @@ stilboestrol	s t ɪ l b iː s t ɹ ɒ l
 stilbon	s t ɪ l b ɒ n
 stile	s t a ɪ l
 stiletto	s t ɪ l e t ə ʊ
-still	s t ɪ ɫ
+still	s t ɪ l
+stillborn	s t ɪ l b ɔː ɹ n
 stillicide	s t ɪ l ɪ s ʌ ɪ d
 stillness	s t ɪ l n ə s
 stilt	s t ɪ l t
@@ -61185,6 +61746,7 @@ stilus	s t a ɪ l ə s
 stime	s t a ɪ m
 stimmy	s t ɪ m i
 stimulable	s t ɪ m j ʊ l ə b l̩
+stimulant	s t ɪ m j ʊ l ə n t
 stimulate	s t ɪ m j ʊ l e ɪ t
 stimulated	s t ɪ m j ʊ l e ɪ t ɪ d
 stimuli	s t ɪ m j ʊ l a ɪ̯
@@ -61701,7 +62263,7 @@ subglacial	s ʌ b ɡ l e ɪ ʃ i ə l
 subglacial	s ʌ b ɡ l e ɪ ʃ ə l
 subgroup	s ʌ b ɡ ɹ uː p
 subindication	s ʌ b ɪ n d ɪ k e ɪ ʃ ə n
-subitize	s ʌ b ɨ t a ɪ z
+subitize	s ʌ b ɪ t a ɪ z
 subito	s uː b ɪ t ə ʊ
 subjacency	s ə b d͡ʒ e ɪ s ə n s i
 subjacent	s ʌ b d ʒ e ɪ s ə n t
@@ -61760,6 +62322,7 @@ subperiosteal	s ʌ b p ɛ ɹ i ɒ s t ɪ ə l
 subpoena	s ə p iː n ə
 subpoenable	s ə p i n ə b ə l
 subprime	s ʌ b p ɹ ʌ ɪ m
+subq	s ʌ b k j uː
 subreption	s ʌ b ɹ ɛ p ʃ ə n
 subsaltation	s ʌ b s l t e ɪ ʃ n
 subsaltation	s ʌ b s ə l t e ɪ ʃ n
@@ -62069,7 +62632,7 @@ sunspot	s ʌ n s p ɒ t
 sunstead	s ʌ n s t ɛ d
 sunup	s ʌ n ʌ p
 suny	s u n i
-suomi	s uː ɔ m ɪ
+suomi	s w ɔː m ɪ
 suona	s w o ʊ n ɑː
 sup	s ʌ p
 super	s j uː p ə ɹ
@@ -62267,6 +62830,8 @@ suprareligious	s j uː p ɹ ə ɹ ɪ l ɪ d͡ʒ ə s
 suprasegmental	s uː p ɹ ə s ɛ ɡ m ɛ n t ə l
 suprasternal	s uː p ɹ ə s t ɜː n ə l
 supremacy	s u p ɹ ɛ m ə s i
+suprematism	s j uː p ɹ ɛ m ə t ɪ z ə m
+suprematist	s j uː p ɹ ɛ m ə t ɪ s t
 supreme	s j uː p ɹ iː m
 supreme	s j ə p ɹ iː m
 supreme	s j ʊ p ɹ iː m
@@ -62312,6 +62877,7 @@ surimi	s ʊ ə ɹ iː m i
 surimi	s ʊ ə ɹ ɪ m i
 suriname	s j ʊ ə ɹ ɪ n æ m
 suriname	s ʊ ə ɹ ɪ n æ m
+surinamese	s ʊ ə ɹ ɪ n ə m iː z
 surjection	s ɜː ɹ d͡ʒ ɛ k ʃ ə n
 surly	s ɜː l i
 surmise	s ɜː m a ɪ z
@@ -62330,7 +62896,6 @@ surrealism	s ə ɹ iː ə l ɪ z ə m
 surrealistic	s ə ɹ iː ə l ɪ s t ɪ k
 surrebutter	s ʌ ɹ ɪ b ʌ t ɚ
 surrect	s ə ɹ ɛ k t
-surrender	s ə ɹ ɛ n d ə ɹ
 surreptitious	s ʌ ɹ ɪ p t ɪ ʃ ə s
 surreptitiously	s ʌ ɹ ə p t ɪ ʃ ə s l i
 surrey	s ʌ ɹ i
@@ -62344,7 +62909,7 @@ surroundings	s ə ɹ a ʊ n d ɪ ŋ z
 surseance	s ɜː ɹ s i ə n s
 surströmming	s ʊ ə ɹ s t ɹ ɒ m ɪ ŋ
 surströmming	s ʊ ə ɹ s t ɹ ɜː m ɪ ŋ
-surtout	s əː t uː t
+surtout	s ɜː t uː t
 surveil	s ə v e ɪ l
 surveillance	s ə v e ɪ l ə n s
 survey	s ə v e ɪ
@@ -62361,6 +62926,7 @@ sus	s ʌ s
 susa	s uː z ə
 susceptibility	s ə s ɛ p t ə b ɪ l ɪ t i
 susceptible	s ə s ɛ p t ɪ b l̩
+suscitate	s ʌ s ɪ t e ɪ t
 sushen	s uː ʃ ʌ n
 sushi	s uː ʃ i
 sushi	s ʊ ʃ i
@@ -62642,7 +63208,7 @@ sylvester	s ɪ l v ɛ s t ɚ
 symbiotic	s ɪ m b a ɪ ɒ t ɪ k
 symbiotic	s ɪ m b i ɒ t ɪ k
 symbol	s ɪ m b ə l
-symbolically	s ɪ m b ɒ l ɪ k l ɨ
+symbolically	s ɪ m b ɒ l ɪ k l ɪ
 symbolism	s ɪ m b ə l ɪ z ə m
 symbolize	s ɪ m b ə l a ɪ z
 symboloid	s ɪ m b ə l ɔ ɪ d
@@ -62687,7 +63253,7 @@ synchronic	s ɪ ŋ k ɹ ɒ n ɪ k
 synchronize	s ɪ ŋ k ɹ ə n a ɪ z
 synchronous	s ɪ ŋ k ɹ ə n ə s
 synchrotron	s ɪ ŋ k ɹ ə ʊ t ɹ ɒ n
-synchysis	s ɪ n k ə s ɨ s
+synchysis	s ɪ n k ə s ɪ s
 syncope	s ɪ ŋ k ə p i
 syncranterian	s ɪ ŋ k ɹ æ n t i ɹ i ə n
 syncranteric	s ɪ ŋ k ɹ æ n t i ɹ i k
@@ -62794,6 +63360,7 @@ t	t iː
 t'internet	t ɪ n t ə n ɛ t
 t'othersider	t ʌ ð ə ɹ s a ɪ d ə ɹ
 ta	t ɑː
+ta	t ə
 ta'en	t e ɪ n
 taaffeite	t ɑː f ʌ ɪ t
 tab	t æ b
@@ -62873,7 +63440,7 @@ taenifuge	t iː n ɪ f j uː d͡ʒ
 tafe	t e ɪ f
 taffaty	t æ f ə t i
 taffeta	t æ f ə t ə
-taffeta	t æ f ɨ t ə
+taffeta	t æ f ɪ t ə
 taffety	t æ f ə t i
 taffy	t æ f i
 tafsir	t æ f s ɪ ə r
@@ -62970,7 +63537,7 @@ tali	t̪ aː l i
 taliban	t æ l ɪ b æ n
 taliban	t æ l ɪ b ɑː n
 taliban	t ɑː l ɪ b ɑː n
-taliesin	t æ l i ɛ s ɨ n
+taliesin	t æ l i ɛ s ɪ n
 taligrade	t æ l ɪ ɡ ɹ e ɪ d
 talion	t a l ɪ ə n
 talisman	t æ l ɪ s m æ n
@@ -63007,6 +63574,7 @@ talmud	t æ l m ə d
 talmud	t æ l m ʊ d
 talmudic	t æ l m ʊ d ɪ k
 talon	t æ l ə n
+talpidae	t æ l p ɪ d iː
 talus	t e ɪ l ə s
 talwege	t aː l v ɛ ç ə
 tam	t æ m
@@ -63067,7 +63635,7 @@ tangential	t æ n d͡ʒ ɛ n t͡ʃ ə l
 tangentially	t æ n d͡ʒ ɛ n ʃ i ə l i
 tangentially	t æ n d͡ʒ ɛ n ʃ ə l i
 tangerine	t æ n d͡ʒ ə ɹ i n
-tangerine	t æ n d͡ʒ ɜ ɹ i n
+tangerine	t æ n d͡ʒ ə ɹ iː n
 tangible	t æ n d͡ʒ ɪ b ə l
 tangier	t æ ŋ ɪ ə
 tangle	t æ ŋ ɡ ə l
@@ -63093,6 +63661,8 @@ tannin	t æ n ɪ n
 tanning	t æ n ɪ ŋ
 tannishness	t æ n ɨ ʃ n ɨ s
 tannoy	t æ n ɔ ɪ
+tanpura	t æ m p ʊ ə ɹ ə
+tanpura	t ɑ m p ʊ ə ɹ ə
 tanru	t æ n ɹ uː
 tansy	t a n z i
 tansy	t æ n z i
@@ -63105,6 +63675,9 @@ tantamount	t æ n t ə m a ʊ n t
 tantara	t æ n t ə ɹ ɑː
 tantivy	t æ n t ɪ v i
 tanto	t ɑ n t ə ʊ
+tantra	t æ n t ɹ ə
+tantra	t ɑː n t ɹ ə
+tantra	t ʌ n t ɹ ə
 tantrum	t æ n t ɹ ə m
 tanuki	t ə n ʊ k ɪ
 tanya	t æ n j ə
@@ -63113,9 +63686,9 @@ tanzania	t æ n z ə n iː ə
 tanzanite	t æ n z ə n a ɪ t
 tao	d a ʊ
 tao	t a ʊ
-taoiseach	t iː ʃ a x
-taoiseach	t iː ʃ ə k
+taoiseach	t iː ʃ i
 taoiseach	t iː ʃ ə x
+taoisigh	t iː ʃ i
 taotie	t a ʊ t j e ɪ
 tap	t æ p
 tapa	t ɑː p ə
@@ -63198,7 +63771,7 @@ tarry	t ɑː ɹ i
 tarsal	t ɑː s ə l
 tarsand	t ɑː ɹ s æ n d
 tarse	t ɑː ɹ s
-tarsier	t a ɹ s i ə ɹ
+tarsier	t ɑ ɹ s i ə ɹ
 tarsus	t ɑː s ə s
 tart	t ɑː t
 tartan	t ɑː t n̩
@@ -63274,6 +63847,7 @@ taupe	t ə ʊ p
 taupo	t a ʊ p ə ʊ
 taur	t ɑː r
 taur	t ɔː r
+taurida	t ɔː ɹ ɪ d ə
 taurine	t ɔː ɹ a ɪ n
 taurine	t ɔː ɹ iː n
 taurocholic	t ɔː ɹ ə k ɒ l ɪ k
@@ -63339,6 +63913,7 @@ teachy	t iː t͡ʃ i
 teacup	t iː k ʌ p
 teade	t iː d
 teak	t iː k
+teaky	t iː k i
 teal	t iː l
 team	t iː m
 teammate	t iː m m e ɪ t
@@ -63371,7 +63946,7 @@ teasable	t iː z ə b ə l
 tease	t iː z
 teased	t iː z d
 teasing	t iː z ɪ ŋ
-teaspoon	t i s p u n
+teaspoon	t iː s p uː n
 teaspoonful	t iː s p uː n f ə l
 teat	t iː t
 teazer	t iː z ə ɹ
@@ -63392,6 +63967,7 @@ technobabble	t ɛ k n ə ʊ b æ b ə l
 technocracy	t ɛ k n ɒ k ɹ ə s i
 technocrat	t ɛ k n ə ʊ k ɹ a t
 technocratic	t ɛ k n ə k ɹ æ t ɪ k
+technological	t ɛ k n ə l ɒ d͡ʒ ɪ k ə l
 technologist	t ɛ k n ɒ l ə d͡ʒ ɪ s t
 technology	t ɛ k n ɒ l ə d͡ʒ i
 technopeasant	t ɛ k n ə ʊ p ɛ z ə n t
@@ -63410,6 +63986,7 @@ teddington	t ɛ d ɪ ŋ t ə n
 teddy	t ɛ d i
 tedge	t ɛ d͡ʒ
 tedious	t iː d ɪ ə s
+tedisome	t iː d ɪ s ə m
 tedium	t iː d i ə m
 tee	t iː
 teegeeack	t iː ɡ i æ k
@@ -63423,6 +64000,7 @@ teenage	t iː n ɪ d͡ʒ
 teenager	t iː n e ɪ d͡ʒ ə ɹ
 teener	t iː n ə
 teens	t iː n z
+teensy	t iː n s i
 teeny	t iː n i
 teenybopper	t iː n i b ɒ p ə
 teep	t iː p
@@ -63470,6 +64048,7 @@ telco	t ɛ l k ə ʊ
 tele	t ɛ l i
 telecabin	t ɛ l ɪ k æ b ɪ n
 telecine	t ɛ l ə s ɪ n e ɪ
+telega	t ɪ l e ɪ ɡ ə
 telegram	t ɛ l ə ɡ ɹ æ m
 telegraph	t ɛ l ə ɡ ɹ æ f
 telegraph	t ɛ l ɪ ɡ ɹ æ f
@@ -63554,7 +64133,7 @@ temp	t ɛ m p
 tempeh	t ɛ m p e ɪ
 temper	t ɛ m p ə
 tempera	t ɛ m p ə ɹ ə
-temperament	t ɛ m p ə ɹ m ə n t
+temperament	t ɛ m p ə m ə n t
 temperament	t ɛ m p ə ɹ ə m ə n t
 temperament	t ɛ m p ɹ ə m ə n t
 temperance	t ɛ m p ə ɹ ə n s
@@ -63633,6 +64212,7 @@ tenge	t ɛ ŋ ɡ e ɪ
 tengrism	t ɛ ŋ ɡ ɹ ɪ z ə m
 tengwar	t ɛ ŋ ɡ w ɑː
 tenible	t ɛ n ɪ b l
+teniposide	t ɛ n ɪ p ə s a ɪ d
 tenkasi	t̪ ɛ n k aː s i
 tenner	t ɛ n ə ɹ
 tennessee	t ɛ n ə s iː
@@ -63656,7 +64236,7 @@ tensor	t ɛ n s ə
 tent	t ɛ n t
 tent	t ɪ n t
 tentacle	t ɛ n t ə k ə l
-tentacle	t ɛ n t ɨ k ə l
+tentacle	t ɛ n t ɪ k ə l
 tentacular	t ɛ n t æ k j uː l ə ɹ
 tentative	t ɛ n t ə t ɪ v
 tentatively	t ɛ n t ə t ɪ v l i
@@ -63730,7 +64310,7 @@ termitarium	t ɜ ɹ m ɪ t ɛ ə ɹ i ə m
 termite	t ɜː ɹ m a ɪ t
 termites	t ɜː m a ɪ t s
 termites	t ɜː m ɪ t iː z
-termless	t ɝ m l ɨ s
+termless	t ɝ m l ɪ s
 terms	t ɜː m z
 tern	t ɜː n
 ternary	t ɜː n ə ɹ i
@@ -63897,6 +64477,7 @@ textspeak	t ɛ k s t s p i k
 textual	t ɛ k s t j u ə l
 textual	t ɛ k s t ʃ u ə l
 textual	t ɛ k s t ʃ ə l
+tezosentan	t ɛ z ə ʊ s ɛ n t æ n
 tečka	t ɛ t͡ʃ k a
 tečka	t ɛ t͡ʃ k ə
 th'	ð
@@ -63954,6 +64535,7 @@ tharf	θ ɑː ɹ f
 thass	ð æ s
 that	ð æ t
 that'd	ð æ d
+that'd	ð æ t ə d
 that's	ð æ t s
 thatch	θ æ t͡ʃ
 thatcher	θ a t͡ʃ ə ɹ
@@ -64009,7 +64591,7 @@ thematic	θ ɪ m æ t ɪ k
 thematise	θ iː m ə t a ɪ z
 thembo	ð ɛ m b ə ʊ
 theme	θ iː m
-themis	θ iː m ɨ s
+themis	θ iː m ɪ s
 themistius	θ ɛ m ɪ s t ɪ ə s
 themistius	θ ɪ m ɪ s t ɪ ə s
 themself	ð ɛ m s ɛ l f
@@ -64044,6 +64626,7 @@ theomachy	θ i ɒ m ə k i
 theopathic	θ iː ə ʊ p a θ ɪ k
 theophany	θ iː ɒ f ə n i
 theophilanthropy	θ iː ə ʊ f ɪ l a n θ ɹ ə p i
+theophilus	θ iː ɒ f ɪ l ə s
 theophylline	θ i ə f ɪ l iː n
 theophylline	θ i ə f ɪ l ɪ n
 theopneust	θ ɪ ə p n j uː s t
@@ -64087,7 +64670,7 @@ therefrom	ð e ə f ɹ ɒ m
 therein	ð e ə ɹ ɪ n
 thereinto	ð ɛ ə ɹ ɪ n t uː
 theremin	θ ɛ ə ɹ ə m ɪ n
-theremin	θ ɛ ɹ ɨ m ɪ n
+theremin	θ ɛ ɹ ɪ m ɪ n
 thereof	ð ɛ ə ɹ ɒ v
 thereon	ð ɛ ə ɹ ɒ n
 thereout	ð ɛ ə ɹ a ʊ t
@@ -64219,8 +64802,8 @@ this'll	ð ɪ s l̩
 this's	ð ɪ s ɪ z
 this've	ð ɪ s ə v
 thistle	θ ɪ s l̩
-thither	ð ɪ ð ə ɹ
-thither	θ ɪ ð ə ɹ
+thither	ð ɪ ð ə
+thither	θ ɪ ð ə
 thitherward	ð ɪ ð ə w ə d
 thlipsis	θ l ɪ p s ɪ s
 thneed	θ n iː d
@@ -64262,6 +64845,7 @@ thoroughly	θ ʌ ɹ ə l i
 thoroughness	θ ʌ ɹ ə n ə s
 thoroughness	θ ʌ ɹ ə ʊ n ə s
 thorp	θ ɔː p
+thorpe	θ ɔː p
 those	ð ə ʊ z
 thot	θ ɒ t
 thoth	θ ə ʊ θ
@@ -64301,7 +64885,8 @@ thousandth	θ a ʊ z ə n θ
 thousandths	θ a ʊ z ə n t θ s
 thowel	θ ə ʊ w ə l
 thrace	θ ɹ e ɪ s
-thracian	θ ɹ e ɪ s iː ə n
+thracian	θ ɹ e ɪ ʃ i ə n
+thracian	θ ɹ e ɪ ʃ ə n
 thrack	θ ɹ æ k
 thrall	θ ɹ ɔː l
 thralldom	θ ɹ ɔː l d ə m
@@ -64475,12 +65060,14 @@ tiberius	t ɪ b ɛ ɹ i ʊ s
 tibet	t ə b e t
 tibet	t ɪ b e t
 tibetan	t ɪ b ɛ t n̩
+tibia	t ɪ b i ə
 tibial	t ɪ b i ə l
 tibicen	t ɪ b a ɪ s ɪ n
 tibicines	t ɪ b a ɪ s ɪ n iː z
 tic	t ɪ k
+tical	t iː k ə l
 tical	t ɪ k ɑː l
-tical	t ɪ k ə l
+tical	t ɪ k ɔː l
 tice	t a ɪ s
 tich	t ɪ t͡ʃ
 tick	t ɪ k
@@ -64497,6 +65084,7 @@ ticklishness	t ɪ k l ɪ ʃ n ɛ s
 ticks	t ɪ k s
 ticrynafen	t ɪ k ɹ ɪ n ə f ɛ n
 tics	t ɪ k s
+tid	t ɪ d
 tidal	t a ɪ d ə l
 tidbit	t ɪ d b ɪ t
 tiddly	t ɪ d l i
@@ -64587,7 +65175,6 @@ tim	t ɪ m
 timaru	t ɪ m ə ɹ uː
 timber	t ɪ m b ə
 timbre	t æ m b ə
-timbre	t ɛ̃ b r ə
 timbrel	t ɪ m b ɹ ə l
 timbuktoo	t ɪ m b ʌ k t uː
 time	t a ɪ m
@@ -64752,6 +65339,7 @@ tlaloc	t l ə l o ʊ k
 tlaxcala	t l ɑː s k ɑː l ə
 tlaxcala	t l ɑː ʃ k ɑː l ə
 tlayuda	t l ɑ j u d ə
+tlemcen	t l ɛ m s ɛ n
 tlingit	k l ɪ ŋ k ɪ t
 tlingit	t l ɪ ŋ ɡ ɪ t
 tmesis	m iː s ɪ s
@@ -64839,6 +65427,7 @@ tokenist	t ə ʊ k ə n ɪ s t
 toki	t o ʊ k i
 toki	t ə ʊ k i
 tokin	t ə ʊ k ɪ n
+tokkaebi	t o ʊ k e ɪ b i
 tokomaru	t ə ʊ k ə ʊ m ɑː ɹ uː
 tokophobia	t ə ʊ k ə f ə ʊ b i ə
 tokoroa	t ə ʊ k ə ʊ ɹ ə ʊ ə
@@ -64874,7 +65463,6 @@ toman	t o ʊ m ɑː n
 toman	t o ʊ m ə n
 toman	t ʊ m ə n
 toman	t ʌ m ə n
-tomato	t ə m e ɪ t o ʊ
 tomato	t ə m ɑː t o ʊ
 tomb	t uː m
 tombal	t uː m b ə l
@@ -65063,6 +65651,7 @@ tortoiseshell	t ɔː ɹ t ə s ʃ ɛ l
 tortoiseshell	t ɔː ɹ t ə ʃ ɛ l
 tortola	t ɔː t ə ʊ l ə
 tortoni	t ɔː t ə ʊ n i
+torts	t ɔː t s
 tortuous	t ɔː t͡ʃ uː ə s
 torture	t ɔː t͡ʃ ə ɹ
 tortured	t ɔː t͡ʃ ə d
@@ -65225,7 +65814,6 @@ trader	t ɹ e ɪ d ə ɹ
 trades	t ɹ e ɪ d z
 tradescantia	t ɹ æ d ɪ s k æ n t i ə
 trading	t ɹ e ɪ d ɪ ŋ
-tradition	t ɹ ə d ɪ ʃ n̩
 tradition	t ɹ ə d ɪ ʃ ə n
 traditional	t ɹ ə d ɪ ʃ n ə l
 traditional	t ɹ ə d ɪ ʃ ə n ə l
@@ -65258,7 +65846,7 @@ trainer	t ɹ e ɪ n ə
 trainers	t ɹ e ɪ n ə ɹ z
 trainiac	t ɹ e ɪ n i æ k
 training	t ɹ e ɪ n ɪ ŋ
-traino	t ɹ æ e n ə ʉ
+traino	t ɹ e ɪ n ə ʊ
 trains	t ɹ e ɪ n z
 traipse	t ɹ e ɪ p s
 traipse	t͡ʃ ɹ e ɪ p s
@@ -65297,7 +65885,7 @@ tranquil	t ɹ æ ŋ k w ɪ l
 tranquility	t r æ ŋ k w ɪ l ɪ t i
 tranquilize	t ɹ æ ŋ k w ɪ l a ɪ z
 tranquilizing	t ɹ æ ŋ k w ɪ l a ɪ z ɪ ŋ
-tranquillity	t r æ ŋ k w ɪ l ɪ t i
+tranquillity	t ɹ æ ŋ k w ɪ l ɪ t i
 trans	t ɹ æ n z
 transact	t ɹ æ n z æ k t
 transaction	t ɹ æ n z æ k ʃ ə n
@@ -65572,7 +66160,7 @@ treechange	t ɹ i t͡ʃ e ɪ n d͡ʒ
 treehouse	t ɹ iː h a ʊ s
 treemapping	t ɹ iː m æ p ɪ ŋ
 treen	t ɹ iː n
-treeness	t ɹ iː n ɨ s
+treeness	t ɹ iː n ɪ s
 treenware	t ɹ iː n w ɛ ə ɹ
 trees	t ɹ iː z
 treey	t ɹ i i
@@ -65634,6 +66222,8 @@ trepopnea	t ɹ ɛ p ə ʊ p n iː ə
 trespass	t ɹ ɛ s p ə s
 tress	t ɹ ɛ s
 tressel	t ɹ ɛ s ə l
+tressure	t ɹ ɛ s j ʊ ə ɹ
+tressure	t ɹ ɛ ʃ ə ɹ
 tressy	t ɹ ɛ s i
 trestle	t ɹ ɛ s ə l
 tret	t ɹ ɛ t
@@ -65715,6 +66305,7 @@ tricks	t ɹ ɪ k s
 tricky	t ɹ ɪ k i
 triclosan	t ɹ ɪ k l ə s æ n
 tricot	t ɹ i k o ʊ
+tricrotous	t ɹ a ɪ k ɹ ə t ə s
 tricuspid	t ɹ a ɪ k ʌ s p ɪ d
 tridem	t ɹ a ɪ d ə m
 trident	t ɹ a ɪ̯ d ə n t
@@ -65818,6 +66409,7 @@ tripod	t ɹ a ɪ p ɒ d
 tripodes	t ɹ ɪ p ə d iː z
 tripoli	t ɹ ɪ p ə l i
 tripolitan	t ɹ ɪ p ɒ l ɪ t ə n
+tripolitania	t ɹ ɪ p ə l ɪ t e ɪ n i ə
 tripos	t ɹ a ɪ p ɒ s
 tripped	t ɹ ɪ p t
 tripping	t ɹ ɪ p ɪ ŋ
@@ -65934,12 +66526,13 @@ trophæal	t ɹ ə ʊ f iː ə l
 tropic	t ɹ ɒ p ɪ k
 tropical	t ɹ ɒ p ɪ k ə l
 tropical	t ɹ ə ʊ p ɪ k ə l
-tropical	t ʃ ɹ ɒ p ɪ k ə l
+tropical	t͡ʃ ɹ ɒ p ɪ k ə l
 tropicalize	t ɹ ɒ p ɪ k ə l a ɪ z
 tropicamide	t ɹ ə ʊ p ɪ k ə m ʌ ɪ d
 tropicbird	t ɹ ɒ p ɪ k b ɜ ɹ d
 tropism	t ɹ ə ʊ p ɪ z ə m
 tropologize	t ɹ ə p ɒ l ə d͡ʒ a ɪ z
+tropomorphic	t ɹ o ʊ p ə m ɔ ɹ f ɪ k
 tropomyosin	t ɹ ə ʊ p ə m ʌ ɪ ə s ɪ n
 tropomyosin	t ɹ ə ʊ p ə ʊ m ʌ ɪ ə s ɪ n
 troppo	t ɹ ɒ p ə ʊ
@@ -66042,7 +66635,6 @@ truths	t ɹ uː ð z
 truths	t ɹ uː θ s
 truthy	t ɹ uː θ i
 try	t ɹ a ɪ
-try	t͡ʃ ɹ a ɪ
 tryhard	t ɹ a ɪ h ɑː d
 trying	t ɹ a ɪ ɪ ŋ
 tryke	t ɹ a ɪ k
@@ -66107,6 +66699,8 @@ tsuridashi	t s uː ɹ i d ɑː ʃ i
 tsuriotoshi	t s uː ɹ i o ʊ t o ʊ ʃ i
 tsuris	t s uː ɹ ɪ s
 tsuris	t s ʊ ɹ ɪ s
+tsushima	s uː ʃ iː m ə
+tsushima	t s uː ʃ iː m ə
 tsutaezori	t s uː t ɑː e ɪ z ɔː ɹ i
 tsutsugamushi	t s u t s u ɡ æ m uː ʃ iː
 tsuyuharai	t s uː j uː h ɑː ɹ a ɪ
@@ -66155,6 +66749,7 @@ tufty	t ʌ f t i
 tug	t ʌ ɡ
 tugboat	t ʌ ɡ b ə ʊ t
 tugged	t ʌ ɡ d
+tuggeranong	t ʌ ɡ ɹ ə n ɒ ŋ
 tugging	t ʌ ɡ ɪ ŋ
 tugs	t ʌ ɡ z
 tui	t uː i
@@ -66232,7 +66827,9 @@ tunicle	t j uː n ɪ k ə l
 tuning	t j uː n ɪ ŋ
 tunis	t j uː n ɪ s
 tunisia	t j uː n ɪ z i ə
+tunisian	t j uː n ɪ z i ə n
 tunnel	t ʌ n ə l
+tunny	t ʌ n i
 tunxi	t ʊ n ʃ iː
 tuoba	t w o ʊ b ɑː
 tup	t ʌ p
@@ -66263,6 +66860,7 @@ turbulence	t ɜː b j ə l ə n s
 turbulent	t ɜː b j ə l ə n t
 turd	t ɜː d
 turdetani	t ʊ ə ɹ d ɛ t ɑ n i
+turdetanian	t ɜː ɹ d ɪ t e ɪ n i ə n
 turdmuffin	t ɜː ɹ d m ʌ f ɪ n
 turducken	t ɜː d ʌ k ə n
 tureen	t ə ɹ iː n
@@ -66287,12 +66885,13 @@ turkman	t ɜː k m ə n
 turkmen	t ɜː k m ə n
 turkmenistan	t ɜː k m ɛ n ɪ s t ɑː n
 turkwoman	t ɜ ɹ k w ʊ m ə n
+turley	t ɤ l iː
 turlough	t ɜː l ɒ x
 turmeric	t j uː m ə ɹ ɪ k
 turmeric	t ɜː m ə ɹ ɪ k
 turmeric	t ʃ uː m ə ɹ ɪ k
 turmoil	t ɜː m ɔ ɪ l
-turn	t ɜː n
+turn	t ɜː ɳ
 turnaround	t ɜː ɹ n ə ɹ a ʊ n d
 turncoat	t əː n k ə ʊ t
 turned	t ɜː n d
@@ -66318,6 +66917,7 @@ turreted	t ʌ ɹ ɪ t ɪ d
 turribant	t ɜː ɹ ɪ b ə n t
 turribant	t ʌ ɹ ɪ b ə n t
 turriff	t ɜ ɹ ɪ f
+turritella	t ʌ ɹ ɪ t ɛ l ə
 turron	t ə ɹ ɒ n
 turtle	t ɜː t l̩
 tuscaloosa	t ʌ s k ə l uː s ə
@@ -66431,6 +67031,7 @@ twincest	t w ɪ n s ɛ s t
 twine	t w a ɪ n
 twinge	t w ɪ n d͡ʒ
 twink	t w ɪ ŋ k
+twinkhon	t w ɪ ŋ k h ʌ n
 twinkle	t w ɪ ŋ k ə l
 twinkling	t w ɪ ŋ k l ɪ ŋ
 twins	t w ɪ n z
@@ -66474,6 +67075,7 @@ tyebble	t͡ʃ ɛ b ə l
 tyek	t j ɛ k
 tying	t a ɪ ɪ ŋ
 tyke	t a ɪ k
+tykhana	t a ɪ k ɑː n ə
 tympan	t ɪ m p ə n
 tympanic	t ɪ m p æ n ɪ k
 tympanites	t ɪ m p ə n a ɪ t iː z
@@ -66636,6 +67238,7 @@ ult	ʌ l t
 ulterior	ʌ l t ɪ ə ɹ ɪ ə
 ultimate	ʌ l t ɪ m ɪ t
 ultimately	ʌ l t ɪ m ə t l i
+ultimately	ʌ l t ɪ m ɪ t l ɪ
 ultimation	ʌ l t ɪ m e ɪ ʃ ə n
 ultimatum	ʌ l t ɪ m e ɪ t ə m
 ultimo	ʌ l t ɪ m ə ʊ
@@ -66695,6 +67298,7 @@ umlaut	ʊ m l a ʊ t
 umlaut	ʌ m l a ʊ t
 umlaute	ʊ m l a ʊ t ə
 ummah	ʊ m ə
+umno	ʌ m n o ʊ
 ump	ʌ m p
 umpire	ʌ m p a ɪ ə ɹ
 umpteen	ʌ m p t iː n
@@ -66831,7 +67435,7 @@ unclutch	ʌ n k l ʌ t͡ʃ
 uncoif	ʌ n k w ɑː f
 uncoif	ʌ n k ɔ ɪ f
 uncoil	ʌ n k ɔ ɪ ə l
-uncollectible	ʌ n k ə l ɛ k t ɨ b l̩
+uncollectible	ʌ n k ə l ɛ k t ɪ b l̩
 uncomfortable	ʌ n k ʌ m f t ə b ə l
 uncomfortable	ʌ n k ʌ m f ə t ə b ə l
 uncommon	ʌ n k ɒ m ə n
@@ -66864,8 +67468,7 @@ uncropped	ʌ n k ɹ ɒ p t
 unction	ʌ ŋ k ʃ ə n
 unctional	ʌ ŋ k t͡ʃ n ə l
 unctional	ʌ ŋ k t͡ʃ ə n ə l
-unctuous	ʌ n k t j u ə s
-unctuous	ʌ n k t͡ʃ u ə s
+unctuous	ʌ ŋ k t͡ʃ ʊ ə s
 unctuousness	ʌ ŋ k t͡ʃ u ə s n ə s
 und	ʌ n d
 undashingly	ʌ n d a ʃ ɪ ŋ l i
@@ -66889,9 +67492,9 @@ underbuilder	ʌ n d ə ɹ b ɪ l d ə ɹ
 undercarriage	ʌ n d ə k æ ɹ ɪ d͡ʒ
 undercover	ʌ n d ə ɹ k ʌ v ə ɹ
 undercurrent	ʌ n d ə k ʌ ɹ ə n t
-underestimate	ʌ n d ɚ ɛ s t ɨ m e ɪ t
-underestimate	ʌ n d ɚ ɛ s t ɨ m ə t
-underestimate	ʌ n d ɚ ɛ s t ɨ m ɨ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m e ɪ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ə t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ɪ t
 underfeeling	ʌ n d ə f iː l ɪ ŋ
 underfire	ʌ n d ə f a ɪ ə
 underfired	ʌ n d ə f a ɪ ə d
@@ -66940,7 +67543,7 @@ undertime	ʌ n d ə ɹ t a ɪ̯ m
 undertime	ʌ n d ɚ t a ɪ̯ m
 undertone	ʌ n d ə ɹ t ə ʊ n
 undertook	ʌ n d ə ɹ t ʊ k
-underutilize	ʌ n d ə j uː t ɨ l a ɪ z
+underutilize	ʌ n d ə j uː t ɪ l a ɪ z
 undervalue	ʌ n d ə ɹ v æ l j u
 underverse	ʌ n d ə ɹ v ɜː ɹ s
 underwater	ʌ n d ə ɹ w ɔː t ə
@@ -67006,7 +67609,7 @@ unenthusiastic	ʌ n ɛ n θ j uː z i æ s t ɪ k
 unequal	ʌ n iː k w ə l
 unequivocable	ʌ n ɨ k w ɪ v ə k ə b ə l
 unequivocably	ʌ n ɨ k w ɪ v ə k ə b l ɪ
-unequivocal	ʌ n ɨ k w ɪ v ə k ə l
+unequivocal	ʌ n ɪ k w ɪ v ə k ə l
 unequivocally	ʌ n ɨ k w ɪ v ə k ə l ɪ
 unergative	ʌ n ɜː ɡ ə t ɪ v
 unergatives	ʌ n ɜː ɹ ɡ ə t ɪ v z
@@ -67113,7 +67716,7 @@ unimportant	ʌ n ɪ m p ɔː t ə n t
 uninitiated	ʌ n ɪ n ɪ ʃ i e ɪ t ɪ d
 uninspired	ʌ n ɪ n s p a ɪ ə d
 uninspiring	ʌ n ɪ n s p a ɪ ə ɹ ɪ ŋ
-unintelligible	ʌ n ɪ n t ɛ l ɨ d͡ʒ ɨ b ə l
+unintelligible	ʌ n ɪ n t ɛ l ɪ d͡ʒ ɪ b ə l
 unintended	ʌ n ɪ n t ɛ n d ɪ d
 unintentional	ʌ n ɪ n t ɛ n ʃ ə n ə l
 uninvite	ʌ n ɪ n v a ɪ t
@@ -67130,8 +67733,8 @@ unique	j uː n iː k
 unique	j ə n iː k
 uniquity	j u n ɪ k w ɪ t i
 unisex	j uː n ɪ s ɛ k s
-unison	j u n ɨ s ə n
-unison	j u n ɨ z ə n
+unison	j u n ɪ s ə n
+unison	j u n ɪ z ə n
 unit	j uː n ɪ t
 unitary	j uː n ɪ t ə ɹ i
 united	j uː n a ɪ t ɪ d
@@ -67153,6 +67756,7 @@ univocal	j uː n ɪ v ə k ə l
 univocal	j uː n ɪ v ə ʊ k ə l
 univocity	j uː n ɪ v ɒ s ɪ t i
 unix	j uː n ɪ k s
+unjam	ʌ n d͡ʒ æ m
 unjust	ʌ n d͡ʒ ʌ s t
 unjustly	ʌ n d͡ʒ ʌ s t l i
 unked	ʌ n k ɛ d
@@ -67170,6 +67774,8 @@ unlaid	ʌ n l e ɪ d
 unlead	ʌ n l ɛ d
 unleaded	ʌ n l ɛ d ə d
 unlearn	ʌ n l əː n
+unlearned	ʌ n l ɜː n d
+unlearned	ʌ n l ɜː n ɪ d
 unleash	ʌ n l i ʃ
 unless	ə n l ɛ s
 unless	ɪ n l ɛ s
@@ -67226,6 +67832,7 @@ unnoticed	ʌ n n ə ʊ t ɪ s t
 unnun	ʌ n n ʌ n
 unoared	ʌ n ɔː ɹ d
 unobtainium	ʌ n ɒ b t e ɪ n ɪ ə m
+unobtrusive	ʌ n ə b t ɹ uː s ɪ v
 unobtrusively	ʌ n ə b t ɹ uː s ɪ v l i
 unorthodox	ʌ n ɔː θ ə d ɒ k s
 unoverridden	ʌ n o ʊ v ɚ ɹ ɪ d ə n
@@ -67271,6 +67878,7 @@ unreasonably	ʌ n ɹ iː z ə n ə b l i
 unrecognizable	ʌ n ɹ ɛ k ə ɡ n a ɪ z ə b ə l
 unrecuring	ʌ n ɹ ɪ k j ʊ ə ɹ ɪ ŋ
 unredressable	ʌ n ɹ ɪ d ɹ ɛ s ə b ə l
+unreliable	ʌ n ɹ ɪ l a ɪ ə b l̩
 unreluctant	ʌ n ɹ ɪ l ʌ k t ə n t
 unremitting	ʌ n ɹ ɪ m ɪ t ɪ ŋ
 unrequited	ʌ n ɹ ə k w a ɪ t ɪ d
@@ -67398,13 +68006,15 @@ unwittingly	ʌ n w ɪ t ɪ ŋ l i
 unwonted	ʌ n w ɒ n t ɪ d
 unwontedly	ʊ n w o ʊ n t ɪ d l i
 unworthy	ʌ n w ɝ ð i
-unwound	ʌ n w ɑ ʊ n d
+unwound	ʌ n w a ʊ̯ n d
+unwound	ʌ n w uː n d
 unwrap	ʌ n ɹ æ p
 unwroken	ʌ n ɹ ə ʊ k ə n
 unyoke	ʌ n j ə ʊ k
 uotsuri	uː o ʊ t s ʊ ə ɹ i
 up	ʌ p
 upanayana	uː p ə n ɑː j ə n ə
+upazila	uː p ɒ d͡ʒ ɪ l ə
 upbar	ʌ p b ɑː ɹ
 upbind	ʌ p b a ɪ n d
 upbraid	ʌ p b ɹ e ɪ d
@@ -67638,6 +68248,7 @@ uterus	j uː t ə ɹ ə s
 uther	j uː θ ə ɹ
 uther	uː θ ə ɹ
 utica	j uː t ɪ k ə
+util	j uː t ɪ l
 utile	j uː t a ɪ l
 utilitarian	j uː t ɪ l ɪ t ɛː ɹ i ə n
 utilitarianist	j u t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
@@ -67645,7 +68256,7 @@ utilitarianist	j ʊ t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianly	j u t ɪ l ɪ t e ɪ ɹ i ə n l i
 utility	j uː t ɪ l ɪ t i
 utility	j ə t ɪ l ɪ t i
-utilize	j uː t ɨ l a ɪ z
+utilize	j uː t ɪ l a ɪ z
 utmost	ʌ t m ə ʊ̯ s t
 utonian	j uː t o ʊ n i ə n
 utopia	j uː t ə ʊ p i ə
@@ -67774,6 +68385,7 @@ valency	v e ɪ l ə n s i
 valent	v e ɪ l ə n t
 valentine	v a l ə n t a ɪ n
 valentine	v æ l ə n t a ɪ n
+valeria	v ə l ɪ ə ɹ i ə
 valerian	v ə l ɪ ə ɹ ɪ ə n
 valet	v æ l e ɪ
 valet	v æ l ɪ t
@@ -67787,6 +68399,7 @@ valid	v æ l ɪ d
 validate	v æ l ɪ d e ɪ t
 validation	v æ l ə d e ɪ ʃ ə n
 validify	v ə l ɪ d ɪ f a ɪ
+valinemia	v e ɪ l ɪ n iː m i ə
 valise	v ə l iː z
 valium	v æ l i ə m
 valkyrie	v æ l k ɚ i
@@ -67797,8 +68410,10 @@ vallejo	v ə l e ɪ ə ʊ
 valletta	v ə l ɛ t ə
 valley	v æ l i
 valleys	v æ l i z
+vallum	v æ l ə m
 valnemulin	v æ l n ɛ m j ʊ l ɪ n
 valour	v æ l ə
+valparaíso	v ɑ l p ɑ ɹ a ɪ iː s o ʊ
 valproate	v æ l p ɹ ə ʊ e ɪ t
 valse	v ɑ l s
 valuable	v æ l j u ə b l̩
@@ -67848,6 +68463,7 @@ vapor	v e ɪ p ə
 vaporous	v e ɪ p ə ɹ ə s
 vaporous	v e ɪ p ɹ ə s
 vaporware	v e ɪ p ə w ɛ ə ɹ
+vaporwave	v e ɪ p ə w e ɪ v
 vapory	v e ɪ p ə ɹ i
 vapourware	v e ɪ p ə w ɛ ə ɹ
 vapulate	v æ p j ʊ l e ɪ t
@@ -67944,6 +68560,7 @@ vecrīga	v ɛ t s ɹ iː ɡ a
 vectis	v ɛ k t ɪ s
 vectisian	v ɛ k t iː z i ə n
 vector	v ɛ k t ə
+vectorize	v ɛ k t ə ɹ a ɪ z
 veda	v e ɪ d ə
 vedette	v ə d ɛ t
 vedge	v ɛ d͡ʒ
@@ -68053,6 +68670,7 @@ venezuela	v ɛ n ɛ z w e ɪ l ə
 venezuela	v ɛ n ɪ z w e ɪ l ə
 vengeance	v ɛ n d͡ʒ ə n s
 vengeful	v e n ʒ f ə l
+vengence	v iː n iː n s
 venial	v iː n i ə l
 venice	v ɛ n ɪ s
 venicia	v ə n iː ʃ ə
@@ -68142,6 +68760,7 @@ verlan	v ɛ ə ɹ l ɑː n
 vermeer	v ə m ɛ ə
 vermeer	v ə m ɪ ə
 vermeil	v ɜː m e ɪ l
+vermetid	v ɜː ɹ m ə t ɪ d
 vermiculate	v ə m ɪ k j ə l e ɪ t
 vermiculate	v ə m ɪ k j ʊ l e ɪ t
 vermiculate	v ə m ɪ k j ʊ l ə t
@@ -68205,6 +68824,7 @@ vertiginous	v ɜː ɹ t ɪ d͡ʒ ɪ n ə s
 vertigo	v ɜː t ɪ ɡ ə ʊ
 verts	v ɜː ɹ t s
 vertu	v əː t uː
+vervaeke	v ɜː v e ɪ k i
 vervaeke	v ɜː v iː k i
 vervain	v ɜː v e ɪ n
 verve	v ɜː v
@@ -68217,8 +68837,8 @@ vesical	v iː s ɪ k ə l
 vesical	v ɛ s ɪ k ə l
 vesicle	v iː s ɪ k ə l
 vesicle	v ɛ s ɪ k ə l
-vesicobullous	v ɛ s ɨ k o ʊ b ʊ l ə s
-vesicocele	v ɛ s ɨ k o ʊ s i l
+vesicobullous	v ɛ s ɪ k o ʊ b ʊ l ə s
+vesicocele	v ɛ s ɪ k o ʊ s i l
 vespasian	v ɛ s p e ɪ z i ə n
 vespasian	v ɛ s p e ɪ ʒ i ə n
 vesper	v ɛ s p ə
@@ -68514,6 +69134,7 @@ vinylon	v a ɪ n ɪ l ɒ n
 viognier	v iː ɒ n j e ɪ
 viol	v a ɪ ə l
 viola	v a ɪ ə l ə
+viola	v a ɪ ə ʊ l ə
 viola	v i ə ʊ l ə
 viola	v iː ə l ə
 violate	v a ɪ ə l e ɪ t
@@ -68576,6 +69197,7 @@ virtualize	v ɜː ɹ t j u ə l a ɪ z
 virtualize	v ɜː ɹ t͡ʃ u ə l a ɪ z
 virtue	v ɜː t͡ʃ uː
 virtues	v əː t͡ʃ uː s
+virtuosity	v ɜː ɹ t j u ɒ s ɪ t i
 virtuoso	v ɜ t ʃ u ə ʊ s ə ʊ
 virtuous	v ɜː t͡ʃ ʊ ə s
 virulence	v ɪ ɹ j ə l ə n s
@@ -68607,6 +69229,7 @@ visibility	v ɪ z ə b ɪ l ə t i
 visibility	v ɪ z ə b ɪ l ɪ t i
 visibility	v ɪ z ɪ b ɪ l ɪ t i
 visible	v ɪ z ə b ə l
+visibly	v ɪ z ə b l i
 visibly	v ɪ z ɪ b l i
 vision	v ɪ ʒ ə n
 visionary	v ɪ ʒ n̩ ə ɹ i
@@ -68650,6 +69273,7 @@ vitrify	v ɪ t ɹ ɪ f a ɪ
 vitrine	v ə t ɹ iː n
 vitrine	v ɪ t ɹ iː n
 vitriolic	v ɪ t ɹ ɪ ɒ l ɪ k
+vitrophyre	v ɪ t ɹ ə f a ɪ ə ɹ
 vituperate	v ɪ t j uː p ə ɹ e ɪ t
 vituperate	v ɪ t j uː p ə ɹ ə t
 vituperation	v a ɪ t j uː p ə ɹ e ɪ ʃ ə n
@@ -69028,6 +69652,7 @@ wallow	w ɒ l ə ʊ
 wallowish	w ɒ l ə ʊ ɪ ʃ
 walls	w ɔː l z
 wally	w ɒ l i
+walm	w ɑː m
 walm	w ɔː m
 walmartian	w ɔː l m ɑː ɹ ʃ ə n
 walnut	w ɔː l n ʌ t
@@ -69101,6 +69726,7 @@ wannabe	w ɒ n ə b i
 wans	w æ n s
 wanstead	w ɒ n s t ɛ d
 want	w ɒ n t
+wanted	w ɒ n t ɪ d
 wanting	w ɒ n t ɪ ŋ
 wantok	w ɒ n t ɒ k
 wantokism	w ɑ n t ɒ k ɪ z ə m
@@ -69121,7 +69747,6 @@ waratah	w ɔː ɹ ə t ɑː
 warble	w ɔː b l̩
 warbler	w ɔː ɹ b l ə ɹ
 warboys	w ɔː b ɔ ɪ z
-warburg	v aː ɐ̯ b ʊ ʁ k
 warcraft	w ɔː k ɹ ɑː f t
 ward	w ɔː d
 warden	w ɔː d ə n
@@ -69321,7 +69946,6 @@ we've	w iː v
 weak	w iː k
 weakened	w iː k ə n d
 weaker	w iː k ə
-weakling	w iː k l ɨ ŋ ɡ
 weakling	w iː k l ɪ ŋ ɡ
 weakly	w iː k l i
 weakness	w iː k n ə s
@@ -69438,6 +70062,7 @@ weighty	w e ɪ t i
 weimar	v a ɪ m ɑː
 weimaraner	v a ɪ m ə ɹ ɑː n ə ɹ
 weimarization	v a ɪ m ɑː ɹ a ɪ z e ɪ ʃ ə n
+weiqi	w e ɪ t ʃ iː
 weir	w ɪ ə
 weird	w iː ə ɹ d
 weird	w ɪ ə ɹ d
@@ -69520,6 +70145,8 @@ weretiger	w ɛ ə t a ɪ ɡ ə
 weretiger	w ɪ ə t a ɪ ɡ ə
 werewolf	w ɛː w ʊ l f
 werewolf	w ɪ ə w ʊ l f
+wergeld	w ɛ ə ɹ ɡ ɛ l d
+wergeld	w ɜː ɹ ɡ ɛ l d
 wert	w ɜː t
 wes	w ɛ s
 wes	w ɛ z
@@ -69601,10 +70228,11 @@ what	w ɒ t
 what	ʍ ɒ t
 what'd	w ʌ d
 what'd	w ʌ t ə d
-what'd	w ʌ t ɨ d
+what'd	w ʌ t ɪ d
 what'll	w ɒ t ə l
 what's	w ɒ t s
 whataboutery	w ɒ t ə b a ʊ t ə ɹ i
+whataboutism	w ə t ə b a ʊ t ɪ z ə m
 whatcha	w ɒ t ʃ j ə
 whatcha	w ɒ t ʃ ə
 whatchamacallit	w ɒ t ʃ ə m ə k ɔː l ɪ t
@@ -69613,7 +70241,6 @@ whatever	w ɒ t ɛ v ə
 whatever	ʍ ɒ t ɛ v ə
 whatever's	ʍ ɒ t ɛ v ə z
 whatnot	w ɒ t n ɒ t
-whatsapps	v ɔ t͡s ʔ ɛ p s
 whatsoever	w ɒ t s ə ʊ ɛ v ə ɹ
 whatten	w ɑ t ə n
 whatten	w ɒ t ə n
@@ -69798,6 +70425,8 @@ whiteboard	w a ɪ t b ɔː d
 whitechapel	w ʌ ɪ t t͡ʃ æ p ə l
 whitechurch	w a ɪ t t͡ʃ ɜː ɹ t͡ʃ
 whitechurch	ʍ a ɪ t t͡ʃ ɜː ɹ t͡ʃ
+whitehall	w a ɪ t h ɔː l
+whitehall	ʍ a ɪ t h ɔː l
 whitelash	h w a ɪ t l æ ʃ
 whitely	w ʌ ɪ t l i
 whiten	h w a ɪ t n̩
@@ -69985,9 +70614,9 @@ wiktionary	w ɪ k ʃ ə n ə ɹ i
 wiktionary	w ɪ k ʃ ə n ɹ ɪ
 wilco	w ɪ l k ə ʊ
 wild	w a ɪ l d
-wild	w a ɪ ə l d
 wildcat	w a ɪ l d k æ t
 wilde	w a ɪ l d
+wilden	w a ɪ l d ə n
 wilder	w a ɪ l d ə ɹ
 wilder	w ɪ l d ə ɹ
 wilderness	w ɪ l d ə n ə s
@@ -70128,7 +70757,7 @@ winne	w ɪ n
 winner	w ɪ n ə
 winnie	w ɪ n i
 winning	w ɪ n ɪ ŋ
-winningest	w ɪ n ɪ ŋ ɨ s t
+winningest	w ɪ n ɪ ŋ ɪ s t
 winnings	w ɪ n ɪ ŋ z
 winnipeg	w ɪ n ə p ɛ ɡ
 winnipegger	w ɪ n ə p ɛ ɡ ə ɹ
@@ -70207,6 +70836,7 @@ with't	w ɪ θ t
 withal	w ɪ ð ɔː l
 withdraught	w ɪ ð d ɹ ɑː f t
 withdraw	w ɪ ð d ɹ ɔː
+withdraw	w ɪ θ d ɹ ɔː
 withdrawal	w ɪ ð d ɹ ɔː ə l
 withdrawal	w ɪ θ d ɹ ɔː ə l
 withdrawn	w ɪ ð d ɹ ɔː n
@@ -70229,8 +70859,9 @@ withheld	w ɪ ð h ɛ l d
 withheld	w ɪ θ h ɛ l d
 withhold	w ɪ ð h ə ʊ l d
 withhold	w ɪ θ h ə ʊ l d
-withholding	w ɪ ð h ə ʊ l d i ŋ
-withholding	w ɪ θ h ə ʊ l d i ŋ
+withholding	w ɪ ð h ə ʊ l d ɪ ŋ
+withholding	w ɪ θ h ə ʊ l d ɪ ŋ
+withiel	w ɪ ð j ə l
 withies	w ɪ ð i z
 withies	w ɪ θ i z
 within	w ɪ ð ɪ n
@@ -70333,9 +70964,7 @@ wombat	w ɒ m b æ t
 wombgate	w uː m ɡ e ɪ t
 wombman	w uː m m ə n
 wombmate	w uː m m e ɪ t
-women	w ɪ m ə n
 women	w ɪ m ɪ n
-women	w ʊ m ə n
 women's	w ɪ m ɪ n z
 won	w ɒ n
 won	w ʌ n
@@ -70424,15 +71053,16 @@ wordbook	w ɜː d b ʊ k
 wordform	w ɜː d f ɔː m
 wordforms	w ɜː d f ɔː m z
 words	w ɜː d z
-wordsmith	w ɜː ɹ d s m ɪ θ
+wordsmith	w ɜː d s m ɪ θ
+wordsmithing	w ɜː d s m ɪ θ ɪ ŋ
 wordster	w ɜː d s t ə
 wordsters	w ɜː d s t ə z
 wore	w ɔː
 work	w øː k
-work	w ɔ ɪ̯ k
-work	w ɜ ɹ k
+work	w ɜ ɪ̯ k
 work	w ɜː k
 work	w ɜː ɹ k
+work	w ɝ k
 work	w ɵː k
 workaday	w ɜː ɹ k ə d e ɪ
 workaround	w ɜː k ə ɹ a ʊ n d
@@ -70440,6 +71070,7 @@ worked	w ɜː k t
 worker	w ɜː k ə
 workers	w ɜː k ə z
 workflow	w ɜː k f l ə ʊ
+workforce	w ɜː k f ɔː s
 workgroup	w əː k ɡ ɹ uː p
 working	w ɜː k ɪ ŋ
 workington	w ɜː ɹ k ɪ ŋ t ə n
@@ -70491,6 +71122,7 @@ worsley	w ɜː ɹ z l i
 worst	w ɜː s t
 worsted	w əː s t ɪ d
 worsted	w ʊ s t ɪ d
+wort	w ɔː t
 wort	w ɜː t
 wortcunning	w ɜː t k ʌ n ɪ ŋ
 worth	w ɜː θ
@@ -70501,6 +71133,8 @@ worthwhile	w ɜː ɹ θ ʍ a ɪ l
 worthwhileness	w ɜː ɹ θ w a ɪ l n ə s
 worthwhileness	w ɜː ɹ θ ʍ a ɪ l n ə s
 worthy	w ɜː ð i
+worts	w ɔː t s
+worts	w ɜː t s
 worty	w ɜː t i
 wot	w ɒ t
 wotcher	w ɒ t͡ʃ ə
@@ -70586,6 +71220,10 @@ wrinkled	ɹ ɪ ŋ k l̩ d
 wrinkledness	ɹ ɪ ŋ k ə l d n ə s
 wrinkliness	ɹ ɪ ŋ k ə l i n ə s
 wrinkly	ɹ ɪ ŋ k ə l i
+wriothesley	r a ɪ z l i
+wriothesley	r a ɪ ə θ s l i
+wriothesley	r ɒ t s l i
+wriothesley	r ɛ z l i
 wrist	ɹ ɪ s t
 wristband	ɹ ɪ s t b æ n d
 wristlet	ɹ ɪ s t l ə t
@@ -70643,6 +71281,8 @@ wug	w ʌ ɡ
 wuhan	uː h ɑː n
 wuhan	w uː h ɑː n
 wuhu	w uː h uː
+wujiang	w u d͡ʒ j æ ŋ
+wujiang	w u d͡ʒ j ɑ ŋ
 wujiaqu	w uː d͡ʒ i ɑː t͡ʃ uː
 wulumuqi	w uː l uː m uː t͡ʃ iː
 wumao	w uː m a ʊ
@@ -70795,6 +71435,7 @@ xeromorphic	z ɪ ə ɹ ə m ɔ ɹ f ɪ k
 xerophagy	z ɪ ə ɹ ɒ f ə d ʒ i
 xerophyte	z ɪ ə ɹ ə ʊ f a ɪ t
 xerox	z ɛ ɹ ɒ k s
+xertz	z ɝ t s
 xerxes	z ɜː k s iː z
 xhosa	k ɔː s ə
 xhosa	k ə ʊ s ə
@@ -70843,6 +71484,7 @@ xizang	ʃ iː z ɑː ŋ
 xmas	k ɹ ɪ s m ə s
 xmas	ɛ k s m ə s
 xoanon	z ə ʊ ə n ɒ n
+xography	ɛ k s ɒ ɡ ɹ ə f i
 xolo	ʃ ə ʊ l ə ʊ
 xor	k s o ɹ
 xor	k s z o ɹ
@@ -70882,7 +71524,7 @@ y'ad	j æ d
 y'all	j ɔ l
 y'all'd	j ɔ l d
 y'all'd've	j ɔ l d ə v
-y'all'dn't've	j ɔ ɫᵈ n̩ t ɘ̆ v
+y'all'dn't've	j ɔ ɫᵈ n̩ t ə v
 y'are	j ɑː ɹ
 y'ave	j æ v
 y'ave	j ə v
@@ -71019,6 +71661,7 @@ yaws	j ɔː z
 yay	j e ɪ
 yayan	j ɑː j ɑː n
 yayo	j e ɪ o ʊ
+yclad	ɪ k l æ d
 yclept	ɪ k l iː p ɪ d
 yclept	ɪ k l ɛ p t
 ye	j e ɪ
@@ -71067,6 +71710,7 @@ yem	j ɛ m
 yemen	j ɛ m ə n
 yen	j ɛ n
 yeo	j ə ʊ
+yeoh	j ə ʊ
 yeoman	j ə ʊ m ə n
 yeomen	j ə ʊ m ə n
 yeomen	j ə ʊ m ɛ n
@@ -71087,6 +71731,7 @@ yern	j əː n
 yes	j ɛ s
 yes'm	j ɛ s ə m
 yeses	j ɛ s ɪ z
+yesn't	j ɛ s ə n t
 yesses	j ɛ s ɪ z
 yessir	j ɛ s ɜː ɹ
 yestaday	j ɛ s t ə d e ɪ
@@ -71213,7 +71858,6 @@ youngest	j ʌ ŋ ɡ ə s t
 youngin	j ʌ ŋ ɪ n
 youngling	j ʌ ŋ l ɪ ŋ
 youngster	j ʌ ŋ s t ə
-youngun	j ʌ ŋ ə n
 your	j ɔː
 your	j ə
 your	j ʊ ə
@@ -71310,6 +71954,7 @@ zachary	z æ k ə ɹ i
 zack	z a k
 zack	z æ k
 zacks	z æ k s
+zaddy	z æ d i
 zadruga	z æ d ɹ uː ɡ ə
 zaffre	z æ f ə ɹ
 zaftig	z æ f t ɪ ɡ
@@ -71332,13 +71977,13 @@ zambuk	z æ m b uː k
 zambuk	z æ m b ʌ k
 zamburak	z ʌ m b ʊ ɹ ʌ k
 zamindar	z ə m iː n d ɑː
-zamzummim	z a m z ʌ m m ɨ m
+zamzummim	z a m z ʌ m m ɪ m
 zander	z æ n d ə ɹ
 zangi	z æ ŋ ɡ iː
 zangid	z æ ŋ ɡ ɪ d
 zannone	t͡s a n ə ʊ n e ɪ
 zante	z a n t ɪ
-zantedeschia	z æ n t ɨ d ɛ s k i ə
+zantedeschia	z æ n t ɪ d ɛ s k i ə
 zany	z e ɪ n i
 zanzibar	z æ n z ɪ b ɑː ɹ
 zap	z æ p
@@ -71398,6 +72043,7 @@ zelina	z ɛ l iː n ə
 zellige	z ɛ l iː d͡ʒ
 zelophehad	z ɪ l ɒ f ɪ h æ d
 zelus	z iː l ə s
+zemlyanka	z ɛ m l i ɑ ŋ k ə
 zemstva	z ɛ m s t v a
 zemstvo	z ɛ m s t v ə ʊ
 zenana	z ə n ɑː n ə
@@ -71562,8 +72208,8 @@ zomedy	z ɒ m ə d i
 zonal	z ə ʊ n ə l
 zone	z ə ʊ n
 zongdu	d z ʊ ŋ d uː
-zongzi	t s ʊ ŋ t s ɨ
-zongzi	z ʊ ŋ z ɨ
+zongzi	t s ʊ ŋ t s ɪ
+zongzi	z ʊ ŋ z ɪ
 zonie	z ə ʊ n i
 zonk	z ɒ ŋ k
 zony	z ə ʊ n i
@@ -71656,6 +72302,8 @@ zun	z ʊ n
 zunyi	d z uː n j iː
 zuojhen	d z w o ʊ d͡ʒ ʌ n
 zuoyun	d z w o ʊ j uː n
+zuppa	t s uː p ə
+zuppa	z uː p ə
 zurich	z j ʊ ə ɹ ɪ k
 zuricher	z j ʊ ə ɹ ɪ k ə
 zwingli	s w ɪ ŋ ɡ l i
@@ -71702,7 +72350,9 @@ zzyzx	z a ɪ z ɪ k s
 éclat	e ɪ k l ɑː
 écorché	e k ɔː ʃ e ɪ
 écu	e ɪ k uː
+élan	e ɪ l æ n
 élan	e ɪ l ɑː n
+émigré	ɛ m ɪ ɡ ɹ e ɪ
 étatisme	e ɪ t ɑː t iː z m
 étatisme	ɛ t ɑ t ɪ z m
 étatisme	ɛ t ɑː t ɪ z ə m

--- a/data/scrape/tsv/eng_latn_uk_broad_filtered.tsv
+++ b/data/scrape/tsv/eng_latn_uk_broad_filtered.tsv
@@ -252,7 +252,7 @@ abide	ə b a ɪ d
 abided	ə b a ɪ d ə d
 abides	ə b a ɪ d s
 abidest	ə b a ɪ d ɪ s t
-abier	ə b ɪ ə ɹ
+abier	ə b ɪ ɚ
 abigail	a b ɪ ɡ e ɪ l
 abigails	a b ɪ ɡ e ɪ l s
 abigeat	ə b ɪ d͡ʒ i ə t
@@ -285,6 +285,8 @@ ablations	ə b l e ɪ ʃ n̩ s
 ablativity	a b l ə t ɪ v ɪ t i
 ablator	æ b l e ɪ t əː
 ablauting	ɑ b l a ʊ t ɪ ŋ
+able	e ɪ b l̩
+able	e ɪ b ə l
 abligurition	ə b l ɪ ɡ j ʊ ɹ ɪ ʃ ə n
 ablings	e ɪ b l ɪ n z
 ablood	ə b l ʌ d
@@ -579,6 +581,8 @@ accept	ə k s ɛ p t
 acceptable	æ k s ɛ p t ə b ə l
 acceptable	ə k s ɛ p t ə b ə l
 acceptation	æ k s ɛ p t e ɪ ʃ ə n
+accepted	æ k s ɛ p t ɪ d
+accepted	ə k s ɛ p t ɪ d
 accepting	ə k s ɛ p t ɪ ŋ
 accepting	ɪ k s ɛ p t ɪ ŋ
 acceptor	ə k s ɛ p t ə ɹ
@@ -591,6 +595,7 @@ accessed	æ k s ɛ s t
 accessed	ə k s ɛ s t
 accesses	æ k s ɛ s ɪ z
 accesses	ə k s ɛ s ɪ z
+accessibility	ə k s ɛ s ə b ɪ l ɪ t i
 accessing	æ k s ɛ s ɪ ŋ
 accessing	ə k s ɛ s ɪ ŋ
 accession	æ k s ɛ ʃ ə n
@@ -740,7 +745,7 @@ acebutolol	a s ɪ b j uː t ə l ɒ l
 aced	e ɪ s t
 acedia	ə s iː d ɪ ə
 acela	ə s ɛ l ə
-aceldama	ə k e l d ə m ə
+aceldama	ə k ɛ l d ə m ə
 aceldama	ə s ɛ l d ə m ə
 acephali	ɑː s ɛ f æ l ɪ i
 acephalous	ə s ɛ f ə l ə s
@@ -773,7 +778,7 @@ acetal	æ s ɪ t æ l
 acetaminophen	ə s i t ə m ɪ n ə f ə n
 acetary	ə s iː t ə ɹ i
 acetate	æ s ɪ t e ɪ̯ t
-acetator	æ s ɪ t e ɪ t ə ɹ
+acetator	æ s ɪ t e ɪ t ɚ
 acetazolamide	ə s iː t ə z ɒ l ə m ʌ ɪ d
 acetazolamide	ə s iː t ə z ə ʊ l ə m ʌ ɪ d
 acetazolamide	ə s ɛ t ə z ɒ l ə m ʌ ɪ d
@@ -819,7 +824,7 @@ achieved	ə t͡ʃ iː v d
 achievement	ə t͡ʃ iː v m ə n t
 achievement	ə t͡ʃ iː v m ɪ n t
 achievements	ə t͡ʃ iː v m ə n t s
-achiever	ə t͡ʃ iː v ə ɹ
+achiever	ə t͡ʃ iː v ɚ
 achieves	ə t͡ʃ iː v z
 achieving	ə t͡ʃ iː v ɪ ŋ
 achievings	ə t͡ʃ iː v ɪ ŋ z
@@ -906,10 +911,9 @@ acquittal	ə k w ɪ t ə l
 acquittance	ə k w ɪ t ə n s
 acquitted	ə k w ɪ t ɪ d
 acrasia	ə k ɹ e ɪ z i ə
-acre	e ɪ k ə
-acre	e ɪ k ə ɹ
-acre	ɑː k ə
-acre	ɑː k ɹ ə
+acre	e ɪ k ɚ
+acre	ɑː k ɚ
+acre	ɑː k ɹ ɚ
 acreage	e ɪ k ə ɹ ɪ d͡ʒ
 acreocracy	e ɪ k ə ɹ ɒ k ɹ ə s i
 acres	e ɪ k ə z
@@ -935,6 +939,8 @@ acropolises	æ k ɹ ɒ p ɒ l ɪ s ɪ z
 acropolitan	æ k ɹ ə p ɒ l ɪ t ə n
 across	ə k ɹ ɒ s
 acrostic	ə k ɹ ɒ s t ɪ k
+acroter	æ k ɹ ə t ə ɹ
+acroterium	æ k ɹ ə t ɪ ə ɹ i ə m
 acrylamide	ə k ɹ ɪ l ə m a ɪ d
 acrylate	æ k ɹ ɪ l e ɪ t
 acrylic	ə k ɹ ɪ l ɪ k
@@ -997,6 +1003,7 @@ acushla	ə k ʊ ʃ l ə
 acute	ə k j uː t
 acutely	ə k j uː t l i
 acyclic	e ɪ s a ɪ k l ɪ k
+acyclic	e ɪ s ɪ k l ɪ k
 acyl	æ s ɪ l
 acyltransferase	a s ɪ l t ɹ a n s f ə ɹ e ɪ z
 acyltransferase	e ɪ s ʌ ɪ l t ɹ ɑː n z f ə ɹ e ɪ z
@@ -1067,7 +1074,7 @@ adduce	ə d ʒ uː s
 adduct	æ d ʌ k t
 adduct	ə d ʌ k t
 adduction	ə d ʌ k ʃ n̩
-adductor	ə d ʌ k t ə ɹ
+adductor	ə d ʌ k t ɚ
 ade	e ɪ d
 adela	æ d ə l ə
 adela	ə d ɛ l ə
@@ -1075,6 +1082,7 @@ adelaide	æ d ə l e ɪ d
 adele	ə d ɛ l
 adeling	æ d ə l ɪ ŋ
 adelings	æ d ə l ɪ ŋ z
+adelopod	ə d ɛ l ə p ɒ d
 adenine	æ d ə n iː n
 adenine	æ d ɪ n ɪ n
 adenines	æ d ɪ n ɪ n z
@@ -1091,8 +1099,10 @@ adermatoglyphia	e ɪ d ɜː m ə t ə ʊ ɡ l ɪ f ɪ ə
 adespota	ə d ɛ s p ə t ə
 adhan	ɑː ð ɑː n
 adhan	ə ð ɑː n
+adhere	æ d h ɪ ə
 adherence	ə d h ɪ ə ɹ ə n s
 adherent	æ d h ɪ ə ɹ ə n t
+adhesion	æ d h iː ʒ ə n
 adhibit	ə d h ɪ b ɪ t
 adhibition	æ d h ɪ b ɪ ʃ ə n
 adhocracy	a d h ɒ k ɹ ə s i
@@ -1116,12 +1126,13 @@ adieux	ə d j ɜː z
 adige	a d ɪ d ʒ e ɪ
 adios	æ d i ɒ s
 adipate	æ d ɪ p e ɪ t
-adipocere	æ d ə p o ʊ s i ə ɹ
-adipocere	æ d ɪ p o ʊ s i ə ɹ
+adipocere	æ d ə p o ʊ s i ɚ
+adipocere	æ d ɪ p o ʊ s i ɚ
 adipocytokine	æ d ɪ p ə ʊ s a ɪ t ə ʊ k a ɪ n
 adipose	æ d ɪ p ə ʊ s
 adipose	æ d ɪ p ə ʊ z
 adirondack	æ d ɪ ɹ ɒ n d æ k
+adit	a d ɪ t
 adit	æ d ɪ t
 adits	æ d ɪ t s
 aditus	æ d ɪ t uː s
@@ -1196,8 +1207,8 @@ admits	ə d m ɪ t s
 admittance	ə d m ɪ t n̩ s
 admitted	ə d m ɪ t ɪ d
 admitting	ə d m ɪ t ɪ ŋ
-admixture	æ d m ɪ k s t͡ʃ ə ɹ
-admixture	ə d m ɪ k s t͡ʃ ə ɹ
+admixture	æ d m ɪ k s t͡ʃ ɚ
+admixture	ə d m ɪ k s t͡ʃ ɚ
 admonish	ə d m ɒ n ɪ ʃ
 admonition	æ d m ə n ɪ ʃ ə n
 ado	ə d uː
@@ -1313,7 +1324,7 @@ advert	ə d v ɜː ɹ t
 advertise	a d v ə ɹ t a ɪ z
 advertisement	æ d v ə t a ɪ z m ə n t
 advertisement	ə d v ɜː t ɪ s m ə n t
-advertiser	æ d v ə ɹ t a ɪ z ə ɹ
+advertiser	æ d v ɚ t a ɪ z ɚ
 advertising	æ d v ə t a ɪ z ɪ ŋ
 advertorial	æ d v ɜː t ɔː ɹ i ə l
 advesperate	æ d v ɛ s p ə ɹ e ɪ t
@@ -1417,12 +1428,14 @@ aesthetic	iː s θ e t ɪ k
 aesthetic	ə s θ e t ɪ k
 aesthetic	ɛ s θ ɛ t ɪ k
 aesthetic	ɪ s θ e t ɪ k
+aesthetician	ɛ s θ ɪ t ɪ ʃ ə n
 aestiferous	ɛ s t ɪ f ɛ ɹ ʌ s
 aestivation	iː s t ɪ v e ɪ ʃ ə n
 aetat	a ɪ t a t
 aetat	iː t a t
 aetheogam	e ɪ iː θ ɪ ə ʊ ɡ æ m
 aetheogamous	e ɪ iː θ iː ɒ ɡ ə m ə s
+aether	eː ð ə
 aether	iː θ ə
 aetiology	iː t ɪ ɒ l ə d ʒ i
 aetites	iː t a ɪ t iː z
@@ -1432,12 +1445,13 @@ aeviternity	iː v ɪ t ɜː n ɪ t i
 aevum	iː v ə m
 af	e ɪ̯ ɛ f
 af	æ f
+afab	e ɪ f æ b
 aface	ə f e ɪ s
 afam	a f a m
 afanc	æ v æ ŋ k
 afanc	ɑ v ɑ ŋ k
 afar	ə f ɑː
-afare	ə f ɛ ə ɹ
+afare	ə f ɛ ɚ
 afeared	ə f ɪ ə ɹ d
 afelimomab	æ f ɛ l ɪ m ə m æ b
 affable	æ f ə b ə l
@@ -1511,16 +1525,15 @@ afghani	æ f ɡ ɑː n i
 afghanistan	æ f ɡ æ n ɪ s t æ n
 afghanistan	æ f ɡ æ n ɪ s t ɑː n
 afghanistan	æ f ɡ ɑː n ɪ s t ɑː n
-afgod	æ f ɡ ɒ d
 aficionado	æ f iː θ j ə ʊ n ɑː ð ə ʊ
 aficionado	æ f ɪ ʃ j ɒ n ɑː d ə ʊ
 aficionado	ə f ɪ s j ə n ɑː d ə ʊ
 aficionado	ə f ɪ ʃ i ə n ɑː d ə ʊ
 aficionado	ə f ɪ ʃ j ə n ɑː d ə ʊ
 afield	ə f iː l d
-afire	ə f a ɪ ə ɹ
+afire	ə f a ɪ ɚ
 aflame	ə f l e ɪ m
-aflare	ə f l ɛ ə ɹ
+aflare	ə f l ɛ ɚ
 aflash	ə f l æ ʃ
 aflat	ə f l æ t
 aflaunt	ə f l ɔː n t
@@ -1528,7 +1541,7 @@ aflibercept	ə f l ɪ b ə ɹ s ɛ p t
 aflight	ə f l a ɪ t
 aflop	ə f l ɒ p
 aflow	ə f l o ʊ
-aflower	ə f l a ʊ ə ɹ
+aflower	ə f l a ʊ ɚ
 aflush	ə f l ʌ ʃ
 aflutter	ə f l ʌ t ə
 afoam	ə f o ʊ m
@@ -1551,7 +1564,7 @@ africana	æ f ɹ ɪ k ɑ n ə
 africo	æ f ɹ ɪ k ə ʊ
 africom	æ f ɹ ɪ k ɑ m
 afrikaans	ɑː f ɹ ɪ k ɑː n z
-afrikaner	æ f ɹ ɪ k ɑː n ə ɹ
+afrikaner	æ f ɹ ɪ k ɑː n ɚ
 afroth	ə f ɹ ɒ θ
 aft	æ f t
 after	ɑː f t ə ɹ
@@ -1597,7 +1610,7 @@ agartala	ə ɡ ə ɹ t ə l ə
 agassi	æ ɡ ə s i
 agate	æ ɡ ə t
 agateophobia	ə ɡ e ɪ t i ə ʊ f ə ʊ b i ə
-agateware	æ ɡ ə t w ɛ ə ɹ
+agateware	æ ɡ ə t w ɛ ɚ
 agatha	æ ɡ ə θ ə
 agave	ə ɡ e ɪ v iː
 agave	ə ɡ ɑː v e ɪ
@@ -1639,6 +1652,7 @@ aggrace	ə ɡ ɹ e ɪ s
 aggrandize	ə ɡ ɹ æ n d a ɪ̯ z
 aggravate	æ ɡ ɹ ə v e ɪ̯ t
 aggravated	æ ɡ ɹ ə v e ɪ̯ t ɪ d
+aggravation	æ ɡ ɹ ə v e ɪ ʃ ə n
 aggregate	æ ɡ ɹ ɪ ɡ e ɪ t
 aggregate	æ ɡ ɹ ɪ ɡ ə t
 aggregation	æ ɡ ɹ ə ɡ e ɪ ʃ ə n
@@ -1654,7 +1668,7 @@ agility	ə d͡ʒ ɪ l ɪ t i
 agin	ə ɡ ɪ n
 aging	e ɪ d͡ʒ ɪ ŋ
 agings	e ɪ d͡ʒ ɪ ŋ z
-aginner	ə ɡ ɪ n ə ɹ
+aginner	ə ɡ ɪ n ɚ
 agio	æ d͡ʒ i o ʊ
 agio	æ d͡ʒ o ʊ
 agio	ɑː d͡ʒ o ʊ
@@ -1669,13 +1683,13 @@ agitatrices	æ d͡ʒ ɪ t e ɪ t ɹ ɪ s iː z
 agitatrix	æ d͡ʒ ɪ t e ɪ t ɹ ɪ k s
 agitprop	æ d ʒ ɪ t p ɹ ɒ p
 agitpropping	æ d ʒ ɪ t p ɹ ɒ p ɪ ŋ
-aglare	ə ɡ l ɛ ə ɹ
+aglare	ə ɡ l ɛ ɚ
 agleam	ə ɡ l iː m
 agley	ə ɡ l e ɪ
 agley	ə ɡ l iː
-aglimmer	ə ɡ l ɪ m ə ɹ
+aglimmer	ə ɡ l ɪ m ɚ
 aglint	ə ɡ l ɪ n t
-aglitter	ə ɡ l ɪ t ə ɹ
+aglitter	ə ɡ l ɪ t ɚ
 agminate	æ ɡ m ɪ n e ɪ t
 agnate	æ ɡ n e ɪ t
 agnath	æ ɡ n ə θ
@@ -1715,6 +1729,7 @@ agra	ə ɡ ɹ ɑː
 agraffe	ə ɡ ɹ æ f
 agrarian	ə ɡ ɹ ɛ ə ɹ i ə n
 agree	ə ɡ ɹ iː
+agreeably	ə ɡ ɹ iː ə b l i
 agreed	ə ɡ ɹ i d
 agreed	ə ɡ ɹ iː d
 agreement	ə ɡ ɹ iː m ə n t
@@ -1917,6 +1932,7 @@ aks	æ k s
 aks	ɑː k s
 aktau	ɑ k t a ʊ
 akubra	ə k uː b ɹ ə
+akwesasne	æ k w ə s æ s n e ɪ
 al	æ l
 al	ɑː l
 alabamian	æ l ə b æ m i ə n
@@ -1978,7 +1994,7 @@ albumen	a l b j ʊ m ɪ n
 albumen	æ l b j uː m ə n
 albumen	æ l b j ʊ m ə n
 albumin	a l b j ʊ m ɪ n
-albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ə ɹ
+albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ɚ
 albuminous	æ l b j uː m ɪ n ə s
 albuquerque	æ l b ə k ɜː k i
 albury	ɔː l b ə ɹ i
@@ -1988,7 +2004,8 @@ alcaide	æ l k a ɪ d i
 alcatote	æ l k ə t ə ʊ t
 alcazar	a l k ə z ɑː
 alcedine	æ l s ə d ʌ ɪ n
-alcester	ɒ l s t ə ɹ
+alces	æ l s iː z
+alcester	ɒ l s t ɚ
 alchemistical	æ l k ə m ɪ s t ɪ k ə l
 alcibiades	æ l s ə b a ɪ ə d i z
 alcid	a l s ɪ d
@@ -2006,6 +2023,8 @@ alcyone	æ l s a ɪ ə n i
 aldcliffe	ɔː k l ɪ f
 aldcliffe	ɔː l d k l ɪ f
 aldebaran	a l d ɛ b ə ɹ ə n
+aldehyde	æ l d ɪ h a ɪ d
+aldehydes	æ l d ɪ h a ɪ d z
 alder	ɔː l d ə
 alderfly	ɔː l d ə f l a ɪ
 alderliefest	ɔː l d ə ɹ l iː f ɪ s t
@@ -2046,6 +2065,11 @@ aleut	ə l uː t
 aleutian	ə l uː ʃ ə n
 alewife	e ɪ l w ʌ ɪ f
 alex	æ l ɪ k s
+alexander	a l ɪ ɡ z ɑː n d ə
+alexander	æ l ɪ ɡ z ɑː n d ə
+alexanders	æ l i ɡ z ɑː n d ə z
+alexanders	æ l ɪ ɡ z ɑː n d ə z
+alexandra	æ l ɪ ɡ z ɑː n d ɹ ə
 alexandrian	æ l ɛ ɡ z æ n d ɹ iː ə n
 alexei	ə l ɛ k s e ɪ
 alexipharmac	ə l ɛ k s ɪ f ɑː m æ k
@@ -2053,6 +2077,7 @@ alexipharmic	ə l ɛ k s ɪ f ɑː m ɪ k
 alexipyretic	ə l ɛ k s ɪ p a ɪ ɹ ɛ t ɪ k
 alexithymia	e ɪ l ɛ k s ə θ a ɪ m i ə
 alexithymic	ə l ɛ k s ɪ θ a ɪ m ɪ k
+alexondra	æ l ɪ ɡ z ɑː n d ɹ ə
 alf	æ l f
 alfacalcidol	a l f ə k a l s ɪ d ɒ l
 alfalfa	æ l f æ l f ə
@@ -2163,7 +2188,6 @@ alkies	æ l k i z
 alkin	ɔː l k ɪ n
 alkyl	æ l k a ɪ l
 alkyl	æ l k ɪ l
-all	ɔː l
 allahabad	æ l ə h ə b æ d
 allahabad	æ l ə h ə b ɑː d
 allamakee	æ l ə m ə k i
@@ -2205,6 +2229,7 @@ alligator	æ l ɪ ɡ e ɪ t ə
 alligators	æ l ɪ ɡ e ɪ t ə z
 allison	æ l ɪ s ə n
 allistic	æ l ɪ s t ɪ k
+allistic	ɑ l ɪ s t ɪ k
 allistic	ə l ɪ s t ɪ k
 allium	æ l i ə m
 alliyah	ɑː l iː j ə
@@ -2351,6 +2376,8 @@ alsace	æ l s e ɪ s
 alsace	æ l s æ s
 alsatian	æ l s e ɪ ʃ ə n
 also	ɔː l s ə ʊ
+alstroemeria	æ l s t ɹ i m iː ɹ ɪ ə
+alt	ɒ l t
 alt	ɔ l t
 alt	ɔː l t
 alta	ɑː l t ə
@@ -2425,7 +2452,9 @@ alxa	ɑ l ʃ ɑː
 alytarch	æ l ɪ t ɑː k
 alytus	ə l iː t ə s
 ama	ɑː m ə
+amab	e ɪ m æ b
 amacrine	æ m ə k ɹ ɪ n
+amadeus	æ m ə d e ɪ ə s
 amadou	æ m ə d uː
 amah	ɑː m ə
 amahs	ɑː m ə z
@@ -2468,6 +2497,7 @@ amaze	ə m e ɪ z
 amazed	ə m e ɪ z d
 amazement	ə m e ɪ z m ə n t
 amazes	ə m e ɪ z ɪ z
+amazigh	æ m ə z ɪ ɡ
 amazing	ə m e ɪ z ɪ ŋ
 amazingly	ə m e ɪ z ɪ ŋ l i
 amazon	æ m ə z ə n
@@ -2509,6 +2539,7 @@ amblyopia	æ m b l ɪ ə ʊ p ɪ ə
 amblyopic	æ m b l iː o ʊ p ɪ k
 amblyopic	æ m b l iː ɒ p ɪ k
 ambo	æ m b ə ʊ
+ambrisentan	æ m b ɹ ɪ s ɛ n t æ n
 ambrose	æ m b ɹ ə ʊ z
 ambrosial	a m b ɹ ə ʊ z ɪ ə l
 ambry	æ m b ɹ i
@@ -2570,6 +2601,7 @@ amfilokhia	æ m f ɪ l ə ʊ k a ɪ ə
 amharic	æ m h æ ɹ ɪ k
 amiable	e ɪ m i ə b ə l
 amiable	æ m i ə b ə l
+amicable	æ m ɪ k ə b ə l
 amical	a m ɪ k l
 amical	a m ɪ k ə l
 amici	æ m ɪ k i
@@ -2682,6 +2714,7 @@ ampersat	æ m p ə s æ t
 ampersat	æ m p ə z æ t
 amphetamine	æ m f ɛ t ə m iː n
 amphetamine	æ m f ɛ t ə m ɪ n
+amphibial	æ m f ɪ b i ə l
 amphibian	æ m f ɪ b ɪ ə n
 amphibole	æ m f ɪ b o ʊ l
 amphibolite	æ m f ɪ b ə l a ɪ t
@@ -2696,7 +2729,7 @@ amphigory	æ m f ɪ ɡ ɔ ɹ i
 amphipathic	a m f ɪ p a θ ɪ k
 amphipod	a m f ɪ p ɒ d
 amphipods	a m f ɪ p ɒ d z
-amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ə ɹ
+amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ɚ
 amphisbaena	æ m f ɪ s b iː n ə
 amphisbæna	æ m f ɪ s b iː n ə
 amphitheatre	æ m f i θ iː ə t ə
@@ -2734,7 +2767,7 @@ amusement	ə m j u z m ə n t
 amuses	ə m j uː z ɪ z
 amusing	ə m j uː z ɪ ŋ
 amusingly	ə m j u z ɪ ŋ l i
-amutter	ə m ʌ t ə ɹ
+amutter	ə m ʌ t ɚ
 amy	e ɪ m i
 amygdala	ə m ɪ ɡ d ə l ə
 amygdalae	ə m ɪ ɡ d ə l a ɪ
@@ -2775,11 +2808,12 @@ anadromes	æ n ə d ɹ o ʊ m z
 anadromous	ə n a d ɹ ə m ə s
 anaerophyte	ə n e ɪ ə ɹ ə ʊ f a ɪ t
 anaesthetist	ə n iː s θ ə t ɪ s t
-anagoge	a n ə ɡ ə ʊ d ʒ i
+anagoge	æ n ə ɡ ɒ d͡ʒ i
+anagoge	æ n ə ɡ ə ʊ d͡ʒ i
 anagogy	æ n ə ɡ o ʊ d͡ʒ i
 anagogy	æ n ə ɡ ɒ d͡ʒ i
 anagram	æ n ə ɡ ɹ æ m
-anagrammer	æ n ə ɡ ɹ æ m ə ɹ
+anagrammer	æ n ə ɡ ɹ æ m ɚ
 anagrams	æ n ə ɡ ɹ æ m s
 anagrind	æ n ə ɡ ɹ ɪ n d
 anaheim	æ n ə h a ɪ m
@@ -2800,7 +2834,6 @@ analogous	ə n æ l ə ɡ ə s
 analogously	ə n æ l ə ɡ ə s l i
 analogy	ə n æ l ə d͡ʒ i
 analphabet	æ n æ l f ə b ɛ t
-analyse	æ n ə l a ɪ z
 analyses	æ n ə l a ɪ z ə z
 analyses	æ n ə l a ɪ z ɪ z
 analyses	ə n æ l ə s iː z
@@ -2811,6 +2844,7 @@ analysises	ə n æ l ɪ s ɪ s ɪ z
 analyst	æ n ə l ɪ s t
 analytic	æ n ə l ɪ t ɪ k
 analytics	æ n ə l ɪ t ɪ k s
+analyze	æ n ə l a ɪ z
 analyzed	æ n ə l a ɪ z d
 anamnesis	æ n æ m n iː s ɪ s
 anamorphic	æ n ə m ɔː f ɪ k
@@ -2865,6 +2899,7 @@ anatase	æ n ə t e ɪ z
 anataxis	a n ə t a k s ɪ s
 anathema	ə n æ θ ə m ə
 anathematize	ə n æ θ ə m ə t a ɪ z
+anatidae	ə n æ t ɪ d iː
 anatiferous	æ n ə t ɪ f ə ɹ ə s
 anatine	a n ə t ʌ ɪ n
 anatole	æ n ə t o ʊ l
@@ -2899,7 +2934,7 @@ ancient	e ɪ n ʃ ə n t
 ancientry	e ɪ n ʃ ə n t ɹ i
 ancienty	e ɪ n t ʃ ə n t i
 ancilla	æ n s ɪ l ə
-ancillary	æ n s ə l ɛ ɹ iː
+ancillary	æ n s ɪ l ə ɹ i
 ancillula	æ n s ɪ l j ʊ l ə
 ancle	æ ŋ k ə l
 ancon	æ ŋ k ɒ n
@@ -2918,7 +2953,7 @@ andorra	æ n d ɔː ɹ ə
 andorran	æ n d ɔː ɹ ə n
 andouille	ɒ n d uː i
 andouilles	ɑ n d uː ɪ z
-andover	æ n d o ʊ v ə ɹ
+andover	æ n d o ʊ v ɚ
 andragogy	a n d ɹ ə ɡ ɒ d ʒ i
 andragogy	a n d ɹ ə ɡ ɒ ɡ i
 andre	ɑː n d ɹ e ɪ
@@ -3032,7 +3067,7 @@ anhelation	æ n h ɪ l e ɪ ʃ n̩
 anhele	ə n h iː l
 anhele	ə n iː l
 anhui	ɑː n h w e ɪ
-anhur	ɑː n h ʊ ə ɹ
+anhur	ɑː n h ʊ ɚ
 anhypostasia	æ n h a ɪ p ə s t e ɪ s ɪ ə
 anhypostasia	æ n h a ɪ p ə s t e ɪ ʒ ə
 anhypostasis	æ n h a ɪ p ə s t e ɪ s ɪ s
@@ -3052,8 +3087,6 @@ animalcule	æ n ɪ m æ l k j uː l
 animalculist	a n ɪ m a l k j ʊ l ɪ s t
 animally	a n ɪ m ə l i
 animals	æ n ɪ m ə l z
-animate	æ n ə m e ɪ t
-animate	æ n ə m ə t
 animate	æ n ɪ m e ɪ t
 animate	æ n ɪ m ə t
 animated	æ n ɪ m e ɪ t ɪ d
@@ -3075,6 +3108,7 @@ anise	ə n iː z
 anishinaabe	ɑː n ɪ ʃ ɪ n ɑː b e ɪ
 anisocytosis	ə n a ɪ s ə ʊ s a ɪ t ə ʊ s ɪ s
 anisogamy	æ n a ɪ s ɒ ɡ ə m i
+anisotropous	æ n a ɪ s ɒ t ɹ ə p ə s
 anita	ə n iː t ə
 aniṭ	ʌ n ɪ t
 anjou	ɒ n ʒ uː
@@ -3098,6 +3132,7 @@ annabeth	æ n ə b ɛ θ
 annal	æ n ə l
 annalist	æ n ə l ɪ s t
 annan	æ n ə n
+annapolis	ə n æ p ə l ɪ s
 anne	æ n
 anneal	ə n iː l
 annette	ə n ɛ t
@@ -3184,6 +3219,7 @@ ansai	ɑː n s a ɪ
 ansatz	æ n s æ t s
 anschluss	a n ʃ l ʊ s
 anselm	a n s ɛ l m
+anser	æ n s ə r
 anserine	a n s ə ɹ iː n
 anserine	a n s ə ɹ ʌ ɪ n
 ansible	æ n s ɪ b ə l
@@ -3194,7 +3230,7 @@ answerable	ɑː n s ə ɹ ə b ə l
 answerable	ɑː n s ɹ ə b ə l
 answered	a n s ə d
 answered	ɑː n s ə d
-answerer	ɑː n s ə ɹ ə
+answerer	ɑː n s ə ɹ ɚ
 answering	ɑː n s ə ɹ ɪ ŋ
 answerphone	æ n s ə f ə ʊ n
 answerphone	æ n s ɜː ɹ f ə ʊ n
@@ -3218,6 +3254,7 @@ ante	æ n t i
 anteater	æ n t iː t ə
 antebellum	æ n t i b ɛ l ə m
 antecedaneous	æ n t ɪ s ɪ d e ɪ n i ə s
+antecedence	æ n t ɛ s ɪ d ə n s
 antecedent	æ n t ɪ s iː d ə n t
 antechamber	æ n t i t͡ʃ e ɪ m b ə
 antechamber	æ n t ɪ t͡ʃ e ɪ m b ə
@@ -3279,7 +3316,7 @@ anthroposophic	æ n θ ɹ ə p ə s ɒ f ɪ k
 anthroposophical	æ n θ ɹ ə p ə s ɒ f ɪ k ə l
 anthroposophist	æ n θ ɹ ə p ɒ s ə f ɪ s t
 anthroposophy	æ n θ ɹ ə p ɒ s ə f i
-anthroposphere	a n θ ɹ ɒ p ə s f ɪ ə ɹ
+anthroposphere	a n θ ɹ ɒ p ə s f ɪ ɚ
 anti	æ n t i
 antialiasing	æ n t i e ɪ l i ə s ɪ ŋ
 antialiasing	æ n t ɑ ɪ̯ e ɪ l i ə s ɪ ŋ
@@ -3387,7 +3424,7 @@ antithrombin	æ n t ɪ θ ɹ ɒ m b ɪ n
 antivenin	æ n t ɪ v ɛ n ɪ n
 antiviral	æ n t i v a ɪ ɹ ə l
 antler	æ n t l ə
-antmire	a n t m a ɪ ə ɹ
+antmire	a n t m a ɪ ɚ
 antoeci	æ n t iː s a ɪ
 antoecian	æ n t iː ʃ ə n
 antoikoi	æ n t ɔ ɪ k ɔ ɪ
@@ -3411,6 +3448,7 @@ antsy	æ n t s i
 antumbra	æ n t ʌ m b ɹ ə
 antwacky	æ n t w æ k i
 anubandha	ə n ʊ b ʌ n d ə
+anura	ə n j ʊ ə r ə
 anuran	ə n j ʊ ə ɹ ə n
 anus	e ɪ n ə s
 anvil	æ n v ɪ l
@@ -3418,7 +3456,7 @@ anxiety	æ ŋ ɡ z a ɪ ə t i
 anxin	ɑː n ʃ iː n
 anxiolytic	æ ŋ k s i ə l ɪ t ɪ k
 anxious	æ ŋ k ʃ ə s
-anxiouser	æ ŋ k ʃ ə s ə ɹ
+anxiouser	æ ŋ k ʃ ə s ɚ
 any	æ n i
 any	ɛ n i
 any	ɛ n ɪ
@@ -3474,7 +3512,7 @@ apeiron	ə p a ɪ ə ɹ ɒ n
 apelles	ə p ɛ l iː z
 apennine	æ p ə n a ɪ n
 apennines	æ p ə n a ɪ n z
-aper	e ɪ p ə ɹ
+aper	e ɪ p ɚ
 apert	ə p ɜː ɹ t
 aperture	a p ə t j ʊ ə
 aperture	a p ə t͡ʃ ə
@@ -3489,7 +3527,11 @@ aphanitic	æ f ə n ɪ t ɪ k
 aphasia	ə f e ɪ z ɪ ə
 aphasia	ə f e ɪ ʒ ə
 aphasic	ə f e ɪ z ə k
+aphelia	æ p h iː l ɪ ə
+aphelia	ə f iː l ɪ ə
+aphelion	æ p h iː l ɪ ə
 aphelion	æ p h iː l ɪ ə n
+aphelion	ə f iː l ɪ ə
 aphelion	ə f iː l ɪ ə n
 apheresis	ə f ɪ ə ɹ ɪ s ɪ s
 apheses	æ f ə s iː z
@@ -3498,7 +3540,7 @@ aphetic	ə f ɛ t ɪ k
 aphetism	æ f ə t ɪ z ə m
 aphetize	æ f ə t a ɪ z
 aphid	e ɪ f ɪ d
-aphorism	æ f ə ɹ ɪ z m̩
+aphorism	æ f ə ɹ ɪ z ə m
 aphoristic	æ f ə ɹ ɪ s t ɪ k
 aphotic	e ɪ f ə ʊ t ɪ k
 aphrodisiac	æ f ɹ o ʊ d i z i æ k
@@ -3546,6 +3588,7 @@ apodictism	a p ə ʊ d ɪ k t ɪ z m
 apodioxis	æ p ə ʊ d a ɪ ɒ k s ɪ s
 apodixis	æ p ə ʊ d a ɪ k s ɪ s
 apodixis	æ p ə ʊ d ɪ k s ɪ s
+apodosis	ə p ɒ d ə s ɪ s
 apogamy	ə p ɒ ɡ ə m ɪ
 apogeal	æ p o ʊ d͡ʒ iː ə l
 apogeal	æ p ə d͡ʒ iː ə l
@@ -3609,15 +3652,15 @@ apparatus	æ p ə ɹ æ t ə s
 apparatus	æ p ə ɹ ɑː t ə s
 apparel	ə p æ ɹ ə l
 apparent	ə p æ ɹ ə n t
-apparently	ə p a ɹ ə n t l i
+apparently	ə p æ ɹ ə n t l iː
 apparition	æ p ə ɹ ɪ ʃ n̩
-apparitor	ə p æ ɹ i t ə ɹ
+apparitor	ə p æ ɹ i t ɚ
 appeal	ə p iː l
 appealed	ə p iː l d
 appealing	ə p iː l ɪ ŋ
 appealingly	ə p ɪ i l ɪ ŋ l i
 appear	ə p ɪ ə
-appearance	ə p ɪ ə ɹ ə n s
+appearance	ə p ɪ ɹ ə n s
 appeared	ə p ɪ ə d
 appearing	ə p ɪ ə ɹ ɪ ŋ
 appears	ə p ɪ ə z
@@ -3712,7 +3755,7 @@ appropry	ə p ɹ ə ʊ p ɹ i
 approval	ə p ɹ uː v ə l
 approve	ə p ɹ uː v
 approved	ə p ɹ uː v d
-approver	ə p ɹ uː v ə ɹ
+approver	ə p ɹ uː v ɚ
 approves	ə p ɹ uː v z
 approving	ə p ɹ uː v ɪ ŋ
 approximal	ə p ɹ ɒ k s ɪ m ə l
@@ -3735,6 +3778,7 @@ april	e ɪ p ɹ ə l
 april	e ɪ p ɹ ɪ l
 aprils	e ɪ p ɹ ə l z
 aprium	e ɪ p ɹ i ə m
+aprocitentan	æ p ɹ ə s ɪ t ɛ n t æ n
 apron	e ɪ p ɹ ə n
 aprons	e ɪ p ɹ ə n z
 apronym	æ p ɹ ə n ɪ m
@@ -3788,7 +3832,7 @@ aquila	æ k w ɪ l ə
 aquiline	æ k w ɪ l a ɪ n
 aquinas	ə k w a ɪ n ə s
 aquitaine	æ k w ɪ t e ɪ n
-aquiver	ə k w ɪ v ə ɹ
+aquiver	ə k w ɪ v ɚ
 ar	ɑː
 ara	e ɪ ɹ ə
 ara	ɛ ɹ ə
@@ -3820,6 +3864,7 @@ arachnophobia	æ ɹ æ k n ə f ə ʊ b ɪ ə
 aragon	æ ɹ ə ɡ ə n
 aragonese	æ r ə ɡ ɒ n iː z
 arak	ə ɹ æ k
+arak	ɛ ɹ ɪ k
 aralia	ə ɹ e ɪ l i ə
 aralia	ə ɹ e ɪ l j ə
 aram	e ɪ ɹ ə m
@@ -3943,13 +3988,13 @@ archivist	ɑː ɹ k a ɪ v ɪ s t
 archivist	ɑː ɹ k ə v ɪ s t
 archivist	ɑː ɹ k ɪ v ɪ s t
 archking	ɑ ɹ t͡ʃ k ɪ ŋ
-archleader	ɑ ɹ t͡ʃ l iː d ə ɹ
+archleader	ɑ ɹ t͡ʃ l iː d ɚ
 archmage	ɑː t ʃ m e ɪ d ʒ
 archology	ɑː k ɒ l ə d͡ʒ ɪ
 archon	ɑː ɹ k ə n
 archontes	ɑː k ə n t ɛ z
 archontology	ɑː k ɒ n t ɒ l ə d͡ʒ ɪ
-archpractitioner	ɑː ɹ t ʃ p ɹ æ k t ɪ ʃ ə n ə
+archpractitioner	ɑː ɹ t ʃ p ɹ æ k t ɪ ʃ ə n ɚ
 archy	ɑ ɹ k i
 archy	ɑ ɹ t͡ʃ i
 archy	ɑː t͡ʃ i
@@ -3972,7 +4017,7 @@ arcweld	ɑ ɹ k w ɛ l d
 ard	ɑː d
 ardent	ɑː d ə n t
 ardor	ɑː d ə
-ardor	ɑː ɹ d ə ɹ
+ardor	ɑː ɹ d ɚ
 arduity	ɑː d j uː ɪ t i
 arduous	ɑː d j uː ə s
 arduous	ɑː d͡ʒ uː ə s
@@ -4000,6 +4045,7 @@ areopagitic	ɛ ə ɹ i ə ʊ p ə d͡ʒ ɪ t ɪ k
 areopagus	æ r i ɒ p ə ɡ ə s
 ares	e ə ɹ iː z
 arete	æ ɹ ɪ t iː
+arethusa	æ ɹ ɪ θ j uː z ə
 arew	ə ɹ ə ʊ
 arezzo	ə ɹ ɛ t s ə ʊ
 argal	ɑː ɹ ɡ ə l
@@ -4007,12 +4053,13 @@ argaman	ɑː ɹ ɡ ə m ə n
 argan	ɑː ɹ ɡ ə n
 argent	ɑː d ʒ ə n t
 argentina	ɑː d͡ʒ ə n t iː n ə
+argentinan	ɑ ɹ d͡ʒ ɪ n t iː n ə n
 argentine	ɑː d ʒ ə n t a ɪ n
 argentine	ɑː d ʒ ə n t iː n
 argentine	ɑː ɹ d͡ʒ ə n t a ɪ n
 argentine	ɑː ɹ d͡ʒ ə n t iː n
-argentinian	ɑ ɹ d͡ʒ ə n t i n i ə n
-argentinian	ɑ ɹ d͡ʒ ə n t iː n i ə n
+argentinian	ɑ ɹ d͡ʒ ə n t i n ɪ ə n
+argentinian	ɑ ɹ d͡ʒ ə n t iː n ɪ ə n
 argentocracy	ɑː d͡ʒ ə n t ɒ k ɹ ə s ɪ
 argentry	ɑː ɹ d͡ʒ ə n t ɹ i
 argh	ɑ ɹ ɡ
@@ -4075,6 +4122,7 @@ aristocrat	æ ɹ ɪ s t ə k ɹ æ t
 aristocratic	æ ɹ ɪ s t ə k ɹ æ t ɪ k
 aristolochic	ə ɹ ɪ s t ə l o ʊ k ɪ k
 aristophanes	æ ɹ ɪ s t ɒ f ə n iː z
+aristotelian	æ ɹ ɪ s t ə t iː l i ə n
 aristotle	æ ɹ ɪ s t ɒ t ə l
 arithmetic	æ ɹ ɪ θ m ɛ t ɪ k
 arithmetic	ə ɹ ɪ θ m ə t ɪ k
@@ -4147,9 +4195,11 @@ arousing	ə ɹ a ʊ z ɪ ŋ
 arow	ə ɹ o ʊ
 arpa	ɑ ɹ p ə
 arpitan	ɑː p ɪ t æ n
+arquebus	ɑː k w ɪ b ə s
 arr	ɑː ɹ
 arrabbiata	a ɹ ə b j ɑː t ə
 arrack	ə ɹ æ k
+arrack	ɛ ɹ ɪ k
 arraign	ə ɹ e ɪ n
 arraigned	ə ɹ e ɪ n d
 arraigning	ə ɹ e ɪ n ɪ ŋ
@@ -4200,7 +4250,8 @@ arrogate	æ ɹ ə ɡ e ɪ t
 arrondissement	ə ɹ ɒ n d ɪ s m ə n t
 arrove	ə ɹ ə ʊ v
 arrow	æ ɹ ə ʊ
-arrowmaker	æ ɹ ə ʊ m e ɪ k ə ɹ
+arrowcide	æ ɹ o ʊ s a ɪ d
+arrowmaker	æ ɹ ə ʊ m e ɪ k ɚ
 arrowroot	æ ɹ ə ʊ ɹ uː t
 arrows	æ ɹ ə ʊ z
 arroyo	ə ɹ ɔ ɪ ə ʊ
@@ -4261,8 +4312,8 @@ articulation	ɑː t ɪ k j ə l e ɪ ʃ ə n
 articulatory	ɑː ɹ t ɪ k j ə l ə t ə ɹ ɪ
 artifact	ɑː t ɪ f æ k t
 artifice	ɑː ɹ t ɪ f ɪ s
-artificer	ɑ ɹ t ɪ f ə s ə ɹ
-artificer	ɑ ɹ t ɪ f ɪ s ə ɹ
+artificer	ɑ ɹ t ɪ f ə s ɚ
+artificer	ɑ ɹ t ɪ f ɪ s ɚ
 artificial	ɑː ɹ t ə f ɪ ʃ ə l
 artificiality	ɑː ɹ t ɪ f ɪ ʃ i æ l ɪ t i
 artillery	ɑː t ɪ l ə ɹ i
@@ -4361,15 +4412,15 @@ ashamed	ə ʃ e ɪ m d
 ashanti	ə ʃ æ n t iː
 ashanti	ə ʃ ɑː n t iː
 ashed	æ ʃ t
-ashen	æ ʃ ɪ n
+ashen	æ ʃ ə n
 asher	æ ʃ ə
-asher	æ ʃ ə ɹ
+asher	æ ʃ ɚ
 asherah	ə ʃ iː ɹ ə
 ashes	æ ʃ ɪ z
 ashfield	æ ʃ f iː l d
 ashford	æ ʃ f ə d
 ashine	ə ʃ a ɪ n
-ashiver	ə ʃ ɪ v ə ɹ
+ashiver	ə ʃ ɪ v ɚ
 ashkelon	æ ʃ k ə l ɒ n
 ashkenazi	æ ʃ k ɪ n ɑː z i
 ashkenazi	æ ʃ k ɪ n ə z iː
@@ -4411,7 +4462,7 @@ aslant	ə s l ɑː n t
 asleep	ə s l iː p
 aslope	ə s l ə ʊ p
 asmara	æ s m ɑː ɹ ə
-asmear	ə s m ɪ ə ɹ
+asmear	ə s m ɪ ɚ
 asmodeus	æ z m ə d iː ə s
 asmrtist	e ɪ ɛ s ɛ m ɑː t ɪ s t
 asnarl	ə s n ɑː ɹ l
@@ -4438,7 +4489,7 @@ asper	æ s p ə
 asperate	æ s p ə ɹ e ɪ t
 asperate	æ s p ə ɹ ə t
 asperge	ə s p ɜː ɹ d͡ʒ
-asperger	æ s p ɜː ɹ ɡ ə ɹ
+asperger	æ s p ɜː ɹ ɡ ɚ
 aspergilloma	æ s p ə ɹ d͡ʒ ɪ l o ʊ m ə
 aspergilloses	æ s p ə ɹ d͡ʒ ɪ l o ʊ s i s
 aspergillosis	æ s p ə ɹ d͡ʒ ɪ l o ʊ s ɪ s
@@ -4589,13 +4640,13 @@ assyrogenous	æ s ɪ ɹ ɒ d ʒ ɪ n ə s
 assythment	ə s ʌ ɪ ð m ə n t
 astana	ə s t ɑː n ə
 astand	ə s t æ n d
-astare	ə s t ɛ ə ɹ
+astare	ə s t ɛ ɚ
 astart	ə s t ɑː ɹ t
 astasia	ə s t e ɪ z i ə
 astasia	ə s t e ɪ ʒ ə
 astatine	a s t ə t iː n
 astay	ə s t e ɪ
-aster	æ s t ə ɹ
+aster	æ s t ɚ
 asterisk	æ s t ə ɹ ɪ s k
 asterisk	æ s t ɹ ɪ s k
 asterism	æ s t ə ɹ ɪ z ə m
@@ -4649,7 +4700,7 @@ astrogeometry	æ s t ɹ ə d͡ʒ iː ɑ m ɛ t ɹ i
 astrohistory	æ s t ɹ ə h ɪ s t ə ɹ i
 astrolabe	æ s t ɹ ə l e ɪ b
 astrolinguistics	æ s t ɹ ə l ɪ ŋ ɡ w ɪ s t ɪ k s
-astrologer	ə s t r ɒ l ə d͡ʒ ə ɹ
+astrologer	ə s t r ɒ l ə d͡ʒ ɚ
 astrological	æ s t ɹ ə l ɒ d͡ʒ ɪ k ə l
 astrology	ə s t ɹ ɒ l ə d ʒ i
 astrometry	ə s t ɹ ɒ m ə t ɹ i
@@ -4738,8 +4789,8 @@ atherine	æ θ ə ɹ ɪ n
 athermic	e ɪ θ ɜ ɹ m ɪ k
 athetesis	æ θ ɪ t iː s ɪ s
 athirst	ə θ əː s t
-athleisure	æ θ l iː ʒ ə ɹ
-athleisure	æ θ l ɛ ʒ ə ɹ
+athleisure	æ θ l iː ʒ ɚ
+athleisure	æ θ l ɛ ʒ ɚ
 athlete	æ θ l iː t
 athletic	æ θ l ɛ t ɪ k
 athletics	æ θ l ɛ t ɪ k s
@@ -4774,6 +4825,7 @@ atoll	ə t ɒ l
 atoltivimab	æ t ɒ l t ɪ v ɪ m æ b
 atom	æ t ə m
 atomic	ə t ɒ m ɪ k
+atomicity	æ t ə m ɪ s ɪ t i
 atomist	æ t ə m ɪ s t
 atompunk	æ t ə m p ʌ ŋ k
 atoms	a t ə m z
@@ -4805,6 +4857,7 @@ atrium	e ɪ t ɹ i ə m
 atrocious	ə t ɹ ə ʊ ʃ ə s
 atrocity	ə t ɹ ɒ s ɪ t i
 atrophy	æ t ɹ ə f i
+atropia	ə t ɹ ə ʊ p i ə
 atropine	a t ɹ ə p iː n
 atropine	a t ɹ ə p ɪ n
 atropos	æ t ɹ ə p ɒ s
@@ -4861,7 +4914,7 @@ attesting	ə t ɛ s t ɪ ŋ
 attests	ə t ɛ s t s
 attic	æ t ɪ k
 attinge	ə t ɪ n d͡ʒ
-attire	ə t a ɪ ə ɹ
+attire	ə t a ɪ ɚ
 attitude	æ t ɪ t j uː d
 attitudinize	æ t ɪ t j uː d ɪ n a ɪ z
 attitudinize	æ t ɪ t uː d ɪ n a ɪ z
@@ -4895,7 +4948,7 @@ atwinkle	ə t w ɪ ŋ k ə l
 atwirl	ə t w ɜː ɹ l
 atwist	ə t w ɪ s t
 atwitch	ə t w ɪ t͡ʃ
-atwitter	ə t w ɪ t ə ɹ
+atwitter	ə t w ɪ t ɚ
 atyap	ə t j a b
 atypical	e ɪ t ɪ p ɪ k ə l
 atyrau	ɑ t ɪ ɹ a ʊ
@@ -4923,7 +4976,7 @@ audiophile	ɔː d i ə ʊ f a ɪ l
 audiovisual	ɔː d i ə ʊ v ɪ z j ʊ ə l
 audit	ɔː d ɪ t
 audition	ɔː d ɪ ʃ ə n
-auditor	ɔː d ɪ t ə ɹ
+auditor	ɔː d ɪ t ɚ
 auditorium	ɔː d ɪ t ɔː ɹ i ə m
 auditory	ɔː d ɪ t ə ɹ i
 auditory	ɔː d ɪ t ɹ i
@@ -5016,9 +5069,9 @@ austenesque	ɔː s t ə n ɛ s k
 austenian	ɔː s t iː n ɪ ə n
 austenite	ɒ s t ɪ n a ɪ t
 auster	ɒ s t ə
-auster	ɒ s t ə ɹ
+auster	ɒ s t ɚ
 auster	ɔː s t ə
-auster	ɔː s t ə ɹ
+auster	ɔː s t ɚ
 austere	ɒ s t ɪ ə ɹ
 austere	ɔː s t ɪ ə ɹ
 austerlitz	a ʊ s t ə l ɪ t s
@@ -5054,10 +5107,12 @@ austronesian	ɔː s t ɹ o ʊ n iː ʒ ə n
 austronesians	ɔː s t ɹ o ʊ n iː ʒ ə n z
 austrophobe	ɒ s t ɹ ə ʊ f ə ʊ b
 autarchic	ɔː t ɑː k ɪ k
-autarchy	ɔː t ɑː ɹ k i
+autarchy	ɔː t ə k i
 autarkic	ɔː t ɑː k ɪ k
+autarky	ɔː t ə k i
 auteur	ɔː t ɜː
 auteur	ə ʊ t ɜː
+authentic	ɒ θ ɛ n t ɪ k
 author	ɔː θ ə
 authoress	ɔː θ ə ɹ ɛ s
 authoritah	ə θ ɔ ɹ ə t ɑː
@@ -5176,7 +5231,7 @@ avenge	ə v ɛ n d͡ʒ
 avens	æ v ɪ n z
 aventail	æ v ə n t e ɪ l
 aventine	æ v ə n t a ɪ n
-aventre	ə v ɛ n t ə ɹ
+aventre	ə v ɛ n t ɚ
 aventurine	ə v ɛ n t j ʊ ə ɹ ɪ n
 aventurine	ə v ɛ n t͡ʃ ə ɹ ɪ n
 avenue	æ v ə n j uː
@@ -5233,6 +5288,7 @@ avon	e ɪ v ɑ n
 avon	e ɪ v ə n
 avondale	e ɪ v ə n d e ɪ l
 avonmouth	e ɪ v ə n m ə θ
+avosentan	æ v ə s ɛ n t æ n
 avouch	ə v a ʊ t͡ʃ
 avourneen	ə v ɔː n iː n
 avourneen	ə v ʊ ə n iː n
@@ -5267,7 +5323,7 @@ awaze	ɑ w ɑ z e ɪ
 awaze	ɑ w ɑ z i
 awe	ɔː
 aweary	ə w ɪ ə ɹ i
-aweather	ə w ɛ ð ə ɹ
+aweather	ə w ɛ ð ɚ
 awed	ɔː d
 aweigh	ə w e ɪ
 aweless	ɔː l ɪ s
@@ -5296,7 +5352,7 @@ awkwards	ɔː k w ə d z
 awl	ɔː l
 awlwort	ɔː l w ɜː ɹ t
 awn	ɔː n
-awner	ɔː n ə ɹ
+awner	ɔː n ɚ
 awning	ɔː n ɪ ŋ
 awnry	ɔː n ɹ i
 awoke	ə w ə ʊ k
@@ -5400,7 +5456,7 @@ azores	ə z ɔː z
 azote	æ z ə ʊ t
 azotemia	æ z ə ʊ t iː m ɪ ə
 azoth	ɑː z ɒ θ
-azotometer	e ɪ z ə ʊ t ɒ m ɪ t ə ɹ
+azotometer	e ɪ z ə ʊ t ɒ m ɪ t ɚ
 azov	ɑː z ɒ v
 azoxystrobin	ə z ɒ k s i s t ɹ ə ʊ b ɪ n
 azrael	æ z ɹ i ə l
@@ -5440,7 +5496,7 @@ babblery	b æ b ə l ɹ i
 babby	b æ b i
 babe	b e ɪ b
 babel	b e ɪ b l̩
-babergh	b e ɪ b ə ɹ
+babergh	b e ɪ b ɚ
 babes	b e ɪ b z
 babiche	b æ b iː ʃ
 babiche	b ə b iː ʃ
@@ -5495,7 +5551,7 @@ backdam	b æ k d æ m
 backdraught	b æ k d ɹ ɑː f t
 backdrop	b æ k d ɹ ɒ p
 backed	b æ k t
-backer	b æ k ə ɹ
+backer	b æ k ɚ
 backfield	b a k f iː l d
 backfisch	b æ k f ɪ ʃ
 backflip	b æ k f l ɪ p
@@ -5582,6 +5638,7 @@ baden	b ɑː d ə n
 badge	b æ d͡ʒ
 badger	b æ d ʒ ɚ
 badger	b æ d͡ʒ ə
+badigeon	b ə d ɪ d ʒ ə n
 badinage	b æ d ɪ n ɑː d ʒ
 badinage	b æ d ɪ n ɑː ʒ
 badine	b ə d iː n
@@ -5596,7 +5653,7 @@ badness	b æ d n ə s
 badong	b ə d ɔ ŋ
 badonkadonk	b ə d ɔ ŋ k ə d ɔ ŋ k
 bae	b e ɪ
-baenomere	b iː n ə m ɪ ə ɹ
+baenomere	b iː n ə m ɪ ɚ
 baenopod	b iː n ə p ɒ d
 baetyl	b iː t a ɪ ɫ
 baff	b æ f
@@ -5660,7 +5717,7 @@ baihe	b a ɪ h ə
 baiji	b a ɪ d͡ʒ i
 baijiu	b a ɪ d͡ʒ uː
 baikal	b a ɪ k æ l
-baikonur	b a ɪ k ə n ɪ ə ɹ
+baikonur	b a ɪ k ə n ɪ ɚ
 bail	b e ɪ̯ l
 baile	b a ɪ l i
 baile	b e ɪ l
@@ -5726,8 +5783,9 @@ balalaiki	b a l ə l a ɪ k i
 balalaiki	b æ l ə l a ɪ k ɪ
 balance	b æ l ə n s
 balanced	b æ l ə n s t
-balancer	b æ l ə n s ə ɹ
+balancer	b æ l ə n s ɚ
 balanephagous	b æ l ə n iː f ə ɡ ə s
+balanic	b ə l æ n ɪ k
 balanitis	b æ l ə n a ɪ t ɪ s
 balanophagous	b æ l ə n ɒ f ə ɡ ə s
 balas	b a l ə s
@@ -5757,6 +5815,7 @@ baled	b e ɪ l d
 baleen	b e ɪ l iː n
 baleen	b ə l iː n
 baleful	b e ɪ l f ə l
+balenciaga	b ə l ɛ n s i ɑː ɡ ə
 bales	b e ɪ l z
 bali	b ɑː l i
 balinese	b ɑː l ɪ n iː z
@@ -5776,7 +5835,7 @@ balladry	b æ l ə d ɹ i
 ballarat	b æ l ə ɹ æ t
 ballast	b æ l ə s t
 ballcock	b ɔː l k ɒ k
-baller	b ɔː l ə ɹ
+baller	b ɔː l ɚ
 ballerina	b æ l ə ɹ iː n ə
 ballerino	b æ l ə ɹ iː n o ʊ
 ballet	b æ l e ɪ
@@ -5791,7 +5850,7 @@ ballistics	b ə l ɪ s t ɪ k s
 ballonet	b a l ə n ɛ t
 balloon	b ə l uː n
 ballooned	b ə l uː n d
-ballooner	b ə l uː n ə ɹ
+ballooner	b ə l uː n ɚ
 ballooning	b ə l uː n ɪ ŋ
 balloonings	b ə l uː n ɪ ŋ z
 balloons	b ə l uː n z
@@ -5813,7 +5872,7 @@ balmily	b ɑː m ɪ l i
 balmoral	b æ l m ɒ ɹ ə l
 balmy	b ɑː m i
 baloney	b ə l ə ʊ n i
-balquhidder	b æ l k w ɪ d ə ɹ
+balquhidder	b æ l k w ɪ d ɚ
 balrog	b a l ɹ ɒ ɡ
 balrog	b ɔː l ɹ ɒ ɡ
 balsa	b æ l s ə
@@ -5838,15 +5897,18 @@ bambooey	b æ m b uː i
 bamboozle	b æ m b uː z l̩
 bambuterol	b æ m b j uː t ə ɹ ɒ l
 bamma	b æ m ə
-bammer	b æ m ə ɹ
+bammer	b æ m ɚ
 bammy	b a m i
 bamp	b æ m p
 bampot	b æ m p ɒ t
 ban	b æ n
+banaba	b ə n ɑː b ə
 banach	b a n a k
 banal	b e ɪ n ə l
 banal	b ə n æ l
 banal	b ə n ɑː l
+banality	b e ɪ n æ l ɪ t i
+banality	b ə n æ l ɪ t i
 banana	b ə n ɑː n ə
 bananas	b ə n ɑː n ə z
 bananery	b ə n ɑː n ə ɹ i
@@ -5871,8 +5933,9 @@ bandit	b æ n d ɪ t
 bandmate	b æ n d m e ɪ t
 bandog	b a n d ɒ ɡ
 bandolero	b æ n d ə l e ə ɹ ə ʊ
-bandolier	b æ n d ə l ɪ ə ɹ
+bandolier	b æ n d ə l ɪ ɚ
 bandolierwise	b æ n d ə l ɪ ə ɹ w a ɪ z
+bandra	b æ n d ɹ ə
 bands	b æ n d z
 bandstand	b æ n d s t æ n d
 bandung	b æ n d ʊ ŋ
@@ -5890,14 +5953,14 @@ bangable	b æ ŋ ɡ ə b ə ɫ
 bangalore	b æ ŋ ɡ ə l ɔː
 bangarang	b æ ŋ ə ɹ æ ŋ
 bangel	b e ɪ n d͡ʒ ə l
-banger	b æ ŋ ə ɹ
+banger	b æ ŋ ɚ
 banging	b æ ŋ ɪ ŋ
 bangiophyte	b æ n d͡ʒ ɪ ɔ f a ɪ t
 bangkok	b æ ŋ k ɒ k
 bangladesh	b æ ŋ ɡ l ə d ɛ ʃ
 bangladesh	b ɑː ŋ ɡ l ə d ɛ ʃ
 bangle	b æ ŋ ɡ ə l
-bangor	b æ ŋ ɡ ə ɹ
+bangor	b æ ŋ ɡ ɚ
 bangs	b æ ŋ z
 bangui	b ɑː ŋ ɡ i
 bangui	b ɑː ŋ ɡ iː
@@ -5908,7 +5971,7 @@ banishes	b æ n ɪ ʃ ɪ z
 banishing	b æ n ɪ ʃ ɪ ŋ
 banishings	b æ n ɪ ʃ ɪ ŋ z
 banishment	b æ n ɪ ʃ m ə n t
-banister	b æ n ɪ s t ə ɹ
+banister	b æ n ɪ s t ɚ
 banjax	b æ n d͡ʒ æ k s
 banjo	b æ n d ʒ ə ʊ
 banjouke	b æ n d͡ʒ ə ʊ j uː k
@@ -6055,6 +6118,7 @@ barghest	b ɑː ɡ ɛ s t
 bargirl	b ɑː ɹ ɡ ɜː ɹ l
 bari	b æ ɹ i
 baria	b ɛ ə ɹ i ə
+bariatric	b æ ɹ i æ t ɹ ɪ k
 bariatrician	b æ ɹ i ə t ɹ ɪ ʃ ə n
 baric	b æ ɹ ɪ k
 baric	b ɛ ə ɹ ɪ k
@@ -6072,7 +6136,7 @@ bark	b ɑː k
 barkeep	b ɑː ɹ k iː p
 barken	b ɑː ɹ k ə n
 barker	b ɑː r k ə r
-barker	b ɑː ɹ k ə ɹ
+barker	b ɑː ɹ k ɚ
 barking	b ɑː k ɪ ŋ
 barking	b ɑː ɹ k ɪ ŋ ɡ
 barkled	b ɑː k ə l d
@@ -6123,7 +6187,7 @@ barramundi	b æ ɹ ə m ʌ n d i
 barranca	b ə ɹ æ ŋ k ə
 barrasso	b ə ɹ æ s o ʊ
 barrasso	b ə ɹ ɑ s o ʊ
-barrator	b æ ɹ ə t ə ɹ
+barrator	b æ ɹ ə t ɚ
 barrators	b æ ɹ ə t ə ɹ z
 barratry	b æ ɹ ə t ɹ i
 barred	b ɑː ɹ d
@@ -6136,7 +6200,7 @@ barrier	b æ ɹ i ə ɹ
 barring	b ɑː ɹ ɪ ŋ ɡ
 barrister	b æ ɹ ɪ s t ə ɹ
 barrow	b æ ɹ ə ʊ
-barry	b æ ɹ i
+barry	b æ ɹ ɪ
 barry	b ɑː ɹ i
 bars	b ɑː ɹ z
 barse	b ɑː s
@@ -6153,8 +6217,6 @@ bartizan	b ɑː t ɪ z æ n
 bartlett	b ɑː ɹ t l ə t
 barton	b ɑː ɹ t ə n
 bartonite	b ɑː ɹ t ə n a ɪ t
-baruch	b ə r u k
-baruch	b ɛ ə r ə k
 baryon	b æ ɹ i ɒ n
 baryon	b ɛ ə ɹ i ɒ n
 barythymia	b æ ɹ ɪ θ a ɪ m ɪ ə
@@ -6223,8 +6285,8 @@ basketball	b ɑː s k ɪ t b ɔː l
 basketweaving	b æ s k ə t w ɪ i v ɪ ŋ
 basketweaving	b æ s k ɪ t w ɪ i v ɪ ŋ
 basle	b ɑː l
-basler	b æ z l ə ɹ
-basler	b ɑː z l ə ɹ
+basler	b æ z l ɚ
+basler	b ɑː z l ɚ
 basmati	b æ z m æ t i
 basmati	b æ z m ɑː t i
 basmati	b ɑː z m ɑː t i
@@ -6236,13 +6298,14 @@ bass	b æ s
 bassaleg	b æ s æ l ɛ ɡ
 bassein	b ə s e ɪ n
 basset	b æ s ɪ t
+basseterre	b æ s t ɛ ə ɹ
 bassinet	b æ s ɪ n ɛ t
 bassist	b e ɪ s ɪ s t
 bassline	b e ɪ s l a ɪ n
 basslines	b e ɪ s l a ɪ n z
 bassoon	b ə s uː n
 bassooned	b ə s uː n d
-bassooner	b ə s uː n ə ɹ
+bassooner	b ə s uː n ɚ
 bassooning	b ə s uː n ɪ ŋ
 bassoons	b ə s uː n z
 basswood	b æ s w ʊ d
@@ -6324,7 +6387,9 @@ batley	b æ t l i
 batman	b a t m a n
 batman	b æ t m æ n
 batman	b æ t m ə n
+baton	b æ t n̩
 baton	b æ t ɒ n
+baton	b æ t ə n
 batoon	b ə t uː n
 batrachian	b ə t ɹ e ɪ k ɪ ə n
 batrachophagous	b ə t ɹ æ k ə f e ɪ ɡ ə s
@@ -6335,7 +6400,7 @@ batsqueak	b a t s k w iː k
 batta	b ʌ t ə
 battalion	b ə t æ l ɪ ə n
 batted	b æ t ɪ d
-batter	b æ t ə ɹ
+batter	b æ t ɚ
 batteries	b æ t ə ɹ i z
 battering	b æ t ə ɹ ɪ ŋ ɡ
 battersea	b æ t ə s i
@@ -6382,6 +6447,7 @@ baxter	b æ k s t ə
 bay	b e ɪ
 bayadère	b a ɪ ə d ɛː
 baybars	b a ɪ b ɑː s
+baybayin	b a ɪ b a j i n
 bayed	b e ɪ d
 bayesian	b e ɪ z i ə n
 bayesian	b e ɪ ʒ ə n
@@ -6436,6 +6502,7 @@ beadings	b iː d ɪ ŋ z
 beads	b iː d z
 beadsman	b iː d z m ə n
 beady	b iː d i
+beagle	b iː ɡ ə l
 beak	b iː k
 beaked	b iː k t
 beaker	b iː k ə ɹ
@@ -6525,6 +6592,7 @@ beauties	b j uː t i z
 beautification	b j uː t ɪ f ɪ k e ɪ ʃ ə n
 beautifies	b j u t ə f a ɪ z
 beautiful	b j uː t ɪ f ə l
+beautiful	b j uː t ɪ f ʊ l
 beautifully	b j uː t ɪ f ə l i
 beautify	b j uː t ɪ f a ɪ
 beautility	b j uː t ɪ l ə t i
@@ -6650,7 +6718,7 @@ beepings	b iː p ɪ ŋ z
 beeps	b iː p s
 beer	b iː ə
 beer	b ɪ ə
-beer	b ɪ ə ɹ
+beer	b ɪ ɚ
 beer	b ɪː
 beers	b ɪ ə ɹ z
 beersheba	b ɛ ə ɹ ʃ e ɪ b ə
@@ -6743,7 +6811,7 @@ beheld	b ɪ h ɛ l d
 behelp	b ɪ h ɛ l p
 behemoth	b iː ə m ə θ
 behemoth	b ə h iː m ə θ
-behest	b i h ɛ s t
+behest	b ɪ h ɛ s t
 behind	b ə h a ɪ n d
 behind	b ɪ h a ɪ n d
 behl	b e ɪ l
@@ -6754,6 +6822,7 @@ behoof	b ɪ h uː f
 behoove	b ɪ h uː v
 behove	b ɪ h ə ʊ v
 behoveful	b ɪ h ə ʊ v f ə l
+behoven	b ɪ h ə ʊ v ə n
 beibei	b e ɪ b e ɪ
 beida	b e ɪ d a
 beige	b e ɪ d͡ʒ
@@ -6761,7 +6830,9 @@ beige	b e ɪ ʒ
 beigey	b e ɪ ʒ i
 beignet	b ɛ n j e ɪ
 beijing	b e ɪ d͡ʒ ɪ ŋ
+beijinger	b e ɪ d ʒ ɪ ŋ ə ɹ
 bein	b iː n
+being	b iː ŋ
 being	b iː ɪ ŋ
 beings	b iː ɪ ŋ z
 beiping	b e ɪ p ɪ ŋ
@@ -6825,6 +6896,7 @@ belief	b ɪ l iː f
 believe	b ɪ l iː v
 believer	b ɪ l iː v ə
 belinda	b ə l ɪ n d ə
+belittle	b ɪ l ɪ t ə l
 belive	b ɪ l a ɪ v
 beliven	b ɪ l ɪ v ə n
 belize	b e ɪ l iː z
@@ -6878,7 +6950,7 @@ belove	b ɪ l ʌ v
 beloved	b ɪ l ʌ v d
 beloved	b ɪ l ʌ v ɪ d
 below	b ɪ l ə ʊ
-belswagger	b ɛ l s w æ ɡ ə ɹ
+belswagger	b ɛ l s w æ ɡ ɚ
 belt	b ɛ l t
 belted	b ɛ l t ɪ d
 belter	b ɛ l t ə
@@ -6909,7 +6981,7 @@ benbecula	b ɛ n b ɛ k j ʊ l ə
 bench	b ɛ n t ʃ
 bench	b ɛ n ʃ
 benched	b ɛ n t͡ʃ t
-bencher	b ɛ n t͡ʃ ə ɹ
+bencher	b ɛ n t͡ʃ ɚ
 benches	b ɛ n t͡ʃ ɪ z
 benching	b ɛ n t͡ʃ ɪ ŋ
 benchings	b ɛ n t͡ʃ ɪ ŋ z
@@ -6976,6 +7048,7 @@ benumb	b i n ʌ m
 benxi	b ʌ n ʃ iː
 benz	b ɛ n z
 benzene	b ɛ n z iː n
+benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɪ p iː n
 benzoin	b ɛ n z ɔ ɪ n
 benzoin	b ɛ n z ə ʊ ɪ n
 benzonatate	b ɛ n z o ʊ n ə t e ɪ t
@@ -7059,6 +7132,7 @@ berserker	b ə z ɜː k ə
 berserker	b ɜː s ɜː k ə
 bert	b ɜː t
 berth	b ɜː θ
+bertha	b ɜː ɹ θ ə
 bertha	b ɜː θ ə
 bertillonage	b ɛː t i j ɒ n ɑː ʒ
 bertram	b ɜː t ɹ ə m
@@ -7123,8 +7197,8 @@ betager	b e ɪ t ə d ʒ ə
 betake	b ɪ t e ɪ k
 betcha	b ɛ t͡ʃ ə
 betcho	b ɛ t͡ʃ o ʊ
-betear	b ɪ t ɛ ə ɹ
-betear	b ɪ t ɪ ə ɹ
+betear	b ɪ t ɛ ɚ
+betear	b ɪ t ɪ ɚ
 betelgeuse	b iː t l d ʒ əː z
 beth	b ɛ t
 beth	b ɛ θ
@@ -7181,11 +7255,11 @@ bevor	b iː v ə
 bevvy	b ɛ v i
 bevy	b ɛ v i
 bewail	b ɪ w e ɪ l
-beware	b i w ɛ ə ɹ
-beware	b ə w ɛ ə ɹ
-beware	b ɪ w ɛ ə ɹ
-bewater	b ɪ w ɔː t ə ɹ
-bewelter	b ɪ w ɛ l t ə ɹ
+beware	b i w ɛ ɚ
+beware	b ə w ɛ ɚ
+beware	b ɪ w ɛ ɚ
+bewater	b ɪ w ɔː t ɚ
+bewelter	b ɪ w ɛ l t ɚ
 bewhape	b ɪ w e ɪ p
 bewhape	b ɪ ʍ e ɪ p
 bewhore	b ɪ h ɔː ɹ
@@ -7235,7 +7309,7 @@ bhaji	b ɑː d͡ʒ i
 bhang	b a ŋ
 bhang	b æ ŋ
 bhangra	b ɑː ŋ ɡ ɹ ə
-bheer	b ɪ ə ɹ
+bheer	b ɪ ɚ
 bhikkhu	b ɪ k uː
 bhojpuri	b o ʊ d͡ʒ p ʊ ə r i
 bhopal	b ə ʊ p ɑː l
@@ -7265,6 +7339,7 @@ bibliometrist	b ɪ b l i ɒ m ə t ɹ ɪ s t
 bibliopoly	b ɪ b l i ɒ p ə l i
 bibliotheca	b ɪ b l i ə θ iː k ə
 bibliothecal	b ɪ b l i ə θ iː k ə l
+bibliotheque	b ɪ b l i ə θ iː k
 bibliotic	b ɪ b l i ɒ t ɪ k
 biblist	b ɪ b l ɪ s t
 bibs	b ɪ b z
@@ -7304,7 +7379,7 @@ bide	b a ɪ d
 bided	b a ɪ d ɪ d
 bideford	b ɪ d ɪ f ə r d
 biden	b a ɪ d ə n
-bidencare	b a ɪ d ə n k ɛ ə ɹ
+bidencare	b a ɪ d ə n k ɛ ɚ
 bidenomics	b a ɪ d ə n ɒ m ɪ k s
 bides	b a ɪ d z
 bidet	b iː d e ɪ
@@ -7318,6 +7393,7 @@ bieber	b iː b ə
 biennial	b a ɪ ɛ n i ə l
 biennium	b ʌ ɪ ɛ n ɪ ə m
 bier	b ɪ ə
+bifarious	b a ɪ f ɛ ə ɹ i ə s
 bifenthrin	b a ɪ f ɛ n θ ɹ ɪ n
 bifeprunox	b ɪ f ɛ p ɹ ə n ɒ k s
 biff	b ɪ f
@@ -7360,7 +7436,7 @@ bikini	b ɪ k iː n i
 bikini	b ɪ k ɪ n i
 bilabial	b a ɪ l e ɪ b i ə l
 bilali	b ɪ l ɑː l i
-bilander	b ɪ l ə n d ə ɹ
+bilander	b ɪ l ə n d ɚ
 bilbao	b ɪ l b a ʊ
 bilberry	b ɪ l b ə ɹ ɪ
 bilbo	b ɪ l b ə ʊ
@@ -7407,7 +7483,6 @@ bimetallic	b a ɪ m ɪ t æ l ɪ k
 bimillennial	b a ɪ m ɪ l ɛ n i ə l
 bimini	b ɪ m ɪ n i
 bimini	b ɪ m ɪ n iː
-bin	b iː n
 bin	b ɪ n
 binal	b a ɪ n ə l
 binarseniate	b a ɪ n ɑː ɹ s iː n i e ɪ t
@@ -7426,7 +7501,11 @@ bine	b a ɪ n
 bines	b a ɪ n z
 bing	b ɪ ŋ
 binge	b ɪ n d͡ʒ
+binged	b ɪ n d͡ʒ d
+binged	b ɪ ŋ d
 binghi	b ɪ ŋ a ɪ
+binging	b ɪ n d͡ʒ ɪ ŋ
+binging	b ɪ ŋ ɪ ŋ
 bingo	b ɪ ŋ ɡ ə ʊ
 bingy	b ɪ ŋ i
 binhai	b ɪ n h a ɪ
@@ -7442,10 +7521,11 @@ binner	b ɪ n ə ɹ
 binning	b ɪ n ɪ ŋ
 binns	b ɪ n z
 binny	b ɪ n i
-binocular	b ɪ n ɒ k j ʊ l ə ɹ
+binocular	b ɪ n ɒ k j ʊ l ɚ
 binoculars	b ə n ɒ k j ə l ə ɹ z
 binoculars	b ɪ n ɒ k j ʊ l ə ɹ z
 binomial	b a ɪ n ə ʊ m i ə l
+binoxide	b a ɪ n ɒ k s a ɪ d
 bins	b ɪ n z
 bint	b ɪ n t
 bintje	b ɪ n t͡ʃ ə
@@ -7454,7 +7534,7 @@ bio	b a ɪ ə ʊ
 bioanalytical	b a ɪ ə ʊ æ n ə l ɪ t ɪ k ə l
 bioanalytics	b a ɪ o ʊ æ n ə l ɪ t ɪ k s
 biocide	b a ɪ ə ʊ s a ɪ d
-biodiversity	b a ɪ ə ʊ d a ɪ v ɜː ɹ s ɪ t i
+biodiversity	b a ɪ ə ʊ d a ɪ v ɜː s ɪ t i
 biofuel	b a ɪ ə ʊ f j ʊ ə l
 biogenesis	b ʌ ɪ ə ʊ d ʒ ɛ n ə s ɪ s
 biographize	b a ɪ ɒ ɡ ɹ ə f a ɪ z
@@ -7631,14 +7711,14 @@ bizbabble	b ɪ z b æ b ə l
 bizen	b a ɪ z ə n
 blab	b l æ b
 blabbed	b l æ b d
-blabber	b l æ b ə ɹ
+blabber	b l æ b ɚ
 blabbermouth	b l æ b ə ɹ m a ʊ θ
 blabbing	b l æ b ɪ ŋ
 blabby	b l æ b i
 blabs	b l æ b z
 blaby	b l e ɪ b i
 black	b l æ k
-blackadder	b l æ k æ d ə ɹ
+blackadder	b l æ k æ ɚ
 blackamoor	b l æ k ə m ɔː
 blackamoor	b l æ k ə m ɔː ɹ
 blackamoor	b l æ k ə m ʊ ə
@@ -7689,7 +7769,7 @@ blaeberry	b l e ɪ b ə ɹ i
 blaenrhondda	b l a ɪ n r ɒ n ð ə
 blag	b l æ ɡ
 blaggard	b l æ ɡ ə d
-blagger	b l æ ɡ ə ɹ
+blagger	b l æ ɡ ɚ
 blagoveshchensk	b l ɑ ɡ ə v ɛ ʃ t͡ʃ ɛ n s k
 blah	b l a
 blah	b l ɑː
@@ -7697,7 +7777,7 @@ blahaj	b l o ʊ h a ɪ
 blahaj	b l ɑː h ɑː ʒ
 blain	b l e ɪ n
 blaine	b l e ɪ n
-blair	b l ɛ ə ɹ
+blair	b l ɛ ɚ
 blaisdon	b l e ɪ z d ə n
 blake	b l e ɪ k
 blamable	b l e ɪ m ə b ə l
@@ -7718,8 +7798,8 @@ blanchability	b l æ n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l æ n ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n ʃ ə b ɪ l ɪ t i
-blancher	b l æ n t͡ʃ ə ɹ
-blancher	b l ɑː n t͡ʃ ə ɹ
+blancher	b l æ n t͡ʃ ɚ
+blancher	b l ɑː n t͡ʃ ɚ
 blancmange	b l ə m ɒ n d͡ʒ
 blanco	b l æ ŋ k ə ʊ
 bland	b l æ n d
@@ -7732,7 +7812,7 @@ blankets	b l æ n k ɛ t s
 blankie	b l æ ŋ k i
 blankley	b l æ ŋ k l i
 blaow	b l a ʊ
-blare	b l ɛ ə ɹ
+blare	b l ɛ ɚ
 blarney	b l ɑː n i
 blasian	b l e ɪ ʒ ə n
 blaspheme	b l æ s f iː m
@@ -7760,12 +7840,12 @@ blazer	b l e ɪ z ə
 blazes	b l e ɪ z ɪ z
 blazing	b l e ɪ z ɪ ŋ
 blazon	b l e ɪ z ə n
-blazoner	b l e ɪ z ə n ə ɹ
+blazoner	b l e ɪ z ə n ɚ
 blazoning	b l e ɪ z ə n ɪ ŋ
 blazonry	b l e ɪ z ə n ɹ i
 bleach	b l iː t͡ʃ
 bleached	b l iː t͡ʃ t
-bleacher	b l iː t͡ʃ ə ɹ
+bleacher	b l iː t͡ʃ ɚ
 bleachfield	b l iː t ʃ f ɪ ə l d
 bleaching	b l iː t͡ʃ ɪ ŋ
 blead	b l iː d
@@ -7808,8 +7888,8 @@ blessedness	b l ɛ s ɪ d n ɪ s
 blesses	b l ɛ s ɪ z
 blessing	b l ɛ s ɪ ŋ
 blessings	b l ɛ s ɪ ŋ z
-blessure	b l ɛ s j ʊ ə ɹ
-blessure	b l ɛ ʃ ə ɹ
+blessure	b l ɛ s j ʊ ɚ
+blessure	b l ɛ ʃ ɚ
 blessèd	b l ɛ s ə d
 blest	b l ɛ s t
 blet	b l ɛ t
@@ -7844,7 +7924,7 @@ blindside	b l a ɪ n d s a ɪ d
 bling	b l ɪ ŋ
 blink	b l ɪ ŋ k
 blinkard	b l ɪ ŋ k ə ɹ d
-blinker	b l ɪ ŋ k ə ɹ
+blinker	b l ɪ ŋ k ɚ
 blinks	b l ɪ ŋ k s
 blinky	b l ɪ ŋ k i
 blip	b l ɪ p
@@ -7860,7 +7940,7 @@ blithedale	b l a ɪ θ d e ɪ l
 blitheful	b l a ɪ ð f ʊ l
 blitheful	b l a ɪ θ f ʊ l
 blithely	b l a ɪ ð l i
-blither	b l a ɪ ð ə ɹ
+blither	b l a ɪ ð ɚ
 blither	b l ɪ ð ə ɹ
 blitz	b l ɪ t s
 blitzed	b l ɪ t s t
@@ -8141,7 +8221,7 @@ boiling	b ɔ ɪ l ɪ ŋ
 boilings	b ɔ ɪ l ɪ ŋ z
 boils	b ɔ ɪ l z
 boinc	b ɔ ɪ ŋ k
-boing	b o ɪ ŋ
+boing	b ɔ ɪ ŋ
 boingy	b ɔ ɪ ŋ ɡ iː
 boink	b ɔ ɪ ŋ k
 boisterous	b ɔ ɪ s t ə ɹ ə s
@@ -8187,7 +8267,6 @@ bolshevist	b ɒ l ʃ ə v ɪ s t
 bolshie	b ɒ l ʃ i
 bolster	b ə ʊ l s t ə
 bolt	b ɒ l t
-bolt	b ɔ ʊ l t
 bolt	b ə ʊ l t
 bolted	b ə ʊ l t ɪ d
 bolth	b o ʊ ɫ θ
@@ -8219,6 +8298,7 @@ bonanza	b ə n æ n z ə
 bonapartism	b ə ʊ n ə p ɑː t ɪ z ə m
 bonavista	b o ʊ n ə v ɪ s t ə
 bonbright	b ɔ n b ɹ a ɪ t
+bonce	b ɒ n s
 bond	b ɒ n d
 bondage	b ɒ n d ɪ d͡ʒ
 bondi	b ɒ n d a ɪ
@@ -8278,6 +8358,7 @@ bookings	b ʊ k ɪ ŋ z
 bookish	b ʊ k ɪ ʃ
 bookkeeper	b ʊ k k iː p ə ɹ
 bookkeeper	b ʌ ʔ k iː p ə ɹ
+bookkeeping	b ʊ k k iː p ɪ ŋ
 booklegging	b ʊ k l ɛ ɡ ɪ ŋ
 booklet	b ʊ k l ə t
 booklist	b ʊ k l ɪ s t
@@ -8332,6 +8413,7 @@ booths	b uː ð z
 booths	b uː θ s
 bootikin	b uː t ɪ k ɪ n
 bootle	b uː t ə l
+bootleggery	b uː t l ɛ ɡ ə ɹ i
 boots	b uː t s
 bootstrap	b uː t s t ɹ æ p
 booty	b uː t i
@@ -8383,6 +8465,7 @@ borne	b ɔː n
 borneo	b ɔː n i ə ʊ
 bornholm	b ɔ ɹ n h ə ʊ m
 borning	b ɔː n ɪ ŋ
+borogove	b ɒ ɹ ə ʊ ɡ ə ʊ v
 boron	b ɔː ɹ ɒ n
 borough	b ʌ ɹ ə
 borrel	b ɒ ɹ ə l
@@ -8405,6 +8488,7 @@ bosanquet	b o ʊ z ə n k ɪ t
 boscage	b ɒ s k ɪ d ʒ
 bose	b ə ʊ s
 bose	b ə ʊ z
+bosentan	b ə ʊ s ɛ n t æ n
 bosh	b ɒ ʃ
 bosk	b ɒ s k
 bosket	b ɒ s k ɪ t
@@ -8423,6 +8507,7 @@ bosque	b ɒ s k e ɪ
 bosques	b ɒ s k e ɪ z
 bosques	b ɒ s k s
 boss	b ɒ s
+bossale	b o ʊ s æ l
 bossman	b ɒ s m æ n
 bosspot	b ɒ s p ɒ t
 bossy	b ɒ s i
@@ -8458,6 +8543,8 @@ bottom	b ɒ t ə m
 bottomless	b ɒ t ə m l ə s
 bottoms	b ɒ t ə m s
 botulism	b ɒ t j ʊ l ɪ z ə m
+botw	b ɑː t w ə
+botw	b ɔː t w ə
 botwood	b ɒ t w ʊ d
 bouche	b uː ʃ
 bouclé	b uː k l e ɪ
@@ -8468,9 +8555,12 @@ boudica	b ə ʊ d ɪ k ə
 boudoir	b uː d w ɑː
 bougainville	b ə ʊ ɡ ə n v ɪ l
 bougainvillea	b uː ɡ ə n v ɪ l ɪ ə
+bougar	b uː ɡ ɑː
 bougar	b uː ɡ ə
-bougar	k uː ɡ ɑː
 bouge	b uː d͡ʒ
+bouget	b uː d ʒ ɛ t
+bouget	b uː d ʒ ɪ t
+bouget	b uː ɡ ɛ t
 bough	b a ʊ
 boughs	b a ʊ z
 bought	b ɔː t
@@ -8487,6 +8577,8 @@ boulder	b ə ʊ l d ə ɹ
 boule	b uː l
 bouleutic	b ə l j uː t ɪ k
 boulevard	b uː l ə v ɑː d
+boulevardier	b ʊ l ə v ɑ ɹ d j e ɪ
+boulevardier	b ʊ l ə v ɑ ɹ d ɪ ɹ
 boulogne	b ə l ɔ ɪ n
 boulogne	b ʊ l ɔ ɪ n
 boulton	b o ʊ l t ə n
@@ -8738,6 +8830,7 @@ branle	b ɹ ɔː l
 branny	b ɹ æ n i
 brans	b ɹ æ n z
 brant	b ɹ æ n t
+branta	b r æ n t ə
 brantle	b ɹ æ n t ə l
 brash	b ɹ æ ʃ
 brass	b ɹ æ s
@@ -8798,6 +8891,7 @@ breachings	b ɹ iː t͡ʃ ɪ ŋ z
 bread	b ɹ ɛ d
 breadalbane	b r ə d ɔː l b æ n
 breadbasket	b ɹ ɛ d b ɑː s k ɪ t
+breadbox	b ɹ ɛ d b ɒ k s
 breadfruit	b ɹ e d f ɹ uː t
 breadstuff	b ɹ ɛ d s t ʌ f
 breadth	b ɹ ɛ d θ
@@ -9253,6 +9347,7 @@ bruv	b ɹ ʌ v
 bruvver	b ɹ ʌ v ə ɹ
 brux	b ɹ ʌ k s
 bruxism	b ɹ ʌ k s ɪ z ə m
+bruz	b ɹ ʌ z
 bryan	b ɹ a ɪ ə n
 bryanite	b ɹ a ɪ ə n a ɪ t
 bryant	b ɹ a ɪ ə n t
@@ -9290,6 +9385,9 @@ buccal	b ʌ k ə l
 buccally	b ʌ k ə l i
 buccaneer	b ʌ k ə n ɪ ə ɹ
 buccinator	b ʌ k s ɪ n e ɪ t ə
+buccoapical	b ʌ k o ʊ e ɪ p ɪ k l̩
+buccocervical	b ʌ k o ʊ s ɝː v ɪ k l̩
+buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɪ v l̩
 buccolabial	b ʌ k o ʊ l e ɪ b i l̩
 buccolingual	b ʌ k o ʊ l ɪ ŋ ɡ w ə l
 buccopalatal	b ʌ k o ʊ p æ l ə t ə l
@@ -9611,6 +9709,7 @@ burp	b ɜː p
 burra	b ʌ ɹ ə
 burrampooter	b ʌ r ə m p uː t ə r
 burrata	b ʊ ɹ ɑː t ə
+burrel	b ʌ ɹ ə l
 burrito	b ə ɹ iː t ə ʊ
 burrito	b ʊ r iː t ə ʊ
 burrovian	b ə ɹ ə ʊ v ɪ ə n
@@ -9679,7 +9778,7 @@ busulfan	b j uː s ʌ l f æ n
 busy	b ɪ z i
 busybodyish	b ɪ z i b ɒ d i ɪ ʃ
 busybodyism	b ɪ z i b ɒ d i ɪ z m̩
-busyness	b ɪ z ɪ n ə s
+busyness	b ɪ z ɪ n ɪ s
 but	b ʌ t
 but's	b ʌ t s
 butane	b j uː t e ɪ n
@@ -9829,6 +9928,9 @@ cacahuatepec	k ɑː k ə w ɑː t ɛ p ɛ k
 cacao	k ə k e ɪ̯ ə ʊ̯
 cacao	k ə k ɑː ə ʊ̯
 cacciatore	k æ t ʃ ə t ɔː ɹ i
+cachaemia	k æ k iː m i ə
+cachaemic	k æ k iː m ɪ k
+cachaemic	k æ k ɛ m ɪ k
 cachalot	k a ʃ ə l ɒ t
 cachalot	k a ʃ ə l ə ʊ
 cachaça	k ə ʃ ɑː s ə
@@ -9856,6 +9958,7 @@ cacogamy	k ə k ɒ ɡ ə m i
 cacogenic	k æ k ə d͡ʒ ɛ n ɪ k
 cacography	k a k ɒ ɡ ɹ ə f i
 cacology	k ə k ɒ l ə d͡ʒ i
+cacophonic	k ə k ɒ f ə n ɪ k
 cacophonous	k ə k ɒ f ə n ə s
 cacophony	k ə k ɒ f ə n i
 cacothymia	k a k ə ʊ θ ʌ ɪ m ɪ ə
@@ -9936,6 +10039,7 @@ cagliari	k æ l j ə ɹ i
 cagliari	k ɑː l j ə ɹ i
 cagot	k ə ɡ ə ʊ
 cagoule	k ə ɡ uː l
+cahier	k a ɪ j e ɪ
 cahoot	k ə h uː t
 cahoots	k ə h uː t s
 caib	k e ɪ b
@@ -10033,6 +10137,7 @@ cali	k æ l i
 caliban	k æ l ɪ b æ n
 caliber	k æ l ɪ b ə ɹ
 calibrate	k æ l ɪ b ɹ e ɪ t
+calibre	k æ l ɪ b ə ɹ
 caliche	k ə l i t͡ʃ i
 calico	k æ l ɪ k ə ʊ
 california	k æ l ɪ f ɔː n i ə
@@ -10131,6 +10236,7 @@ cama	k ɑː m ə
 camail	k æ m e ɪ l
 camail	k ə m e ɪ l
 camaldolese	k ə m ɑ l d ə l i z
+camaraderie	k æ m ə ɹ æ d ə ɹ i
 camaraderie	k æ m ə ɹ ɑː d ə ɹ i
 camas	k ɑː m ə z
 camber	k æ m b ə
@@ -10252,6 +10358,7 @@ candelabrum	k æ n d ɪ l e ɪ b ɹ ə m
 candelabrum	k æ n d ɪ l ɑː b ɹ ə m
 candian	k æ n d ɪ ə n
 candid	k æ n d ɪ d
+candidacy	k æ n d ɪ d ə s i
 candidate	k æ n d ɪ d e ɪ t
 candidate	k æ n d ɪ d ə t
 candidature	k æ n d ɪ d ə t j ʊ ə ɹ
@@ -10487,6 +10594,7 @@ caracole	k æ ɹ ə k ə ʊ l
 carafe	k ə ɹ æ f
 caragana	k æ ɹ ə ɡ ɑː n ə
 caragana	k ɑː ɹ ə ɡ ɑː n ə
+carambola	k æ ɹ ə m b ə ʊ l ə
 caramel	k æ ɹ ə m ə l
 caramel	k æ ɹ ə m ɛ l
 caramelize	k a r ə m ə l ʌ ɪ z
@@ -10498,7 +10606,9 @@ carat	k æ ɹ ə t
 caravaggesque	k æ ɹ ə v æ d ʒ ɛ s k
 caravaggio	k æ ɹ ə v æ d ʒ i ə ʊ
 caravan	k æ ɹ ə v æ n
-caravanserai	k a ɹ ə v a n s ə ɹ ʌ ɪ
+caravansary	k æ ɹ ə v æ n s ə ɹ i
+caravanserai	k æ ɹ ə v æ n s ə ɹ a ɪ
+caravanserial	k æ ɹ ə v æ n s ə ɹ i ə l
 caravel	k æ ɹ ə v ɛ l
 caraway	k æ ɹ ə w e ɪ
 carb	k ɑː b
@@ -10659,6 +10769,7 @@ carn	k ɑː n
 carnaby	k ɑː ɹ n ə b i
 carnage	k ɑː n ɪ d ʒ
 carnaroli	k ɑː n ə ɹ ə ʊ l ɪ
+carnatic	k ɑ ɹ n æ t ɪ k
 carnation	k ɑː n e ɪ ʃ ə n
 carnaval	k ɑ ɹ n ə v ɑ l
 carnegie	k ɑː n ɛ ɡ i
@@ -10956,6 +11067,8 @@ catecholamine	k a t ə k ɒ l ə m iː n
 catecholamine	k a t ə k ə ʊ l ə m iː n
 catechu	k æ t ɪ t͡ʃ uː
 catechumen	k æ t ɪ k j uː m ɛ n
+catechumenate	k æ t ɪ k j uː m ə n e ɪ t
+catechumenate	k æ t ɪ k j uː m ə n ə t
 categorially	k æ t ə ɡ ɒ ɹ ɪ ə l i
 categorically	k æ t ə ɡ ɒ ɹ ɪ k ə l i
 categories	k æ t ɪ ɡ ə ɹ i z
@@ -10973,6 +11086,7 @@ caterham	k e ɪ t ə ɹ ə m
 catering	k e ɪ t ə ɹ ɪ ŋ
 caterpillar	k æ t ə p ɪ l ə
 caterwaul	k æ t ə w ɔː l
+caterwauling	k æ t ə w ɔː l ɪ ŋ
 catesby	k e ɪ t s b i
 catfighting	k æ t f a ɪ t ɪ ŋ
 catford	k æ t f ə d
@@ -11014,6 +11128,10 @@ catloaf	k æ t l ə ʊ f
 catmint	k æ t m ɪ n t
 catnip	k a t n ɪ p
 cato	k e ɪ t ə ʊ
+catoblepas	k æ t o ʊ b l iː p ə s
+catoblepas	k æ t o ʊ b l ɛ p ə s
+catoblepas	k æ t o ʊ b l ɪ p ə s
+catoblepas	k ə t ɒ b l ɪ p ə s
 catoecic	k ə t iː s ɪ k
 catoptric	k a t ɒ p t ɹ ɪ k
 catridge	k a t ɹ ɪ d͡ʒ
@@ -11053,6 +11171,8 @@ caulis	k ɔː l ɪ s
 caulk	k ɔː k
 cauma	k a ʊ m ə
 causal	k ɔː z ə l
+causality	k ɔː z æ l ɪ t ɪ
+causation	k ɔː z e ɪ ʃ ə n
 causative	k ɔː z ə t ɪ v
 causator	k ɔː z e ɪ t ə ɹ
 cause	k ɔː z
@@ -11213,7 +11333,6 @@ cells	s ɛ l z
 celluloid	s ɛ l j ə l ɔ ɪ d
 cellulose	s ɛ l j ʊ l ə ʊ z
 celly	s ɛ l i
-celsius	s ɛ l s i ə s
 celt	k ɛ l t
 celt	s ɛ l t
 celta	s ɛ l t ə
@@ -11330,6 +11449,7 @@ cephalon	s e f ə l ɒ n
 cephalon	s e f ə l ə n
 cephalopod	s ɛ f a l a p ɒ d
 cephalosporin	k ɛ f ə l ə ʊ s p ɔ ə ɹ ɪ n
+cephas	s i f ə s
 cepheus	s iː f i ə s
 cepheus	s iː f j uː s
 cepstrum	k ɛ p s t ɹ ə m
@@ -11370,12 +11490,15 @@ ceremonies	s ɛ ɹ ɪ m ə n i z
 ceremony	s ɛ ɹ ɪ m ə n i
 cereology	s ɪ ə ɹ ɪ ɒ l ə d ʒ i
 cereous	s ɪ ə ɹ i ə s
+cererian	s ə ɹ ɪ ə ɹ ɪ ə n
 ceres	s ɪ ə ɹ iː z
+ceresian	s ə ɹ iː z i ə n
 cerise	s ə ɹ iː s
 cerise	s ə ɹ iː z
 cerium	s ɪ ə ɹ i ə m
 cernuous	s ɜː ɹ n j u ə s
 cerrial	s ɛ ɹ i ə l
+cerrigceinwen	k ɛ r ɪ ɡ k ɛ i n ʊ ɛ n
 certain	s ɜː t n̩
 certainly	s ɜː t n̩ l i
 certainty	s ɜː t n̩ t i
@@ -11395,6 +11518,7 @@ cervantes	s ɛ ɹ v ɑː n t e ɪ z
 cervelliere	s ɛ ɹ v ə l j ɛ ə ɹ
 cervical	s ɜː v a ɪ k l̩
 cervical	s ɜː v ɪ k l̩
+cervices	s ɝ v ɪ s iː z
 cervidae	s ə ɹ v ə d i
 cervine	s əː v ʌ ɪ n
 cervix	s ɜː v ɪ k s
@@ -11633,6 +11757,7 @@ chaptalization	ʃ æ p t ə l a ɪ z e ɪ ʃ ə n
 chapter	t͡ʃ æ p t ə
 chapters	t͡ʃ æ p t ə z
 chaqu	t͡ʃ ɑː t͡ʃ uː
+char	k æ ɹ
 char	k ɑː
 char	k ɛ ə
 char	t͡ʃ ɑː
@@ -11657,6 +11782,7 @@ chardonnay	ʃ ɑː ɹ d ə n e ɪ
 chare	t͡ʃ ɛ ə
 charette	ʃ ə ɹ ɛ t
 charge	t͡ʃ ɑː d͡ʒ
+charged	t͡ʃ ɑː d͡ʒ d
 chargeous	t͡ʃ ɑː ɹ d͡ʒ ə s
 charger	t ʃ ɑː d ʒ ə
 charges	t͡ʃ ɑː d͡ʒ ɪ z
@@ -11848,7 +11974,7 @@ cheese	t͡ʃ iː z
 cheesecake	t͡ʃ iː z k e ɪ k
 cheesed	t͡ʃ iː z d
 cheesehead	t͡ʃ iː z h ɛ d
-cheeselet	t͡ʃ iː z l ə t
+cheeselet	t͡ʃ iː z l ɪ t
 cheeser	t͡ʃ iː z ə
 cheeses	t͡ʃ iː z ɪ z
 cheesetastic	t͡ʃ iː z t æ s t ɪ k
@@ -12086,7 +12212,6 @@ chilaquiles	t͡ʃ i l ə k i l e ɪ s
 chilblain	t͡ʃ ɪ l b l e ɪ n
 chilcotin	t͡ʃ ɪ l k o ʊ t ɪ n
 child	t͡ʃ a ɪ l d
-child	t͡ʃ a ɪ ə l d
 childbed	t͡ʃ a ɪ l d b ɛ d
 childe	t͡ʃ a ɪ l d
 childer	t͡ʃ ɪ l d ə r
@@ -12126,6 +12251,7 @@ chilver	t͡ʃ ɪ l v ə ɹ
 chimbley	t͡ʃ ɪ m b l i
 chime	t ʃ a ɪ m
 chimed	t͡ʃ a ɪ m d
+chimenea	t ʃ ɪ m ə n e ɪ ə
 chimera	k ɪ m ɪ ə ɹ ə
 chimera	k ʌ ɪ m ɪ ə ɹ ə
 chimeric	k a ɪ m ɛ ɹ ɪ k
@@ -12166,6 +12292,8 @@ chinned	t͡ʃ ɪ n d
 chinning	t͡ʃ ɪ n ɪ ŋ
 chinny	t͡ʃ ɪ n i
 chinoiserie	ʃ iː n w ɑː z ə ɹ iː
+chinone	k a ɪ n ə ʊ n
+chinone	k ɪ n ə ʊ n
 chinook	t͡ʃ ɪ n uː k
 chinook	ʃ ɪ n ʊ k
 chinquapin	t͡ʃ ɪ n k ə p ɪ n
@@ -12179,6 +12307,7 @@ chip	t͡ʃ ɪ p
 chipewyan	t͡ʃ ɪ p ə w a ɪ ə n
 chipmunk	t͡ʃ ɪ p m ʌ ŋ k
 chipolata	t͡ʃ ɪ p ə l ɑː t ə
+chipotle	t ʃ ɪ p ɒ t l e ɪ
 chipotle	t ʃ ɪ p ə ʊ t l e ɪ
 chipped	t͡ʃ ɪ p t
 chippendale	t͡ʃ ɪ p n̩ d e ɪ l
@@ -12216,6 +12345,8 @@ chirurgy	k ɪ ɹ ɜː ɹ d͡ʒ i
 chisel	t͡ʃ ɪ z ə l
 chiseled	t͡ʃ ɪ z ə l d
 chislehurst	t͡ʃ ɪ z ə l h ɜː s t
+chislic	t͡ʃ ɪ s l ɪ k
+chislic	t͡ʃ ɪ z l ɪ k
 chiswick	t͡ʃ ɪ z ɪ k
 chit	t͡ʃ ɪ t
 chita	t͡ʃ ɪ t ɑː
@@ -12292,6 +12423,7 @@ choctaw	t͡ʃ ɒ k t ɔː
 chode	t ʃ ə ʊ d
 choenix	k iː n ɪ k s
 choffer	t͡ʃ ɔː f ə
+choi	t ʃ ɔ ɪ
 choice	t͡ʃ ɔ ɪ s
 choiceful	t͡ʃ ɔ ɪ s f ə l
 choices	t͡ʃ ɔ ɪ s ɪ z
@@ -12363,6 +12495,7 @@ choreograph	k ɒ ɹ i ə ɡ ɹ æ f
 choreograph	k ɒ ɹ i ə ɡ ɹ ɑː f
 choreography	k ɔ ɹ i ɒ ɡ ɹ ə f i
 chori	k ɔː ɹ a ɪ
+choric	k ɔː ɹ ɪ k
 chorion	k ɔ ɹ i ɑ n
 chorister	k ɒ ɹ ɪ s t ə ɹ
 chorizo	t͡ʃ ɒ ɹ iː s ə ʊ
@@ -12374,7 +12507,7 @@ choroid	k ɒ ɹ ɔ ɪ d
 choroid	k ɔː ɹ ɔ ɪ d
 chorus	k ɔː ɹ a ɪ
 chorus	k ɔː ɹ ə s
-chose	t ʃ ə ʊ z
+chose	t͡ʃ ə ʊ z
 chosen	t͡ʃ ə ʊ z ə n
 choss	t͡ʃ ɒ s
 chotki	t͡ʃ ɒ t k i
@@ -12461,11 +12594,13 @@ chrysolite	k ɹ ɪ s ə l a ɪ t
 chrysopoeia	k ɹ ɪ s ə p iː ə
 chrysopoeian	k ɹ ɪ s ə p iː ə n
 chrysostom	k ɹ ɪ s ə s t ə m
+chthamaloid	θ æ m ə l ɔ ɪ d
 chthonian	k θ ə ʊ n ɪ ə n
 chthonian	θ ə ʊ n ɪ ə n
 chthonic	k θ ɒ n ɪ k
 chu	t ʃ u
 chub	t͡ʃ ʌ b
+chubasco	t ʃ uː b ɑː s k ə ʊ
 chubby	t͡ʃ ʌ b i
 chubs	t͡ʃ ʌ b z
 chuchotage	ʃ u ʃ ə ʊ t ɑː ʒ
@@ -12530,6 +12665,7 @@ churl	t ʃ ɜː l
 churlish	t ʃ ɜː l ɪ ʃ
 churly	t͡ʃ ɜː ɹ l i
 churn	t ʃ ɜː n
+churnalism	t ʃ əː n ə l ɪ z ə m
 churrasco	t͡ʃ ʊ ɹ æ s k ə ʊ
 churrasco	t͡ʃ ʊ ɹ ɑː s k ə ʊ
 churro	t ʃ ʊ ɹ ə ʊ
@@ -12617,6 +12753,10 @@ cinching	s ɪ n t͡ʃ ɪ ŋ
 cinchona	s ɪ ŋ k ə ʊ n ə
 cinchophen	s ɪ ŋ k ə f ɛ n
 cinchy	s ɪ n t͡ʃ i
+cincinnati	s ɪ n s ɪ n æ t i
+cincinnati	s ɪ n s ɪ n æ t ə
+cincinnatus	s ɪ n s ɪ n e ɪ t ə s
+cincinnatus	s ɪ n s ɪ n ɑː t ə s
 cincture	s ɪ ŋ k t͡ʃ ə ɹ
 cinder	s ɪ n d ə ɹ
 cinderella	s ɪ n d ə ɹ ɛ l ə
@@ -12634,7 +12774,8 @@ cingulum	s ɪ ŋ ɡ j ə l ə m
 cinnabar	s ɪ n ə b ɑ ɹ
 cinnabar	s ɪ n ə b ɑː ɹ
 cinnamon	s ɪ n ə m ə n
-cinquain	s ɪ n k e n
+cinquain	s æ ŋ k e ɪ n
+cinquain	s ɪ ŋ k e ɪ n
 cinque	s æ ŋ k
 cinque	s ɪ ŋ k
 cinquecentist	t ʃ i ŋ k w ɛ t ʃ ɛ n t ɪ s t
@@ -12671,6 +12812,7 @@ circuline	s ɜː ɹ k j ʊ l a ɪ n
 circumambulate	s ɝ k ə m æ m b j u l e ɪ t
 circumambulation	s ɝ k ə m æ m b j u l e ɪ ʃ ə n
 circumaural	s ɝ k ʌ m a ɹ ʌ l
+circumbendibus	s ɝ k m̩ b ɛ n d ɪ b ə s
 circumcellion	s ɜː k ə m s ɛ l ɪ ə n
 circumclusion	s ɜː ɹ k ə m k l uː ʒ ə n
 circumference	s ɜː k ʌ m f ɹ ə n s
@@ -12947,12 +13089,14 @@ claymation	k l e ɪ m e ɪ ʃ ə n
 claymore	k l e ɪ m ɔː ɹ
 clays	k l e ɪ z
 clayton	k l e ɪ t ə n
+clazosentan	k l e ɪ z ə ʊ s ɛ n t æ n
 clean	k l iː n
 cleaned	k l iː n d
 cleaner	k l iː n ə
 cleaning	k l iː n ɪ ŋ
 cleanings	k l iː n ɪ ŋ z
 cleanliness	k l ɛ n l i n ə s
+cleanliness	k l ɛ n l i n ɪ s
 cleanly	k l iː n l i
 cleanly	k l ɛ n l i
 cleanness	k l iː n n ə s
@@ -12992,7 +13136,7 @@ clementine	k l ɛ m ə n t iː n
 clemizole	k l ɛ m ɪ z o ʊ l
 clen	k l ɛ n
 clench	k l ɛ n t͡ʃ
-cleopatra	k l i o ʊ p æ t ɹ ə
+cleopatra	k l iː o ʊ p æ t ɹ ə
 clepe	k l iː p
 clepsydra	k l ɛ p s ɪ d ɹ ə
 clept	k l ɛ p t
@@ -13140,6 +13284,7 @@ cloom	k l uː m
 clooney	k l uː n i
 cloop	k l uː p
 clop	k l ɒ p
+clopen	k l ə ʊ p ə n
 clopidogrel	k l ə ʊ p ɪ d ə ɡ ɹ ɛ l
 cloque	k l ɒ k e ɪ
 close	k l ə ʊ s
@@ -13148,6 +13293,7 @@ closed	k l ə ʊ z d
 closely	k l ə ʊ s l iː
 closen	k l ə ʊ s ə n
 closeness	k l ə ʊ s n ə s
+closer	k l ə ʊ s ə
 closer	k l ə ʊ z ɚ
 closes	k l ə ʊ s ɪ z
 closes	k l ə ʊ z ɪ z
@@ -13253,6 +13399,8 @@ clutchings	k l ʌ t͡ʃ ɪ ŋ z
 clutter	k l ʌ t ə ɹ
 clutton	k l ʌ t ə n
 clyde	k l a ɪ d
+clymene	k l a ɪ m ɪ n i
+clymene	k l ɪ m ɪ n i
 clypei	k l ɪ p ɪ a ɪ
 clypeus	k l ɪ p ɪ ə s
 clyster	k l ɪ s t ə
@@ -13407,6 +13555,7 @@ codical	k ə ʊ d ɪ k ə l
 codicil	k ɒ d ɪ s ɪ l
 codicil	k ə ʊ d ɪ s ɪ l
 codies	k ə ʊ d i z
+codification	k ə ʊ d ɪ f ɪ k e ɪ ʃ ə n
 codlet	k ɒ d l ə t
 codling	k ɒ d l ɪ ŋ
 codominant	k ə ʊ d ɒ m ɪ n ə n t
@@ -13436,6 +13585,7 @@ coextensive	k ə ʊ ɪ k s t ɛ n s ɪ v
 coextinct	k o ʊ ɛ k s t ɪ ŋ k t
 coextinct	k o ʊ ɪ k s t ɪ ŋ k t
 cofe	s iː ə v iː
+cofeoffee	k ə ʊ f ɛ f iː
 coffa	k ɔ f ə
 coffee	k ɒ f i
 coffeemaking	k ɒ f i m e ɪ k ɪ ŋ
@@ -13567,7 +13717,8 @@ coliseum	k ɒ l ə s iː ə m
 coll	k ɒ l
 collab	k o ʊ l æ b
 collab	k ə l æ b
-collaborate	k ə l a b ə ɹ e ɪ t
+collaborate	k ə l æ b ə ɹ e ɪ t
+collaborate	k ə l æ b ɹ e ɪ t
 collaboration	k ə l æ b ə ɹ e ɪ ʃ ə n
 collaborative	k ə l a b ə ɹ ə t ɪ v
 collaborator	k ə l æ b ə ɹ e ɪ t ə
@@ -13575,6 +13726,7 @@ collage	k ɒ l ɑː ʒ
 collage	k ə l ɑː ʒ
 collagen	k ɒ l ə d͡ʒ ə n
 collagen	k ɒ l ə d͡ʒ ɪ n
+collagenous	k ə l æ d͡ʒ ɪ n ə s
 collagic	k ə l æ d͡ʒ ɪ k
 collapse	k ə l æ p s
 collar	k ɒ l ə
@@ -13813,7 +13965,7 @@ commentative	k ə m ɛ n t ə t ɪ v
 commented	k ɒ m ɛ n t ɪ d
 comments	k ɒ m ɛ n t s
 commerce	k ɒ m ə s
-commerce	k ɒ m ɜː s
+commerce	k ə m ɜː s
 commercial	k ə m ɜː ʃ ə l
 comminate	k ɒ m ɪ n e ɪ t
 comminute	k ɒ m ɪ n j uː t
@@ -13914,7 +14066,8 @@ compassed	k ʌ m p ə s t
 compassion	k ə m p æ ʃ ə n
 compassionate	k ə m p æ ʃ ə n e ɪ t
 compassionate	k ə m p æ ʃ ə n ə t
-compatibility	k ə m p æ t ɪ b ɪ l ɪ t i
+compatibility	k ə m p æ t ə b ɪ l ɪ t i
+compatible	k ə m p æ t ə b ə l
 compatriot	k ə m p e ɪ t ɹ i ə t
 compatriot	k ə m p æ t ɹ i ə t
 compeer	k ɒ m p ɪ ə ɹ
@@ -13975,6 +14128,7 @@ completely	k ə m p l iː t l i
 completes	k ə m p l iː t s
 completing	k ə m p l iː t ɪ ŋ
 completion	k ə m p l iː ʃ ə n
+completist	k ə m p l iː t ɪ s t
 completory	k ə m p l iː t ə ɹ i
 complex	k ɒ m p l ɛ k s
 complex	k ə m p l ɛ k s
@@ -14123,7 +14277,7 @@ conche	k ɒ n t ʃ
 conches	k ɒ n t͡ʃ ə z
 conches	k ɒ ŋ k
 conchifer	k ɒ ŋ k ɪ f ə ɹ
-conchoidal	k ɒ n k ɔ ɪ ɪ d ə l
+conchoidal	k ɒ ŋ k ɔ ɪ d ə l
 conchology	k ɒ ŋ k ɒ l ə d͡ʒ i
 conchs	k ɒ n t͡ʃ
 conchs	k ɒ ŋ k s
@@ -14165,7 +14319,7 @@ concurrent	k ɒ ŋ k ʌ ɹ ə n t
 concurrent	k ə ŋ k ʌ ɹ ə n t
 concuss	k ɒ n k ʌ s
 concuss	k ə n k ʌ s
-concussion	k ə n k ʌ ʃ n
+concussion	k ə n k ʌ ʃ n̩
 concussion	k ə n k ʌ ʃ ə n
 condemn	k ə n d ɛ m
 condemnable	k ə n d ɛ m n ə b ə l
@@ -14282,7 +14436,7 @@ conflate	k ə n f l e ɪ t
 conflation	k ə n f l e ɪ ʃ ə n
 conflict	k ɒ n f l ɪ k t
 conflict	k ə n f l ɪ k t
-conflicted	k ə n f l ɪ k t ɪ d
+conflicted	k ə n f l ɪ t ɪ d
 conflow	k ə n f l ə ʊ
 confluence	k ɒ n f l u ə n s
 conforaneous	k ɒ n f ə ɹ e ɪ n ɪ ə s
@@ -14357,6 +14511,7 @@ congruous	k ɑ ŋ ɡ ɹ u ə s
 conic	k ɒ n ɪ k
 conical	k ɒ n ɪ k ə l
 conifer	k ɒ n ɪ f ə ɹ
+coniferous	k ə n ɪ f ə ɹ ə s
 conject	k ə n d͡ʒ ɛ k t
 conjecture	k ə n d͡ʒ ɛ k t͡ʃ ə ɹ
 conjoin	k ə n d͡ʒ ɔ ɪ n
@@ -14537,6 +14692,8 @@ consternation	k ɒ n s t ə n e ɪ ʃ ə n
 constipate	k ɒ n s t ɪ p e ɪ t
 constipated	k ɒ n s t ə p e ɪ t ə d
 constipation	k ɒ n s t ɪ p e ɪ ʃ ə n
+constituencies	k ə n s t ɪ t j u ə n s iː z
+constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s iː z
 constituency	k ə n s t ɪ t j u ə n s i
 constituency	k ə n s t ɪ t͡ʃ u ə n s i
 constituent	k ə n s t ɪ t j u ə n t
@@ -14976,6 +15133,7 @@ cor	k ɔː
 coral	k ɒ ɹ ə l
 coranto	k ə ɹ æ n t ə ʊ
 coranto	k ə ɹ ɑː n t ə ʊ
+corb	k ɔː ɹ b
 corbe	k ɔː ɹ b
 corbel	k ɔː b ə l
 corbyn	k ɔː b ɪ n
@@ -14996,6 +15154,7 @@ cordon	k ɔː ɹ d ə n
 cordovan	k ɔː d ə v ə n
 cords	k ɔː d z
 corduroy	k ɔː d ə ɹ ɔ ɪ
+corduroy	k ɔː d ɹ ɔ ɪ
 cordyceps	k ɔː d ɪ s ɛ p s
 core	k ɔː
 corelborin	k ɒ ɹ ə l b ɔː ɹ ɪ n
@@ -15055,6 +15214,7 @@ corollary	k ɒ ɹ ɒ l ə ɹ i
 corollary	k ɒ ɹ ə l ə ɹ i
 corona	k ə ɹ ə ʊ n ə
 coronach	k ɒ ɹ ə n ə k
+coronado	k ɒ ɹ ə n ɑː d ə ʊ
 coronae	k ə ɹ ə ʊ n iː
 coronal	k ɒ ɹ ə n ə l
 coronal	k ə ɹ ə ʊ n ə l
@@ -15063,7 +15223,7 @@ coronas	k ə ɹ ə ʊ n ə s
 coronate	k ɒ ɹ ə n e ɪ t
 coronate	k ɒ ɹ ə n ə t
 coronatide	k ə ɹ ə ʊ n ə t a ɪ d
-coronation	k ɒ ɹ ə n e ɪ ʃ ə n
+coronation	k ɒ ɹ ə n e ɪ ʃ n̩
 coronavirus	k ə ɹ o ʊ n ə v a ɪ ɹ ə s
 coronavirus	k ə ɹ ə ʊ n ə v a ɪ ɹ ə s
 coronel	k ɒ ɹ ə n ə l
@@ -15314,6 +15474,7 @@ countervail	k a ʊ n t ə v e ɪ l
 countervailing	k a ʊ n t ə v e ɪ l ɪ ŋ
 counterview	k a ʊ n t ə ɹ v j uː
 counterweigh	k a ʊ n t ə w e ɪ
+countess	k a ʊ n t ɪ s
 counties	k a ʊ n t i z
 counting	k a ʊ n t ɪ ŋ
 countings	k a ʊ n t ɪ ŋ z
@@ -15395,6 +15556,7 @@ coventry	k ɒ v ə n t ɹ i
 cover	k ʌ v ə
 coverack	k ɒ v ə ɹ ə k
 coverage	k ʌ v ə ɹ ɪ d ʒ
+coverall	k ʌ v ə ɹ ɔː l
 covered	k ʌ v ə ɹ d
 covering	k ʌ v ə ɹ ɪ ŋ
 coverlet	k ʌ v ə ɹ l ɪ t
@@ -15630,6 +15792,7 @@ creasings	k ɹ iː s ɪ ŋ z
 creasy	k ɹ iː s i
 create	k ɹ iː e ɪ t
 created	k ɹ i e ɪ t ɪ d
+creatic	k ɹ iː æ t ɪ k
 creatify	k ɹ i e ɪ t ɪ f a ɪ
 creatine	k ɹ iː ə t iː n
 creating	k ɹ iː e ɪ t ɪ ŋ
@@ -15733,7 +15896,6 @@ cretic	k ɹ iː t ɪ k
 cretin	k ɹ ɛ t ɪ n
 crevasse	k ɹ ə v æ s
 crevice	k ɹ ɛ v ɪ s
-crew	k ɹ u ʊ̯
 crew	k ɹ uː
 crewe	k ɹ u ʊ̯
 crewe	k ɹ uː
@@ -15851,7 +16013,6 @@ criterion	k ɹ ɪ t ɪ ə ɹ i ə n
 criterium	k ɹ a ɪ t ɪ ə ɹ i ə m
 crith	k ɹ ɪ θ
 critic	k ɹ ɪ t ɪ k
-critical	k ɹ ɪ t ə k ə l
 critical	k ɹ ɪ t ɪ k ə l
 critically	k ɹ ɪ t ɪ k l i
 critically	k ɹ ɪ t ɪ k ə l i
@@ -15985,8 +16146,10 @@ crubeen	k ɹ ə b iː n
 crucial	k ɹ uː ʃ ə l
 crucially	k ɹ uː ʃ ə l i
 crucian	k ɹ uː ʃ ə n
+cruciate	k r uː ʃ i ə t
 crucible	k ɹ uː s ɪ b ə l
 cruciferous	k ɹ u s ɪ f ə ɹ ə s
+crucifix	k ɹ uː s ɪ f ɪ k s
 crucifixion	k ɹ uː s ɪ f ɪ k ʃ ə n
 crucify	k ɹ uː s ɪ f a ɪ
 cruck	k ɹ ʌ k
@@ -16033,6 +16196,7 @@ crunchings	k ɹ ʌ n t͡ʃ ɪ ŋ z
 crunchy	k ɹ ʌ n t͡ʃ i
 crunk	k ɹ ʌ ŋ k
 crunkmeister	k ɹ ʌ ŋ k m a ɪ s t ə
+cruor	k ɹ uː ə ɹ
 crup	k ɹ ʌ p
 crupper	k ɹ ʌ p ə
 crural	k ɹ ʊ ə ɹ ə l
@@ -16066,6 +16230,7 @@ cry	k ɹ a ɪ̯
 crybaby	k ɹ a ɪ b e ɪ b i
 crying	k ɹ a ɪ̯ ɪ ŋ
 cryobiotic	k ɹ a ɪ ə ʊ b a ɪ ɒ t ɪ k
+cryonicist	k ɹ a ɪ ɒ n ɪ s ɪ s t
 cryovolcanic	k ɹ ʌ ɪ ə ʊ v ɒ l k a n ɪ k
 crypsis	k ɹ ɪ p s ɪ s
 crypt	k ɹ ɪ p t
@@ -16089,6 +16254,8 @@ crypts	k ɹ ɪ p t s
 crystal	k ɹ ɪ s t ə l
 crystalize	k ɹ ɪ s t ə l a ɪ z
 crystalline	k ɹ ɪ s t ə l a ɪ n
+crystalline	k ɹ ɪ s t ə l iː n
+crystalline	k ɹ ɪ s t ə l ɪ n
 crystallize	k ɹ ɪ s t ə l a ɪ z
 crystals	k ɹ ɪ s t ə l z
 crèche	k ɹ e ɪ ʃ
@@ -16146,10 +16313,12 @@ cud	k ʊ d
 cud	k ʌ d
 cudden	k ʌ d ə n
 cuddle	k ʌ d l̩
+cuddleologist	k ʌ d ʌ l ɒ l ə d͡ʒ ɪ s t
 cuddler	k ʌ d l ə
 cuddler	k ʌ d l̩ ə
 cuddly	k ʌ d l i
 cuddly	k ʌ d l̩ i
+cuddly	k ʌ d ə l i
 cuddy	k ʌ d i
 cudgel	k ʌ d͡ʒ ə l
 cudgerie	k ʌ d ʒ ə ɹ i
@@ -16477,6 +16646,7 @@ cyanotype	s a ɪ æ n ə t a ɪ p
 cyanotype	s a ɪ æ n ə ʊ t a ɪ p
 cyattie	k j æ t i
 cyber	s a ɪ b ə
+cyberbole	s a ɪ b ɜː b ə l i
 cyberdisinhibition	s a ɪ b ə d ɪ s ɪ n h ɪ b ɪ ʃ ə n
 cybernat	s a ɪ b ə n æ t
 cybernetic	s a ɪ b ə ɹ n ɛ t ɪ k
@@ -17020,6 +17190,7 @@ dartmoor	d ɑː t m ɔː ɹ
 dartmouth	d ɑː t m ə θ
 darts	d ɑː t s
 daruma	d ɑː ɹ ʊ m ə
+darusentan	d æ ɹ ə s ɛ n t æ n
 darvel	d ɑː ɹ v ə l
 darwin	d ɑː w ɪ n
 darwinian	d ɑː w ɪ n i ə n
@@ -17083,6 +17254,7 @@ daunting	d ɔː n t ɪ ŋ
 dauntless	d ɔː n t l ə s
 dauphin	d ɔː f ɪ n
 dauphinoise	d ɔː f ɪ n w ɑː z
+dauphiné	d ə ʊ f ɪ n e ɪ
 daurade	d ɔː ɹ ɑː d
 dauria	d ɑː ʊ ə r ɪ ə
 dauw	d a ʊ
@@ -17211,6 +17383,7 @@ deagglomerate	d iː æ ɡ l ɒ m ə ɹ e ɪ t
 deagglomeration	d iː æ ɡ l ɒ m ə ɹ e ɪ ʃ ə n
 deal	d iː l
 dealate	d i e ɪ l e ɪ t
+dealate	d i e ɪ l ɪ t
 dealated	d i e ɪ l e ɪ t ə d
 dealbation	d iː æ l b e ɪ ʃ ə n
 dealer	d iː l ə ɹ
@@ -17257,6 +17430,8 @@ dearthy	d ɜː θ i
 dearticulate	d iː ɑː t ɪ k j ə l e ɪ t
 dearworth	d ɪ ə ɹ w ɜː ɹ θ
 deary	d ɪ ə ɹ i
+deas	d e ɪ ə s
+deas	d iː ə s
 deasil	d i s ə l
 deasil	d i z ə l
 deasil	d j ɛ ʃ ə l
@@ -17398,6 +17573,7 @@ debutant	d ɛ b j uː t ə n t
 debutante	d e ɪ b j uː t ɑː n t
 debutante	d ɛ b j uː t ɑː n t
 debuted	d e ɪ b j uː d
+debuted	d ɪ b j uː d
 debuts	d e ɪ b j uː z
 debuts	d ɛ b j uː z
 debutyration	d iː b j uː t a ɪ ɹ e ɪ ʃ ə n
@@ -17449,6 +17625,7 @@ decan	d i k æ n
 decan	d ɛ k ə n
 decanal	d ɛ k ə n æ l
 decanal	d ɛ k ə n ə l
+decanal	d ɪ k e ɪ n ə l
 decangle	d ɛ k æ ŋ ɡ ə l
 decangular	d ɪ k æ ŋ ɡ j ə l ə ɹ
 decani	d ɪ k e ɪ n a ɪ
@@ -17897,6 +18074,7 @@ decussation	d ɛ k ʌ s e ɪ ʃ ə n
 decussative	d ɪ k ʌ s ə t ɪ v
 dedicant	d ɛ d ɪ k ə n t
 dedicate	d ɛ d ɪ k e ɪ t
+dedicate	d ɛ d ɪ k ɪ t
 dedicated	d ɛ d ɪ k e ɪ t ə d
 dedicatedly	d ɛ d ɪ k e ɪ t ə d l i
 dedicatee	d ɛ d ɪ k ə t iː
@@ -17947,6 +18125,7 @@ deepen	d iː p ə n
 deepener	d iː p ə n ə ɹ
 deeper	d iː p ə
 deepest	d iː p ɪ s t
+deepfake	d i p f e ɪ k
 deeply	d iː p l i
 deepness	d iː p n ə s
 deer	d ɪ ə
@@ -18071,10 +18250,11 @@ defined	d ɪ f ʌ ɪ n d
 definedness	d ɪ f a ɪ n d n ə s
 definement	d ɪ f a ɪ n m ə n t
 definer	d ɪ f a ɪ n ə ɹ
+definiendum	d ɪ f ɪ n i ɛ n d ə m
 definiens	d eː f iː n i eː n s
 definiens	d iː f a ɪ n ɪ ɛː n z
 definiens	d ɪ f ɪ n ɪ ɛ n z
-definite	d ɛ f ɪ n ɪ t
+definite	d ɛ f ɪ n ə t
 definitely	d ɛ f n ɪ t l i
 definitely	d ɛ f ə n ɪ t l i
 definitely	d ɛ f ɪ n ɪ t l i
@@ -18475,7 +18655,7 @@ demideity	d ɛ m iː d e ɪ ɪ t ɪ
 demideity	d ɛ m iː d e ɪ̯ ə t ɪ
 demideity	d ɛ m iː d iː ɪ t ɪ
 demiflat	d ɛ m ɪ f l æ t
-demigod	d ɛ m ɪ ɡ ɒ d
+demigod	d ɛ m i ɡ ɒ d
 demigrate	d iː m a ɪ ɡ ɹ e ɪ t
 demigrate	d ɛ m ɪ ɡ ɹ e ɪ t
 demijohn	d ɛ m ɪ d ʒ ɒ n
@@ -18576,6 +18756,7 @@ demyelinating	d iː m a ɪ j ə l ɪ n e ɪ t ɪ ŋ
 demystify	d iː m ɪ s t ɪ f a ɪ
 den	d ɛ n
 dena'ina	d ə n aː i n ə
+denali	d ɪ n ɑː l i
 denar	d e ɪ n ɑː ɹ
 denar	d ɛ n ɑː ɹ
 denarius	d ɪ n ɑː ɹ ɪ ə s
@@ -19085,6 +19266,7 @@ detailed	d ɪ t e ɪ l d
 details	d iː t e ɪ l z
 details	d ɪ t e ɪ l z
 detain	d ɪ t e ɪ n
+detained	d ɪ t e ɪ n d
 detainee	d ɪ t e ɪ n iː
 detect	d ɪ t ɛ k t
 detectable	d ɪ t ɛ k t ə b ə ɫ
@@ -19180,6 +19362,7 @@ developers	d ɪ v ɛ l ə p ə ɹ z
 developing	d ɪ v ɛ l ə p ɪ ŋ
 development	d ɪ v ɛ l ə p m ə n t
 developmentals	d ɪ v ɛ l ə p m ɛ n t ə l z
+developmentation	d ɪ v ɛ l ə p m ə n t e ɪ ʃ ə n
 deverbalize	d iː v ɜː b ə l a ɪ z
 devi	d e ɪ v i
 deviance	d iː v ɪ ə n s
@@ -19273,7 +19456,6 @@ dhyana	d j ɑː n ə
 di	d a ɪ
 diabase	d a ɪ ə b e ɪ s
 diabeetus	d a ɪ ə b iː t ə s
-diabetes	d a ɪ ə b eː t ɪ s
 diabetes	d a ɪ ə b iː t iː z
 diabetes	d a ɪ ə b iː t ɪ s
 diabetic	d a ɪ ə b ɛ t ɪ k
@@ -19459,6 +19641,7 @@ diclofenac	d a ɪ k l o ʊ f ə n æ k
 dicrotic	d ʌ ɪ k ɹ ɒ t ɪ k
 dicrotophos	d a ɪ k ɹ ə ʊ t ə f ɒ s
 dictamen	d ɪ k t e ɪ m ə n
+dictamina	d ɪ k t æ m ɪ n ə
 dictaphone	d ɪ k t ə f ə ʊ n
 dictate	d ɪ k t e ɪ t
 dictated	d ɪ k t e ɪ t ɪ d
@@ -19477,6 +19660,8 @@ dicyclic	d a ɪ s a ɪ k l ɪ k
 did	d ɪ d
 didactic	d a ɪ d æ k t ɪ k
 didactic	d ɪ d æ k t ɪ k
+didactician	d a ɪ d ə k t ɪ ʃ ə n
+didactics	d a ɪ d æ k t ɪ k s
 didanosine	d ɪ d a n ə ʊ s iː n
 diddest	d ɪ d ɛ s t
 diddly	d ɪ d ə l i
@@ -19500,6 +19685,7 @@ died	d a ɪ d
 diedre	d ɪ ə d r i
 diegetic	d a ɪ ə d͡ʒ ɛ t ɪ k
 diego	d i e ɪ ɡ o ʊ
+dieguez	d i e ɪ ɡ ɛ z
 diel	d a ɪ ə l
 diel	d i ə l
 dielectric	d a ɪ ə l ɛ k t ɹ ɪ k
@@ -19518,12 +19704,14 @@ diet	d a ɪ ə t
 dietary	d a ɪ ə t ɛ ɹ i
 dietary	d a ɪ ə t ɹ i
 dietetic	d a ɪ ə t ɛ t ɪ k
+dietetician	d a ɪ ə t ɪ t ɪ ʃ ə n
+dietetics	d a ɪ ə t ɛ t ɪ k s
 diethylstilboestrol	d ʌ ɪ iː θ ʌ ɪ l s t ɪ l b iː s t ɹ ɒ l
 diethylstilboestrol	d ʌ ɪ ɛ θ ɪ l s t ɪ l b iː s t ɹ ɒ l
 dietitian	d a ɪ ə t ɪ ʃ ə n
 diff	d ɪ f
 differ	d ɪ f ə
-difference	d ɪ f ɹ ə n s
+difference	d ɪ f ə ɹ ə n s
 differences	d ɪ f ɹ ə n s ɪ z
 different	d ɪ f ə ɹ ə n t
 different	d ɪ f ɹ ə n t
@@ -19569,6 +19757,7 @@ digestible	d a ɪ d ʒ ɛ s t ə b ə ɫ
 digestif	d a ɪ d ʒ ɛ s t ɪ f
 digestif	d iː ʒ ɛ s t iː f
 digestion	d a ɪ d͡ʒ ɛ s t͡ʃ ə n
+digestion	d ɪ d͡ʒ ɛ s t͡ʃ ə n
 digestive	d a ɪ d ʒ ɛ s t ɪ v
 diggens	d ɪ ɡ ɪ n z
 digger	d ɪ ɡ ə
@@ -19751,6 +19940,8 @@ dines	d a ɪ n z
 dinette	d a ɪ n ɛ t
 ding	d ɪ ŋ
 dinge	d ɪ n d͡ʒ
+dinged	d ɪ n d͡ʒ d
+dinged	d ɪ ŋ d
 dinger	d ɪ ŋ ɡ ə ɹ
 dinghy	d ɪ ŋ ɡ i
 dingily	d ɪ n d ʒ ɪ l i
@@ -19782,6 +19973,7 @@ dinocarid	d a ɪ n ə k æ ɹ ɪ d
 dinocarid	d a ɪ n ə k ɛ ə ɹ ɪ d
 dinokaryote	d a ɪ n ə ʊ k æ ɹ i ə ʊ t
 dinomania	d a ɪ n ə ʊ m e ɪ n ɪ ə
+dinorwig	d ɪ n ɔ r w ɪ ɡ
 dinosaur	d a ɪ n ə s ɔː ɹ
 dinosaurian	d ʌ ɪ n ə ʊ s ɔː ɹ ɪ ə n
 dinq	d ɪ ŋ k
@@ -20355,6 +20547,7 @@ disseize	d ɪ s iː z
 disseizin	d ɪ s iː z ɪ n
 dissemblance	d ɪ s ɛ m b l ə n s
 disseminate	d ɪ s ɛ m ɪ n e ɪ t
+dissemination	d ɪ s ɛ m ɪ n e ɪ ʃ ə n
 dissension	d ɪ s ɛ n ʃ ə n
 dissensus	d ɪ s ɛ n s ə s
 dissent	d ɪ s ɛ n t
@@ -20525,6 +20718,7 @@ divert	d a ɪ v ɜː t
 diverted	d a ɪ v ɜː t ə d
 diverticulum	d ɑ ɪ v ɜː t ɪ k j ə l ə m
 divertimento	d ɪ v ɜː t ɪ m ɛ n t ə ʊ
+divertisement	d ɪ v ɜː ɹ t ɪ z m ə n t
 divertive	d a ɪ v ɜː ɹ t ɪ v
 dives	d a ɪ v z
 divest	d a ɪ v ɛ s t
@@ -20535,6 +20729,7 @@ divide	d ɪ v a ɪ d
 dividend	d ɪ v ɪ d ɛ n d
 divider	d ɪ v a ɪ d ə ɹ
 dividual	d ɪ v ɪ d͡ʒ u ə l
+divination	d ɪ v ɪ n e ɪ ʃ ə n
 divinatory	d ɪ v ɪ n ə t ɹ i
 divine	d ɪ v a ɪ n
 diviner	d ɪ v a ɪ n ə ɹ
@@ -20589,6 +20784,7 @@ djokovic	d ʒ ə ʊ k ə v ɪ t ʃ
 dkim	d iː k ɪ m
 dmz	d iː ɛ m z iː
 dmz	d iː ɛ m z ɛ d
+dna	d iː ɛ n e ɪ
 dnieper	d n iː p ə
 dnieper	n iː p ə
 dnipro	d n iː p r ə ʊ
@@ -20684,6 +20880,7 @@ dogleg	d ɒ ɡ l ɛ ɡ
 dogma	d ɒ ɡ m ə
 dogman	d ɒ ɡ m ə n
 dogmatic	d ɒ ɡ m a t ɪ k
+dogs	d ɒ ɡ z
 dogsbody	d ɒ ɡ z b ɒ d ɪ
 dogwatch	d ɒ ɡ w ɒ t͡ʃ
 dogwood	d ɒ ɡ w ʊ d
@@ -20698,7 +20895,9 @@ doink	d ɔ ɪ ŋ k
 doit	d ɔ ɪ t
 dojigger	d uː d͡ʒ ɪ ɡ ə ɹ
 dojo	d ə ʊ d ʒ ə ʊ
+dokkaebi	d o ʊ k e ɪ b i
 dolan	d ə ʊ l ə n
+dolbadarn	d ɔ l b a d aː n
 dolcelatte	d ɒ l t ʃ ə l a t ɪ
 dolcelatte	d ɒ l t ʃ ə l ɑː t e ɪ
 dolcelatte	d ɒ l t ʃ ə l ɑː t ɪ
@@ -20720,6 +20919,7 @@ dollarization	d ɑ l ɝ ɪ z e ɪ̯ ʃ ɪ n
 dollars	d ɒ l ə z
 dollop	d ɒ l ə p
 dolly	d ɒ l i
+dollywood	d ɒ l i w ʊ d
 dolman	d ɒ l m ə n
 dolmen	d ɒ l m ɛ n
 dolomite	d ɒ l ə m a ɪ t
@@ -20740,6 +20940,7 @@ dolt	d ɔ ʊ l t
 dolt	d ə ʊ l t
 dolts	d o ʊ l t s
 dolus	d o ʊ l ə s
+dolwyddelan	d ɔ l w ɪ ð ɛ l a n
 dom	d ɒ m
 domable	d ə ʊ m ə b l̩
 domain	d ə m e ɪ n
@@ -20956,6 +21157,7 @@ doubled	d ʌ b l̩ d
 doublet	d ʌ b l ə t
 doubloon	d ʌ b l uː n
 doubly	d ʌ b l i
+doubly	d ʌ b ə l l i
 doubs	d uː
 doubt	d a ʊ t
 doubted	d a ʊ t ɪ d
@@ -21046,6 +21248,7 @@ dows	d a ʊ z
 dowse	d a ʊ s
 dowse	d a ʊ z
 dowser	d a ʊ z ə
+doxa	d ɒ k s ə
 doxastic	d ɒ k s æ s t ɪ k
 doxepin	d ɒ k s ə p ɪ n
 doxology	d ɒ k s ɒ l ə d ʒ i
@@ -21064,6 +21267,7 @@ drabble	d ɹ æ b ə l
 drachm	d ɹ æ m
 drachma	d ɹ æ k m ə
 drachmae	d ɹ æ k m iː
+drachme	d ɹ æ k m i
 draco	d ɹ e ɪ k ə ʊ
 draconian	d ɹ æ k ə ʊ n i ə n
 draconian	d ɹ ə k ə ʊ n i ə n
@@ -21364,7 +21568,6 @@ druse	d ɹ u z
 drusilla	d ɹ u s ɪ l ə
 druxy	d ɹ ʌ k s i
 dry	d ɹ a ɪ
-dry	d͡ʒ ɹ a ɪ
 dryad	d ɹ a ɪ æ d
 dryad	d ɹ a ɪ ə d
 dryas	d ɹ a ɪ æ s
@@ -21403,6 +21606,7 @@ dubitation	d j uː b ɪ t e ɪ ʃ ə n
 dubitation	d ʒ uː b ɪ t e ɪ ʃ ə n
 dubitative	d j uː b ɪ t ə t ɪ v
 dublin	d ʌ b l ə n
+dublin	d ʌ b l ɪ n
 dubnium	d ʌ b n i ə m
 dubonnet	d j uː b ɒ n e ɪ
 dubplate	d ʌ b p l e ɪ t
@@ -21469,6 +21673,7 @@ dukedom	d j uː k d ə m
 dukedom	d ʒ uː k d ə m
 dukedoms	d j uː k d ə m z
 dukkha	d ʊ k ə
+dulce	d ʌ l s
 dulcet	d ʌ l s ə t
 dulcet	d ʌ l s ɪ t
 dulcify	d ʌ l s ɪ f a ɪ
@@ -21814,6 +22019,7 @@ ears	ɪ ə ɹ z
 earsh	æː ɹ ʃ
 earshot	ɪ ə ʃ ɒ t
 earth	ɜː θ
+earthen	ɜː ɹ ð ə n
 earthen	ɜː ɹ θ ə n
 earthenware	əː θ ə n w ɛː
 earthling	ɜː θ l ɪ ŋ
@@ -21836,9 +22042,7 @@ eases	iː z ɪ z
 easesome	iː z s ʌ m
 easie	iː z i
 easier	iː z i ə
-easily	iː z ə l iː
 easily	iː z ɪ l i
-easily	iː z ɪ l iː
 easiness	iː z ɪ n ə s
 easing	iː z ɪ ŋ
 easings	iː z ɪ ŋ z
@@ -21965,6 +22169,7 @@ ecstatic	ɛ k s t æ t ɪ k
 ecstatica	ɛ k s t æ t ɪ k ə
 ectal	ɛ k t ə l
 ectasia	ɛ k t e ɪ z j ə
+ectasis	ɛ k t ə s ɪ s
 ectomorph	ɛ k t ə ʊ m ɔː f
 ectoparasite	ɛ k t ə ʊ p æ ɹ ə s a ɪ t
 ectoplasm	ɛ k t ə p l æ z ə m
@@ -22045,6 +22250,8 @@ edmundston	ɛ d m ə n d s t ə n
 edo	ɛ d ə ʊ
 edom	i d ə m
 edomite	iː d ə m a ɪ t
+edonentan	ɛ d ə n ɛ n t æ n
+edriophthalmic	ɛ d r ɪ ɒ f θ æ l m ɪ k
 educate	ɛ d j ʊ k e ɪ t
 educate	ɛ d͡ʒ ʊ k e ɪ t
 educated	ɛ d j uː k e ɪ t ɪ d
@@ -22153,6 +22360,7 @@ egging	ɛ ɡ ɪ ŋ
 eggings	ɛ ɡ ɪ ŋ z
 eggless	ɛ ɡ l ə s
 eggnog	ɛ ɡ n ɒ ɡ
+eggplant	ɛ ɡ p l æ n t
 eggs	ɛ ɡ z
 eggshell	ɛ ɡ ʃ ɛ l
 eggy	ɛ ɡ i
@@ -22374,6 +22582,8 @@ elie	ɛ l i
 eliezer	ɛ l i iː z ə ɹ
 eliezer	ɛ l i ɛ z ə ɹ
 eligible	ɛ l ɪ d͡ʒ ə b ə l
+elijah	ɪ l a ɪ d͡ʒ ə
+elijah	ɪ l a ɪ ʒ ə
 eliminate	ɪ l ɪ m ɪ n e ɪ t
 elimination	ɪ l ɪ m ɪ n e ɪ ʃ ə n
 eliminatrix	ɪ l ɪ m ɪ n e ɪ t ɹ ɪ k s
@@ -22435,7 +22645,7 @@ elohim	ɛ l o ʊ h ɪ m
 eloign	ɪ l ɔ ɪ n
 eloise	ɛ l ə ʊ iː z
 elon	iː l ɔ n
-elongate	ɪ l ɔ ŋ ɡ e ɪ t
+elongate	ɪ l ɒ ŋ ɡ e ɪ t
 elope	ɛ l ə ʊ p
 elope	ɪ l ə ʊ p
 eloquate	ɛ l ə k w e ɪ t
@@ -22671,6 +22881,7 @@ emphatic	ɪ m f æ t ɪ k
 emphatically	ɛ m f æ t ɪ k l i
 emphysema	ɛ m f ɪ s iː m ə
 empire	ɛ m p a ɪ ə
+empiric	ɪ m p ɪ ɹ ɪ k
 empirical	ɪ m p ɪ ɹ ɪ k ə l
 employ	ɛ m p l ɔ ɪ
 employ	ɪ m p l ɔ ɪ
@@ -23024,6 +23235,7 @@ enrage	ɪ n ɹ e ɪ d͡ʒ
 enraged	ɪ n ɹ e ɪ d͡ʒ d
 enrapture	ɛ n ɹ æ p t͡ʃ ə ɹ
 enrapture	ɪ n ɹ æ p t͡ʃ ə ɹ
+enrasentan	ɛ n ɹ ə s ɛ n t æ n
 enrich	ɪ n ɹ ɪ t͡ʃ
 enrichen	ɛ n ɹ ɪ t͡ʃ ə n
 enrichen	ɪ n ɹ ɪ t͡ʃ ə n
@@ -23033,6 +23245,7 @@ ens	ɛ n z
 ensanguine	ɛ n s æ ŋ ɡ w ə n
 ensanguined	ɛ n s a ŋ ɡ w ɪ n d
 ensconce	ɛ n s k ɒ n s
+enscripturate	ɪ n s k ɹ ɪ p t͡ʃ ə r e ɪ t
 ensear	ɪ n s ɪ ə ɹ
 ensemble	ɒ n s ɒ m b ə l
 ensete	ɛ n s ə t
@@ -23088,7 +23301,7 @@ enterolith	ɛ n t ə ɹ ə l ɪ θ
 enterolith	ɛ n t ɛ ɹ ə l ɪ θ
 enteropathy	ɛ n t ə ɹ ɒ p ə θ i
 enterothorax	ɛ n t ə ɹ o ʊ θ ɔː ɹ æ k s
-enterprise	ɛ n t ɚ p ɹ a ɪ z
+enterprise	ɛ n t ə p ɹ a ɪ z
 enters	ɛ n t ə z
 entertain	ɛ n t ə t e ɪ n
 entertained	ɛ n t ə t e ɪ n d
@@ -23117,6 +23330,7 @@ entitle	ɛ n t a ɪ t ə l
 entitled	ɪ n t a ɪ t l̩ d
 entitlement	ə n t a ɪ t ə l m ə n t
 entity	e n t ɪ t i
+entomb	ɪ n t uː m
 entombment	ɛ n t uː m m ə n t
 entombment	ɪ n t uː m m ə n t
 entomophagy	ɛ n t ə m ɒ f ə d͡ʒ i
@@ -23129,6 +23343,7 @@ entrail	ɛ n t ɹ ə l
 entrails	ɛ n t ɹ e ɪ l z
 entrails	ɛ n t ɹ ə l z
 entrance	ɛ n t ɹ æ n s
+entrance	ɛ n t ɹ ɑː n s
 entrance	ɛ n t ɹ ə n s
 entranced	ɛ n t ɹ ɑː n s t
 entrances	ɛ n t ɹ æ n s ə z
@@ -23172,14 +23387,13 @@ envelope	ɛ n v ɛ l ə p
 enveloped	ɪ n v ɛ l ə p t
 envenom	ɪ n v ɛ n ə m
 enviable	ɛ n v i ə b l̩
+envie	ɑː n v iː
 envie	ɛ n v a ɪ
 envie	ɪ n v a ɪ
 envied	ɛ n v i d
 envied	ɪ n v a ɪ d
 envious	ɛ n v iː ə s
 environ	ɪ n v a ɪ ɹ ə n
-environment	ɪ n v a ɪ ɚ n m ə n t
-environment	ɪ n v a ɪ ɹ ə n m ə n t
 environmental	ɪ n v a ɪ ɹ ə n m ɛ n t ə l
 envisage	ɛ n v ɪ z ɪ d͡ʒ
 envisage	ɪ n v ɪ z ɪ d͡ʒ
@@ -23190,6 +23404,7 @@ envowel	ɛ n v a ʊ ə l
 envoy	ɛ n v ɔ ɪ
 envy	ɛ n v i
 enweaken	ɛ n w iː k n̩
+enyo	ɪ n a ɪ o ʊ
 enzedder	ɛ n z ɛ d ə ɹ
 enzo	ɛ n z o ʊ
 enzo	ɛ n z ə ʊ
@@ -23318,6 +23533,7 @@ epiphysis	ə p ɪ f ɪ s ɪ s
 epiphysis	ɪ p ɪ f ɪ s ɪ s
 epiphyte	ɛ p ɪ f ɑ ɪ t
 epirot	ɪ p ʌ ɪ ɹ ə t
+epirus	ɪ p a ɪ ə ɹ ə s
 episcopacy	ɪ p ɪ s k ə p ə s i
 episcopal	ə p ɪ s k ə p l̩
 episcopalian	ə p ɪ s k ə p e ɪ l i n̩
@@ -23461,7 +23677,7 @@ eratosthenian	ɛ ɹ æ t ə s θ iː n i ə n
 eratosthenian	ɛ ɹ ə t ə s θ iː n i ə n
 erbium	ɜː b ɪ ə m
 erd	ɜː d
-erdoğan	ɛ ə ɹ d o ʊ ɑː n
+erdoğan	ɛ ə ɹ d ə w æ n
 ere	ɛ ə
 ere	ɛː
 ere	ɪ ə ɹ
@@ -23495,6 +23711,8 @@ erinaceous	ɛ ɹ ə n e ɪ ʃ ə s
 erinaceous	ɛ ɹ ɪ n e ɪ ʃ ə s
 erinyes	ɪ ɹ ɪ n i iː z
 erinys	ɪ ɹ ɪ n ɪ s
+eris	ɛ ɹ ɪ s
+eris	ɪ ə ɹ ɪ s
 eriskay	ɛ ɹ ɪ s k e ɪ
 erith	iː ɹ ɪ θ
 eritrea	ɛ ɹ ɪ t ɹ e ɪ ə
@@ -23582,6 +23800,8 @@ escapologist	ɛ s k ə p ɒ l ə d ʒ ɪ s t
 escapology	ɛ s k ə p ɒ l ə d ʒ iː
 escargot	ɪ s k ɑː ɡ ə ʊ
 escarole	ɛ s k ə ɹ ə ʊ l
+escarp	ɪ s k ɑː p
+escarpment	ɪ s k ɑː p m ə n t
 eschar	ɛ s k ɑː
 eschatological	ɛ s k ə t ə l ɒ d ʒ ɪ k ə l
 eschatology	ɛ s k ə t ɒ l ə d͡ʒ i
@@ -23687,6 +23907,7 @@ esthiomene	ɛ s θ i ɒ m ə n i
 esthonia	ɛ s t ə ʊ n i ə
 esthonia	ɛ s θ ə ʊ n i ə
 estimable	ɛ s t ɪ m ə b ə l
+estimate	ɛ s t ɪ m ɪ t
 estimation	ɛ s t ɪ m e ɪ ʃ ə n
 estimative	ɛ s t ɪ m e ɪ t ɪ v
 estimative	ɛ s t ɪ m ə t ɪ v
@@ -23874,6 +24095,7 @@ euphony	j uː f ə n i
 euphoria	j uː f ɔː ɹ i ə
 euphoriant	j u f ɔ ɹ i ə n t
 euphrates	j uː f ɹ e ɪ t iː z
+euphrosyne	j uː f ɹ ɒ z ɪ n i
 eupyrion	j uː p ɪ ɹ i ə n
 eurafrican	j ʊ ə ɹ æ f ɹ ɪ k ə n
 euramerica	j ʊ ə ɹ ə m ɛ ɹ ə k ə
@@ -24128,6 +24350,9 @@ excited	ɪ k s a ɪ t ɪ d
 excitement	ɪ k s a ɪ t m ə n t
 exciting	ɛ k s ʌ ɪ t ɪ ŋ
 exciting	ɪ k s ʌ ɪ t ɪ ŋ
+exciton	ɛ k s a ɪ t ɒ n
+exciton	ɛ k s ɪ t ə n
+exciton	ɪ k s a ɪ t ɑ n
 exclaim	ɛ k s k l e ɪ m
 exclaim	ɪ k s k l e ɪ m
 exclaimed	ɛ k s k l e ɪ m d
@@ -24160,8 +24385,8 @@ excruciating	ɪ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ
 excruciatingly	ɛ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ l i
 excruciatingly	ɪ k s k ɹ uː s iː e ɪ t ɪ ŋ l i
 exculpate	ɛ k s k ə l p e ɪ t
-exculpatory	ɛ k s k ʌ l p ə t ə ɹ i
-exculpatory	ɛ k s k ʌ l p ə t ɹ i
+exculpatory	ɪ k s k ʌ l p ə t ə ɹ i
+exculpatory	ɪ k s k ʌ l p ə t ɹ i
 excursion	ɛ k s k ɜː ɹ ʃ ə n
 excursion	ɛ k s k ɜː ɹ ʒ ə n
 excursus	ɪ k s k ɜː s ə s
@@ -24194,7 +24419,7 @@ exegesis	ɛ k s ɪ d ʒ iː s ɪ s
 exegete	ɛ k s ɪ d ʒ iː t
 exemplar	ɛ ɡ z ɛ m p l ə
 exemplar	ɪ k z ɛ m p l ə
-exemplary	ɛ ɡ z ɛ m p l ə ɹ i
+exemplary	ɪ ɡ z ɛ m p l ə ɹ i
 exemplify	ɛ ɡ z ɛ m p l ɪ f a ɪ
 exemplify	ɪ ɡ z ɛ m p l ɪ f a ɪ
 exempt	ɛ ɡ z ɛ m p t
@@ -24237,6 +24462,7 @@ exhibitry	ɛ ɡ z ɪ b ɪ t ɹ i
 exhilarate	ɪ ɡ z ɪ l ə ɹ e ɪ t
 exhort	ɛ ɡ z ɔː t
 exhort	ɪ ɡ z ɔː t
+exhortative	ɪ ɡ z ɔ ɹ t ə t ɪ v
 exhumation	e k s h j uː m e ɪ ʃ ə n
 exhume	ɛ k s h j uː m
 exhume	ɪ ɡ z j uː m
@@ -24331,6 +24557,7 @@ expenditures	ɛ k s p ɛ n d ɪ t͡ʃ ə z
 expenditures	ɪ k s p ɛ n d ɪ t͡ʃ ə z
 expends	ɛ k s p ɛ n d z
 expends	ɪ k s p ɛ n d z
+expenny	ɪ k s p ɛ n i
 expense	ɪ k s p ɛ n s
 expenses	ɪ k s p ɛ n s ɪ z
 expensive	ɛ k s p ɛ n s ɪ v
@@ -24344,6 +24571,7 @@ experiential	ɛ k s p ɪ ə ɹ i ɛ n ʃ ə l
 experiential	ɪ k s p ɪ ə ɹ i ɛ n ʃ ə l
 experiment	ɛ k s p ɛ ɹ ɪ m ə n t
 experiment	ɪ k s p ɛ ɹ ɪ m ə n t
+experimental	ɪ k s p ɛ ɹ ə m ɛ n t ə l
 experiments	ɛ k s p ɛ ɹ ɪ m ə n t s
 experiments	ɪ k s p ɛ ɹ ɪ m ə n t s
 expert	ɛ k s p əː t
@@ -24550,7 +24778,6 @@ exudate	ɛ ɡ z j ʊ d e ɪ t
 exude	ɪ ɡ z j uː d
 exult	ɪ ɡ z ʌ l t
 exultation	ɛ ɡ z ʌ l t e ɪ ʃ ə n
-exuma	ɛ k s uː m ə
 exuviate	ɛ k s uː v ɪ e ɪ t
 exuviate	ɪ ɡ z j uː v ɪ e ɪ t
 ey	e ɪ
@@ -24670,8 +24897,8 @@ fadge	f æ d͡ʒ
 fading	f e ɪ d ɪ ŋ
 fado	f ɑː d o ʊ
 fady	f e ɪ d i
+fady	f æ d i
 fady	f ɑː d i
-faeces	f iː s iː z
 faena	f a e n ə
 faff	f æ f
 faffy	f æ f i
@@ -24804,6 +25031,7 @@ fan	f æ n
 fanac	f æ n æ k
 fanatic	f ə n æ t ɪ k
 fanatical	f ə n æ t ɪ k ə l
+fanaticism	f ə n æ t ɪ s ɪ z ə m
 fancied	f æ n s ɪ d
 fancies	f æ n s i z
 fanciful	f æ n s ɪ f ə l
@@ -24813,6 +25041,7 @@ fandabidozi	f æ n d æ b iː d ə ʊ z i
 fandango	f æ n d æ ŋ ɡ ə ʊ
 fandemonium	f æ n d ə m ə ʊ n i ə m
 fandom	f æ n d ə m
+fandosentan	f æ n d ə s ɛ n t æ n
 fandub	f æ n d ʌ b
 fane	f e ɪ n
 faned	f æ n ɛ d
@@ -24859,6 +25088,7 @@ fantastical	f æ n t æ s t ɪ k ə l
 fantasticalness	f a n t a s t ɪ k ə l n ə s
 fantasy	f æ n t ə s i
 fanti	f æ n t i
+fantods	f æ n t ɒ d z
 fanzine	f æ n z iː n
 fap	f æ p
 fapiao	f ɑː p i a ʊ
@@ -25101,6 +25331,7 @@ februarys	f ɛ b ɹ u ɛ ɹ i z
 februation	f ɛ b ɹ ʊ e ɪ ʃ ə n
 febuary	f ɛ b j ʊ ə ɹ i
 fecal	f iː k ə l
+feces	f iː s iː z
 feck	f ɛ k
 feckful	f ɛ k f ə l
 feckless	f ɛ k l ə s
@@ -25136,6 +25367,7 @@ feeler	f iː l ə
 feelgoodery	f iː l ɡ ʊ d ə ɹ i
 feeling	f iː l ɪ ŋ
 feelings	f iː l ɪ ŋ z
+feels	f i j ə l z
 feels	f iː l z
 feely	f iː l i
 feeney	f i n i
@@ -25150,11 +25382,12 @@ feigns	f e ɪ n z
 feijoa	f e ɪ d͡ʒ o ʊ ə
 feijoa	f e ɪ h o ʊ ə
 feijoa	f e ɪ ʒ o ʊ ə
-feijoada	f ɛ ɪ ʒ w ɑː d ə
+feijoada	f e ɪ ʒ w ɑː d ə
 feinstein	f a ɪ n s t a ɪ n
 feinstein	f a ɪ n s t iː n
 feint	f e ɪ n t
 feinter	f e ɪ n t ə ɹ
+feirie	f ɪ ə r i
 feis	f ɛ ʃ
 feiseanna	f ɛ ʃ ə n ə
 feist	f a ɪ s t
@@ -25183,6 +25416,7 @@ felly	f ɛ l i
 felly	f ɛ l l i
 felon	f ɛ l ə n
 felony	f ɛ l ə n i
+feloprentan	f ɛ l ə p ɹ ɛ n t æ n
 felt	f ɛ l t
 felter	f ɛ l t ə ɹ
 feltham	f ɛ l t ə m
@@ -25262,7 +25496,7 @@ ferm	f ɜː ɹ m
 fermanagh	f ə ɹ m æ n ə
 fermata	f ɜː m ɑː t ə
 ferment	f ə m ɛ n t
-ferment	f əː m ɛ n t
+ferment	f ɜː m ɛ n t
 fermentate	f ɜː ɹ m ə n t e ɪ t
 fermentation	f ɜː ɹ m ə n t e ɪ ʃ ə n
 fermentation	f ɜː ɹ m ɛ n t e ɪ ʃ ə n
@@ -25408,6 +25642,8 @@ fibrillate	f ʌ ɪ b r ɪ l e ɪ t
 fibrillogenic	f ɪ b ɹ ɪ l ə ʊ d͡ʒ ɛ n ɪ k
 fibrillose	f ɪ b ɹ ɪ l ə ʊ s
 fibrin	f a ɪ b ɹ ɪ n
+fibrine	f a ɪ b ɹ ɪ n
+fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɪ n ə s
 fibrous	f a ɪ b ɹ ə s
 fibula	f ɪ b j ʊ l ə
 fic	f ɪ k
@@ -25477,7 +25713,7 @@ fifeshire	f a ɪ f ʃ ə ɹ
 fifeshire	f a ɪ f ʃ ɪ ə ɹ
 fifi	f i f i
 fifo	f a ɪ f ə ʊ
-fifteenth	f ɪ f t iː n θ
+fifteenth	h ɪ f t iː n θ
 fifth	f ɪ f t
 fifth	f ɪ f θ
 fifth	f ɪ θ
@@ -25594,6 +25830,8 @@ finally	f a ɪ n ə l i
 finals	f a ɪ n ə l z
 finance	f a ɪ n æ n s
 finance	f ɪ n æ n s
+finances	f a ɪ n æ n s ɪ z
+finances	f ɪ n æ n s ɪ z
 financial	f a ɪ n æ n ʃ ə l
 financial	f ɪ n æ n ʃ ə l
 financialization	f ʌ ɪ n a n ʃ l̩ ʌ ɪ z e ɪ ʃ n̩
@@ -25744,6 +25982,7 @@ fissiparous	f ɪ s ɪ p ə ɹ ə s
 fissure	f ɪ ʃ ə
 fist	f ɪ s t
 fisted	f ɪ s t ɪ d
+fister	f ɪ s t ə
 fistfight	f ɪ s t f a ɪ t
 fistful	f ɪ s t f ʊ l
 fistiana	f ɪ s t ɪ e ɪ n ə
@@ -25812,7 +26051,6 @@ flabby	f l æ b i
 flabellate	f l ə b ɛ l ə t
 flabellum	f l ə b ɛ l ə m
 flaccid	f l æ k s ɪ d
-flaccid	f l æ s ɪ d
 flack	f l æ k
 flacon	f l æ k ɒ n
 flacon	f l ɑː k ɒ n
@@ -25956,6 +26194,7 @@ flecking	f l ɛ k ɪ ŋ
 fleckings	f l ɛ k ɪ ŋ z
 flecks	f l ɛ k s
 flecky	f l ɛ k i
+flector	f l ɛ k t ə ɹ
 fled	f l ɛ d
 fledge	f l ɛ d͡ʒ
 fledged	f l ɛ d͡ʒ d
@@ -26066,7 +26305,7 @@ floccinaucinihilipilification	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l 
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɒ s ɪ n ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 flocculation	f l ɒ k j ʊ l ɛ ɪ̯ ʃ ə n
-flocculent	f l ɒ k j ʊ l ə n t
+flocculent	f l ɒ k j ə l ə n t
 flock	f l ɒ k
 flocks	f l ɒ k s
 floe	f l ə ʊ
@@ -26142,6 +26381,7 @@ flowering	f l a ʊ ə ɹ ɪ ŋ
 flowerpot	f l a ʊ ə p ɒ t
 flowers	f l a ʊ ə z
 flowing	f l ə ʊ ɪ ŋ
+flowk	f l a ʊ k
 flown	f l ə ʊ n
 flows	f l ə ʊ z
 flox	f l ɒ k s
@@ -26337,6 +26577,7 @@ foof	f uː f
 foofaraw	f u f ə ɹ ɔ
 foofooraw	f uː f ə ɹ ɔː
 fook	f uː k
+fook	f ʊ k
 fool	f uː l
 fooled	f uː l d
 fooler	f uː l ə ɹ
@@ -26410,7 +26651,7 @@ forbear	f ɔː b ɛ ə
 forbearance	f ɔː b ɛː ɹ ə n t s
 forbearingly	f ɔː b ɛː ɹ ɪ ŋ l i
 forbid	f ə b ɪ d
-forbidden	f ə b ɪ d ə n
+forbidden	f ə b ɪ d n̩
 forbidding	f ə b ɪ d ɪ ŋ
 forby	f ə b ʌ ɪ
 force	f ɔː s
@@ -26562,6 +26803,7 @@ formulae	f ɔː ɹ m j ə l a ɪ
 formulae	f ɔː ɹ m j ə l e ɪ
 formulae	f ɔː ɹ m j ə l i
 formulaicity	f ɔ ɹ m j ə l e ɪ ɪ s ə t iː
+formulary	f ɔː ɹ m j ʊ l ə ɹ i
 formulate	f ɔː ɹ m j ʊ l e ɪ t
 formule	f ɔː ɹ m j uː l
 fornicate	f ɔː n ɪ k e ɪ t
@@ -26638,7 +26880,9 @@ forworn	f ə ɹ w ɔː ɹ n
 fosaprepitant	f ɒ s ə p ɹ ɛ p ɪ t ə n t
 fosphenytoin	f ɒ s f ə n ɪ t ə ʊ ɪ n
 foss	f ɒ s
+fossa	f uː s ə
 fossa	f ɒ s ə
+fossa	f ʊ s ə
 fosse	f ɒ s
 fossette	f ɒ s ɛ t
 fossick	f ɒ s ɪ k
@@ -26742,6 +26986,7 @@ fragor	f ɹ e ɪ ɡ ə ɹ
 fragrance	f ɹ e ɪ ɡ ɹ ə n s
 fragrant	f ɹ e ɪ ɡ ɹ ə n t
 fraidy	f ɹ e ɪ d i
+fraight	f ɹ e ɪ t
 frail	f ɹ e ɪ l
 fraischeur	f ɹ e ɪ ʃ ə ɹ
 fraise	f ɹ e ɪ z
@@ -27143,6 +27388,7 @@ frumpy	f ɹ ʌ m p ɪ
 frush	f ɹ ʌ ʃ
 frustrate	f ɹ ə s t ɹ e ɪ t
 frustrated	f ɹ ə s t ɹ e ɪ t ɪ d
+frustrating	f ɹ ə s t ɹ e ɪ̯ t ɪ ŋ
 frustrating	f ɹ ʌ s t ɹ e ɪ̯ t ɪ ŋ
 frutage	f ɹ uː t ə d͡ʒ
 frutescence	f ɹ uː t ɛ s ə n s
@@ -27158,6 +27404,7 @@ fubbery	f ʌ b ə ɹ i
 fubble	f ʌ b ə l
 fubsy	f ʌ b s ɪ
 fubu	f u b ʊ
+fuchien	f uː t ʃ i ɛ n
 fuchs	f j uː k s
 fuchsia	f j uː ʃ ə
 fuchsine	f uː k s iː n
@@ -27193,6 +27440,7 @@ fuel	f j ʊ ə l
 fuero	f w ɛ ə ɹ ə ʊ
 fufufu	f uː f uː f uː
 fug	f ʌ ɡ
+fuga	f j uː ɡ ə
 fugacious	f j uː ɡ e ɪ ʃ ə s
 fugazi	f u ɡ ɑː z i
 fugged	f ʌ ɡ d
@@ -27269,11 +27517,13 @@ fume	f j uː m
 fumed	f j uː m d
 fumer	f j uː m ə ɹ
 fumes	f j uː m z
+fumfer	f ʌ m f ə
 fumigate	f j uː m ɪ ɡ e ɪ t
 fumigation	f j uː m ɪ ɡ e ɪ ʃ ə n
 fuming	f j uː m ɪ ŋ
 fumings	f j uː m ɪ ŋ z
 fun	f ʌ n
+funafuti	f uː n ə f uː t i
 funalicious	f ʌ n ə l ɪ ʃ ə s
 funambulate	f j ʊ n æ m b j ʊ l e ɪ t
 funambulist	f j uː n æ m b j ʊ l ɪ s t
@@ -27301,6 +27551,7 @@ fundraiser	f ʌ n d ɹ e ɪ z ə
 fundraising	f ʌ n d ɹ e ɪ z ɪ ŋ
 funds	f ʌ n d z
 funemployed	f ʌ n ɪ m p l ɔ ɪ d
+funen	f j uː n ə n
 funeral	f j uː n ə ɹ ə l
 funeral	f j uː n ɹ ə l
 funerary	f j uː n ə ɹ ə ɹ i
@@ -27485,8 +27736,9 @@ gabby	ɡ æ b i
 gabe	ɡ e ɪ b
 gabel	ɡ e ɪ b ə l
 gabelle	ɡ a b ɛ l
-gabion	ɡ e ɪ b ɪ ə n
+gabion	ɡ e ɪ b i ə n
 gable	ɡ e ɪ b ə l
+gablet	ɡ e ɪ b l ə t
 gabon	ɡ ə b ɒ n
 gabonese	ɡ æ b ə n iː z
 gaborone	ɡ æ b ə ɹ ə ʊ n i
@@ -27516,6 +27768,7 @@ gadolinium	ɡ æ d ə l ɪ n i ə m
 gadroon	ɡ ə d ɹ uː n
 gadrooned	ɡ ə d ɹ uː n d
 gadsbud	ɡ æ d z b ʌ d
+gadus	ɡ e ɪ d ə s
 gadzooks	ɡ æ d z uː k s
 gaea	d͡ʒ iː ə
 gaea	ɡ a ɪ ə
@@ -27567,6 +27820,7 @@ gaiting	ɡ e ɪ t ɪ ŋ
 gaits	ɡ e ɪ t s
 gaiwan	ɡ a ɪ w ɑː n
 gaja	ɡ ɑː d͡ʒ ə
+gak	ɡ æ k
 gal	ɡ æ l
 gala	ɡ ɑː l ə
 galactagogue	ɡ ə l æ k t ə ɡ ɒ ɡ
@@ -27583,7 +27837,7 @@ galantine	ɡ a l ə n t iː n
 galashiels	ɡ æ l ə ʃ iː ə l z
 galatea	ɡ æ l ə t ɪ ə
 galatians	ɡ ə l e ɪ ʃ ə n z
-galaxy	ɡ a l ə k s i
+galaxy	ɡ æ l ə k s i
 galbanum	ɡ æ l b ə n ə m
 galbe	ɡ æ l b
 gale	ɡ e ɪ l
@@ -27596,6 +27850,7 @@ galicia	ɡ ə l ɪ s i ə
 galicia	ɡ ə l ɪ ʃ ə
 galician	ɡ ə l ɪ s i ə n
 galician	ɡ ə l ɪ ʃ ə n
+galileo	ɡ æ l ɪ l e ɪ ə ʊ
 galimatias	ɡ æ l ə m e ɪ ʃ i ə s
 galingale	ɡ æ l ɪ ŋ ɡ e ɪ l
 gall	ɡ ɔː l
@@ -27643,7 +27898,7 @@ galvanic	ɡ æ l v æ n ɪ k
 galvanism	ɡ æ l v ə n ɪ z ə m
 galvanize	ɡ æ l v ə n a ɪ̯ z
 galvanometer	ɡ æ l v ə n ɒ m ɪ t ə
-galveston	ɡ æ l v ə s t ə n
+galveston	ɡ æ l v ɪ s t ə n
 galway	ɡ ɔː l w e ɪ
 galwegian	ɡ ɔː l w iː d ʒ ə n
 galyak	ɡ æ l j æ k
@@ -27653,7 +27908,9 @@ gamaliel	ɡ æ m ə l iː ə l
 gamb	ɡ a m b
 gambado	ɡ æ m b e ɪ d ə ʊ
 gambell	ɡ æ m b ə l
+gambeson	ɡ æ m b ɪ s ə n
 gambia	ɡ æ m b i ə
+gambison	ɡ æ m b ɪ s ə n
 gamble	ɡ æ m b ə l
 gambling	ɡ æ m b l ɪ ŋ
 gambling	ɡ æ m b l̩ ɪ ŋ
@@ -27715,6 +27972,7 @@ gangsteress	ɡ æ ŋ s t ə ɹ ɛ s
 gangue	ɡ æ ŋ
 ganguro	ɡ ɑː n ɡ u ɹ ə ʊ
 ganister	ɡ æ n ɪ s t ə ɹ
+ganj	ɡ æ n d ʒ
 ganja	ɡ æ n d ʒ ə
 ganjapreneur	ɡ æ n d͡ʒ ə p ɹ ə n ɜː ɹ
 ganjapreneur	ɡ ɑ n d͡ʒ ə p ɹ ə n ɜː ɹ
@@ -27804,18 +28062,20 @@ gary	ɡ æ ɹ ɪ
 garçon	ɡ ɑː ɹ s ɒ n
 garçonnière	ɡ ɑː s ə n j ɛ ə
 gas	ɡ æ s
+gas	ɡ æ z
 gasbag	ɡ æ s b æ ɡ
 gascoigne	ɡ æ s k ɔ ɪ n
 gascon	ɡ æ s k ə n
 gasconade	ɡ a s k ə n e ɪ d
 gases	ɡ æ s ɪ z
+gases	ɡ æ z ɪ z
 gash	ɡ æ ʃ
 gasket	ɡ æ s k ɪ t
 gaskin	ɡ æ s k ɪ n
 gaslight	ɡ æ s l a ɪ t
 gasoline	ɡ æ s l i n
 gasoline	ɡ æ s l̩ i n
-gasoline	ɡ æ s ə l i n
+gasoline	ɡ æ s ə l iː n
 gasometer	ɡ æ s ɒ m ɪ t ə
 gasp	ɡ ɑː s p
 gasped	ɡ ɑː s p t
@@ -27845,6 +28105,7 @@ gather	ɡ æ ð ə
 gathered	ɡ æ ð ə d
 gathering	ɡ æ ð ə ɹ ɪ ŋ
 gator	ɡ e ɪ t ə ɹ
+gatorade	ɡ e ɪ t ə ɹ e ɪ d
 gau	ɡ a ʊ
 gauche	ɡ ə ʊ ʃ
 gaucherie	ɡ o ʊ ʃ ə ɹ iː
@@ -27884,6 +28145,7 @@ gaw	ɡ ɔː
 gawa	ɡ a w a
 gawain	ɡ ɑː w e ɪ n
 gawain	ɡ ə w e ɪ n
+gawber	ɡ ɔː b ə ɹ
 gawd	ɡ ɔː d
 gawf	ɡ ɔː f
 gawk	ɡ ɔː k
@@ -27911,6 +28173,7 @@ gazehound	ɡ e ɪ z h a ʊ n d
 gazella	ɡ ə z ɛ l ə
 gazelle	ɡ ə z ɛ l
 gazes	ɡ e ɪ z ə z
+gazes	ɡ e ɪ z ɪ z
 gazette	ɡ ə z ɛ t
 gazillion	ɡ ə z ɪ l j ə n
 gazing	ɡ e ɪ z ɪ ŋ
@@ -28017,6 +28280,7 @@ gene	d͡ʒ iː n
 genealogist	d ʒ iː n iː æ l ə d ʒ ɪ s t
 genealogy	d ʒ iː n i æ l ə d ʒ i
 genealogy	d ʒ iː n i ɒ l ə d ʒ i
+genearch	d ʒ iː n i ɑː ɹ k
 genera	d͡ʒ ɛ n ə ɹ ə
 general	d͡ʒ ɛ n ɹ ə l
 generalia	d͡ʒ ɛ n ə ɹ e ɪ l i ə
@@ -28177,11 +28441,12 @@ geordie	d ʒ ɔː d i
 george	d ʒ ɔː ɹ d ʒ
 georgeson	d ʒ ɔː ɹ d ʒ s ə n
 georgetown	d͡ʒ ɔː ɹ d͡ʒ t a ʊ n
-georgia	d ʒ ɔː d ʒ ə
-georgian	d ʒ ɔː d ʒ ə n
+georgia	d͡ʒ ɔː d͡ʒ ə
+georgian	d͡ʒ ɔː d͡ʒ ə n
 georgina	d ʒ ɔː ɹ d ʒ iː n ə
 geosmin	d͡ʒ iː ɒ z m ɪ n
 geospace	d͡ʒ iː ə ʊ s p e ɪ s
+geospeedometry	d ʒ iː ə ʊ s p iː d ɒ m ɪ t ɹ i
 geosphere	d͡ʒ iː ə s f ɪ ə ɹ
 geosphere	d͡ʒ iː ə ʊ s f ɪ ə ɹ
 geosyncline	d ʒ iː ə ʊ s ɪ ŋ k l ʌ ɪ n
@@ -28194,6 +28459,7 @@ geppetto	d͡ʒ ə p ɛ t o ʊ
 ger	ɡ ɛ ə ɹ
 geraint	ɡ ɛ ɹ a ɪ n t
 gerald	d͡ʒ ɛ ɹ ə l d
+geranium	d ʒ ə ɹ e ɪ n i ə m
 geranylgeranylacetone	d͡ʒ ɛ ɹ ə n ɪ l d͡ʒ ɛ ɹ ə n ɪ l æ s ɪ t ə ʊ n
 gerard	d͡ʒ ɛ ɹ ɑː d
 gerasena	ɡ ɛ ɹ ə s iː n ə
@@ -28213,6 +28479,7 @@ germans	d͡ʒ ɜː m ə n z
 germany	d͡ʒ ɜː m ə n i
 germen	d ʒ ɜː m ə n
 germinal	d ʒ ɜː m ɪ n ə l
+germinal	d ʒ ɜː ɹ m ɪ n ə l
 germinate	d͡ʒ ɜː ɹ m ɪ n e ɪ t
 gern	ɡ ɜː ɹ n
 gerocomy	d ʒ ɪ ə ɹ ɒ k ə m i
@@ -28228,6 +28495,7 @@ gershon	ɡ ɜː ʃ ɒ n
 gersum	ɡ ɜː s ə m
 gerund	d͡ʒ ɛ ɹ ə n d
 gerundive	d ʒ ə ɹ ʌ n d ɪ v
+gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɪ
 gesellschaft	ɡ ə z ɛ l ʃ a f t
 gesso	d͡ʒ ɛ s ə ʊ
 gest	d͡ʒ ɛ s t
@@ -28286,6 +28554,7 @@ ghent	ɡ ɛ n t
 gherao	ɡ ɛ ɹ a ʊ
 gherkin	ɡ ɜː k ɪ n
 ghetto	ɡ ɛ t ə ʊ
+ghey	d ʒ a ɪ
 ghibelline	ɡ ɪ b ɪ l a ɪ n
 ghibli	ɡ ɪ b l i
 ghillie	ɡ ɪ l i
@@ -28430,6 +28699,7 @@ gingerol	d͡ʒ ɪ n d͡ʒ ə ɹ ɒ l
 gingham	ɡ ɪ ŋ ə m
 gingiva	d͡ʒ ɪ n d͡ʒ a ɪ v ə
 gingiva	d͡ʒ ɪ n d͡ʒ ɪ v ə
+gingival	d͡ʒ ɪ n d͡ʒ ɪ v ə l
 gingivitis	d͡ʒ ɪ n d͡ʒ ɪ v a ɪ t ə s
 ginglymus	d ʒ ɪ ŋ ɡ l ɪ m ə s
 ginglymus	ɡ ɪ ŋ ɡ l ɪ m ə s
@@ -28449,7 +28719,6 @@ ginseng	d͡ʒ ɪ n s ɪ ŋ
 ginsu	ɡ ɪ n s uː
 giovanni	d͡ʒ iː ə v ɑ n i
 giovanni	d͡ʒ o ʊ v ɑ n i
-gipper	ɡ ɪ p ɚ
 gippo	d͡ʒ ɪ p ə ʊ
 giraffe	d ʒ ɪ ɹ ɑː f
 giraffes	d ʒ ɪ ɹ ɑː f s
@@ -28464,6 +28733,7 @@ girl	ɡ ɪ ə l
 girlcock	ɡ ɜː l k ɑ k
 girldick	ɡ ɜː l d ɪ k
 girleen	ɡ əː l iː n
+girlf	ɡ ɜː l f
 girlfriend	ɡ ɜː l f ɹ ɛ n d
 girlish	ɡ ɜː l ɪ ʃ
 girls	ɡ ɜː l z
@@ -28476,6 +28746,8 @@ girt	ɡ ɜː t
 girth	ɡ ɜː θ
 girus	d͡ʒ a ɪ ɹ ə s
 gisborne	ɡ ɪ z b ə n
+giselle	d ʒ ɪ z ɛ l
+giselle	ʒ ɪ z ɛ l
 gismu	ɡ iː s m uː
 gissard	ɡ ɪ s ɜː d
 gist	d͡ʒ ɪ s t
@@ -28577,6 +28849,7 @@ glazed	ɡ l e ɪ z d
 glazes	ɡ l e ɪ z ɪ z
 glazier	ɡ l e ɪ z i ə ɹ
 glazier	ɡ l e ɪ z j ə ɹ
+glazier	ɡ l e ɪ ʒ ə ɹ
 glazing	ɡ l e ɪ z ɪ ŋ
 glazings	ɡ l e ɪ z ɪ ŋ z
 glazy	ɡ l e ɪ z i
@@ -28664,6 +28937,7 @@ globish	ɡ l ə ʊ b ɪ ʃ
 globster	ɡ l ɒ b s t ə
 globule	ɡ l ɒ b j uː l
 globulin	ɡ l ɒ b j ʊ l ɪ n
+globus	ɡ l ə ʊ b ə s
 globy	ɡ l ə ʊ b i
 glocal	ɡ l ə ʊ k ə l
 glockenspiel	ɡ l ɒ k ə n ʃ p iː l
@@ -28704,6 +28978,8 @@ glossatrix	ɡ l ɒ s e ɪ t ɹ ɪ k s
 glossitis	ɡ l ɒ s a ɪ t ɪ s
 glossolalia	ɡ l ɒ s ə l e ɪ l i ə
 glossology	ɡ l ɒ s ɒ l ə d ʒ i
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t a ɪ n
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t ɪ n
 glossopharyngeal	ɡ l ɒ s ə ʊ f a ɹ n̩ d͡ʒ iː ə l
 glossopharyngeal	ɡ l ɒ s ə ʊ f a ɹ ə n d͡ʒ iː ə l
 glossopharyngeal	ɡ l ɒ s ə ʊ f ə ɹ ɪ n d͡ʒ i ə l
@@ -28914,7 +29190,7 @@ golborne	ɡ ɒ l b ɔː ɹ n
 golconda	ɡ ɒ l k ɒ n d ə
 gold	ɡ ə ʊ l d
 golden	ɡ ə ʊ l d ə n
-goldeneye	ɡ ə ʊ l d n̩ ɑ ɪ
+goldeneye	ɡ ə ʊ l d ə n a ɪ
 goldfish	ɡ o ʊ l d f ɪ ʃ
 goldilocks	ɡ ə ʊ l d i l ɒ k s
 golding	ɡ ə ʊ l d ɪ ŋ
@@ -29002,7 +29278,6 @@ goop	ɡ uː p
 goopy	ɡ uː p i
 goos	ɡ uː s
 goos	ɡ uː z
-goose	ɡ uː s
 gooseberry	ɡ uː s b ə ɹ i
 gooseberry	ɡ ʊ z b ə ɹ i
 goosefoot	ɡ uː s f ʊ t
@@ -29028,14 +29303,13 @@ gorget	ɡ ɔː d ʒ ɪ t
 gorgias	ɡ ɔ ɹ d͡ʒ i ə s
 gorgon	ɡ ɔː r ɡ ə n
 gorhen	ɡ ɔː h ɛ n
-gorilla	ɡ ɒ ɹ ɪ l ə
 gorilla	ɡ ə ɹ ɪ l ə
 gork	ɡ ɔː k
 gorm	ɡ ɔː ɹ m
 gormless	ɡ ɔː m l ə s
 gormy	ɡ ɔː m i
 goropism	ɡ ə ɹ ə ʊ p ɪ z ə m
-gorp	ɡ ɔː ɹ p
+gorp	ɡ ɔː p
 gorringe	ɡ ɒ ɹ ɪ n d͡ʒ
 gorse	ɡ ɔː s
 gorsedd	ɡ ɔː ɹ s ɛ ð
@@ -29051,6 +29325,7 @@ gosh	ɡ ɒ ʃ
 gosha	ɡ o ʊ ʃ ə
 goshawk	ɡ ɒ s h ɔː k
 goshbustified	ɡ ɒ ʃ b ʌ s t ɪ f a ɪ d
+gosht	ɡ o ʊ ʃ t
 gosling	ɡ ɒ z l ɪ ŋ
 gospel	ɡ ɒ s p ə l
 gosplan	ɡ ɒ s p l æ n
@@ -29286,6 +29561,8 @@ grasped	ɡ ɹ ɑː s p t
 grasping	ɡ ɹ ɑː s p ɪ ŋ
 grass	ɡ ɹ æ s
 grass	ɡ ɹ ɑː s
+grasshawk	ɡ ɹ æ s h ɔː k
+grasshawk	ɡ ɹ ɑː s h ɔː k
 grasshopper	ɡ ɹ æ s h ɒ p ə ɹ
 grasshopper	ɡ ɹ ɑː s h ɒ p ə ɹ
 grassley	ɡ ɹ æ s l i
@@ -29405,7 +29682,7 @@ greenford	ɡ ɹ iː n f ə d
 greengage	ɡ ɹ iː n ɡ e ɪ d͡ʒ
 greengrocer	ɡ ɹ i n ɡ ɹ ə ʊ s ə ɹ
 greenhouse	ɡ ɹ iː n h a ʊ s
-greeniac	ɡ ɹ i n i æ k
+greeniac	ɡ ɹ iː n i æ k
 greening	ɡ ɹ iː n ɪ ŋ
 greenings	ɡ ɹ iː n ɪ ŋ z
 greenish	ɡ ɹ iː n ɪ ʃ
@@ -29465,8 +29742,10 @@ greven	ɡ ɹ i v ə n
 greviere	ɡ ɹ ɛ v j ɛ ə ɹ
 grew	ɡ ɹ u ʊ̯
 grew	ɡ ɹ uː
+grex	ɡ ɹ ɛ k s
 grexit	ɡ ɹ ɛ k s ɪ t
 grexit	ɡ ɹ ɛ ɡ z ɪ t
+grey	ɡ ɹ e ɪ
 greyback	ɡ ɹ e ɪ b a k
 greyhound	ɡ ɹ e ɪ h a ʊ n d
 greyish	ɡ ɹ e ɪ ɪ ʃ
@@ -29479,6 +29758,7 @@ grice	ɡ ɹ ʌ ɪ s
 grid	ɡ ɹ ɪ d
 gridded	ɡ ɹ ɪ d ɪ d
 gridding	ɡ ɹ ɪ d ɪ ŋ
+griddle	ɡ ɹ ɪ d ə l
 gride	ɡ ɹ a ɪ d
 griding	ɡ ɹ a ɪ d ɪ ŋ
 gridiron	ɡ ɹ ɪ d a ɪ ə n
@@ -29502,6 +29782,7 @@ griff	ɡ ɹ ɪ f
 griffe	ɡ ɹ ɪ f
 griffin	ɡ ɹ ɪ f ɪ n
 griffith	ɡ ɹ ɪ f ɪ θ
+griffon	ɡ ɹ ɪ f ə n
 grift	ɡ ɹ ɪ f t
 grifter	ɡ ɹ ɪ f t ə
 grifting	ɡ ɹ ɪ f t ɪ ŋ
@@ -29509,6 +29790,7 @@ grig	ɡ ɹ ɪ ɡ
 grike	ɡ ɹ a ɪ k
 grill	ɡ ɹ ɪ l
 grillade	ɡ ɹ i j ɑː d
+grillade	ɡ ɹ ɪ l ɑː d
 grillbilly	ɡ ɹ ɪ l b ɪ l i
 grille	ɡ ɹ ɪ l
 grilled	ɡ ɹ ɪ l d
@@ -29687,6 +29969,7 @@ grue	ɡ ɹ uː
 gruel	ɡ ɹ uː ə l
 gruelling	ɡ ɹ ʊ ə l ɪ ŋ
 grues	ɡ ɹ uː z
+gruesome	ɡ ɹ uː s ʌ m
 gruff	ɡ ɹ ʌ f
 gruffish	ɡ ɹ ʌ f ɪ ʃ
 gruit	ɡ ɹ a ɪ t
@@ -29729,6 +30012,7 @@ guadalquivir	ɡ w ɑː d ə l k ɪ v ɪ ə
 guadeloupe	ɡ w ɑː d ə l uː p
 guadiana	ɡ w ɑː d ɪ ɑː n ə
 guaiacum	ɡ w a ɪ ə k ə m
+guaifenesin	ɡ w a ɪ f ɛ n ɪ s ɪ n
 guam	ɡ w æ m
 guam	ɡ w ɑː m
 guam	ɡ w ɒ m
@@ -29745,6 +30029,7 @@ guanines	ɡ w ɑː n iː n z
 guano	ɡ w ɑː n ə ʊ
 guanxi	k w a n ʃ i
 guanxi	ɡ w a n ʃ i
+guanylate	ɡ w ɑː n ɪ l e ɪ t
 guarana	ɡ w ə ɹ ɑː n ə
 guaranine	ɡ w ɑː ɹ ə n iː n
 guarantee	ɡ æ ɹ ə n t iː
@@ -29794,6 +30079,7 @@ guffaw	ɡ ə f ɔː
 guhr	ɡ ʊ ə ɹ
 gui	d ʒ iː j uː a ɪ
 gui	ɡ uː i
+guiana	ɡ i æ n ə
 guiche	ɡ iː ʃ
 guidance	ɡ a ɪ d ə n s
 guide	ɡ a ɪ d
@@ -29832,6 +30118,7 @@ guiltily	ɡ ɪ l t ɪ l i
 guilting	ɡ ɪ l t ɪ ŋ
 guiltless	ɡ ɪ l t l ə s
 guilts	ɡ ɪ l t s
+guilty	ɡ ɪ l t i
 guimpe	ɡ ɪ m p
 guinea	ɡ ɪ n i
 guinea	ɡ ɪ n iː
@@ -29901,6 +30188,7 @@ gumption	ɡ ʌ m p ʃ ə n
 gums	ɡ ʌ m z
 gumshoe	ɡ ʌ m ʃ uː
 gun	ɡ ʌ n
+guna	ɡ ʊ n ə
 gunai	ɡ ʌ n a ɪ
 gundelet	ɡ ʌ n d ə l ə t
 gunfire	ɡ ʌ n f ʌ ɪ ə
@@ -29959,6 +30247,8 @@ gusle	ɡ ʊ s l ə
 gusset	ɡ ʌ s ɪ t
 gust	ɡ ʌ s t
 gustable	ɡ ʌ s t ə b ə l
+gustatory	ɡ ʌ s t ə t ə ɹ i
+gustatory	ɡ ʌ s t ə t ɹ i
 gusted	ɡ ʌ s t ɪ d
 gustfulness	ɡ ʌ s t f ə l n ə s
 gusting	ɡ ʌ s t ɪ ŋ
@@ -29992,6 +30282,7 @@ guys	ɡ a ɪ z
 guyu	ɡ uː j uː
 guyver	ɡ a ɪ v ə
 guz	ɡ ʌ z
+guze	ɡ j uː z
 guzheng	ɡ uː d͡ʒ ʌ ŋ
 guzman	ɡ u z m ɑ n
 guzzle	ɡ ʌ z ə l
@@ -30004,6 +30295,8 @@ gwyneth	ɡ w ɪ n e θ
 gwyneth	ɡ w ɪ n ə θ
 gwyneth	ɡ w ɪ n ɪ θ
 gwyniad	ɡ w ɪ n iː ɑː ɹ d
+gyaru	ɡ j æ ɹ uː
+gyaru	ɡ j ɑː ɹ uː
 gybe	d͡ʒ a ɪ b
 gylany	ɡ ɪ l ə n i
 gyle	ɡ a ɪ l
@@ -30182,6 +30475,7 @@ hagging	h æ ɡ ɪ ŋ
 haggis	h æ ɡ ɪ s
 haggis	h ɑː d ʒ i s
 haggle	h æ ɡ ə l
+hagiographer	h æ ɡ i ɒ ɡ ɹ ə f ə
 hagiographic	h æ ɡ i o ʊ ɡ ɹ æ f ɪ k
 hagiography	h æ ɡ i ɒ ɡ ɹ ə f i
 hagiolatry	h a ɡ i ɒ l ə t ɹ i
@@ -30212,17 +30506,17 @@ haines	h e ɪ n z
 haint	h e ɪ n t
 haiphong	h a ɪ f ɒ ŋ
 hair	h ɛ ə
-hair	h ɛ ɚ
 hair	h ɛː
 hairbow	h ɛ ə ɹ b ə ʊ
 haircolor	h ɛ ə k ʌ l ɚ
 haircolor	h ɛ ɚ k ʌ l ɚ
+haircut	h ɛ ə ɹ k ʌ t
 hairdo	h ɛ ə d uː
 hairen	h ɛ ə ɹ ə n
 hairpin	h ɛ ə p ɪ n
 hairsbreadth	h ɛ ə ɹ z b ɹ ɛ d θ
 hairshirt	h ɛ ə ʃ ɜː t
-hairy	h ɛ ɚ i
+hairy	h ɛ ə ɹ i
 haitch	h e ɪ t͡ʃ
 haiti	h e ɪ t i
 haitian	h e ɪ ʃ ə n
@@ -30267,6 +30561,8 @@ halfpenny	h ɑː f p ɛ n i
 halfpennyworth	h ɛ ɪ p n ɪ w ə θ
 halfpennyworth	h ɛ ɪ p ə θ
 halfway	h ɑː f w e ɪ
+halibut	h æ l ɪ b ə t
+halibut	h ɒ l ɪ b ə t
 halicarnassus	h æ l ɪ k ɑ ɹ n æ s ə s
 halicore	h ə l ɪ k ə ɹ iː
 halide	h e ɪ l a ɪ d
@@ -30279,7 +30575,7 @@ hall	h ɔː l
 hallage	h ɔː l ɪ d͡ʒ
 hallatrow	h æ l ə t ɹ ə ʊ
 hallecret	h æ l ɪ k r ɛ t
-hallelujah	h æ l ɪ l j uː j ə
+hallelujah	h æ l ə l j uː j ə
 hallewell	h æ l ɪ w ɛ l
 halley	h æ l i
 hallmark	h ɔː l m ɑː k
@@ -30365,6 +30661,7 @@ hampton	h æ m p t ə n
 hamsa	h æ m s ə
 hamsa	h ɑ m s ə
 hamstring	h æ m s t ɹ ɪ ŋ
+hamtramck	h æ m t r æ m ɪ k
 hamulose	h æ m j ʊ l ə ʊ z
 han	h e ɪ n
 han	h æ n
@@ -30396,6 +30693,8 @@ handiwork	h æ n d i w ɜː k
 handkerchief	h æ ŋ k ə t ʃ iː f
 handkerchief	h æ ŋ k ə t ʃ ɪ f
 handlanger	h æ n d l æ ŋ ə
+handle	h æ n d l̩
+handle	h ɛ ə n d l̩
 handlebar	h æ n d ə l b ɑː
 handled	h æ n d l̩ d
 handler	h æ n d l ə
@@ -30511,6 +30810,8 @@ hard	h ɑː d
 hardcore	h ɑː ɹ d k ɔː ɹ
 harden	h ɑː d n̩
 hardened	h ɑː d n̩ d
+hardener	h ɑː d n̩ ə
+hardener	h ɑː d ə n ə
 harder	h ɑː d ə
 hardest	h ɑː d ɪ s t
 hardiment	h ɑː d ɪ m ə n t
@@ -30523,7 +30824,7 @@ hardware	h ɑː d w ɛ ə
 hardy	h ɑː d i
 hare	h ɛ ə
 hare	h ɛ ɚ
-hare	h ɛ ɹ
+hare	h ɛː
 harefield	h ɛː f iː l d
 harem	h ɑː ɹ iː m
 harem	h ɛ ə ɹ ə m
@@ -30568,6 +30869,8 @@ harping	h ɑː p ɪ ŋ
 harpoon	h ɑː p uː n
 harpsichord	h ɑː ɹ p s ɪ k ɔː ɹ d
 harpy	h ɑː p i
+harquebus	h ɑ ɹ k w ɪ b ʌ s
+harquebus	h ɑ ɹ k ɪ b ʌ s
 harrage	h æ ɹ ɪ d͡ʒ
 harras	h æ ɹ ə s
 harridan	h æ ɹ ɪ d ə n
@@ -30623,7 +30926,7 @@ hasn't	h æ z n̩ t
 hasp	h æ s p
 hasp	h ɑː s p
 hassium	h æ s i ə m
-hassle	h æ s l
+hassle	h æ s l̩
 hassock	h a s ə k
 hast	h æ s t
 hasta	h æ s t ə
@@ -30890,6 +31193,7 @@ hebridean	h ɛ b ɹ ɪ d iː ə n
 hebrides	h ɛ b ɹ ə d iː z
 hecate	h ɛ k ə t i
 hecatomb	h ɛ k ə t uː m
+hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hechsher	h ɛ k ʃ ə ɹ
 heck	h ɛ k
 hecka	h ɛ k ə
@@ -31075,6 +31379,7 @@ hemodynamic	h i m o ʊ d a ɪ n æ m ɪ k
 hemodynamics	h i m o ʊ d a ɪ n æ m ɪ k s
 hemopoietic	h iː m ə p ɔ ɪ ɛ t ɪ k
 hemorrhage	h ɛ m ə ɹ ɪ d͡ʒ
+hemorrhagiparous	h ɛ m ə r ɪ d͡ʒ ɪ p ə r ə s
 hemorrhoid	h ɛ m ə ɹ ɔ ɪ d
 hemorrhoid	h ɛ m ɹ ɔ ɪ d
 hemosiderosis	h iː m ə ʊ s ɪ d ə ɹ ə ʊ s ɪ s
@@ -31100,6 +31405,7 @@ hendecasyllabic	h ɛ n d ɛ k ə s ɪ l æ b ɪ k
 hendecasyllable	h ɛ n d ɛ k ə s ɪ l ə b l
 hendecasyllable	h ɛ n d ɪ k ə s ɪ l ə b l
 hendiadys	h ɛ n d a ɪ ə d ɪ s
+hendiatris	h ɛ n d a ɪ ə t ɹ ɪ s
 hendon	h ɛ n d ə n
 henge	h ɛ n d͡ʒ
 henna	h ɛ n ə
@@ -31189,6 +31495,7 @@ heritable	h ɛ ɹ ɪ t ə b l̩
 heritage	h ɛ ɹ ɪ t ɪ d͡ʒ
 herman	h ɜː m ə n
 hermaphroditus	h ɚ m æ f ɹ ə d a ɪ t ə s
+hermeneutical	h ɝ m ə n j uː t ɪ k ə l
 hermeneutics	h ɜː ɹ m ə n j uː t ɪ k s
 hermetic	h ə ɹ m ɛ t ɪ k
 hermeticism	h əː m ɛ t ɪ s ɪ z m̩
@@ -31237,6 +31544,7 @@ hertz	h ɜː t s
 herzegovina	h ɛ ə ɹ t s ə ɡ o ʊ v ɪ n ə
 herzegovina	h ɜ ɹ t s ə ɡ o ʊ v iː n ə
 hes	h iː z
+hes	h ɛ s
 hes	h ɛ z
 hesiod	h iː s i ə d
 hesiod	h ɛ s i ə d
@@ -31286,7 +31594,7 @@ heterophone	h ɛ t ə ɹ ə ʊ f ə ʊ n
 heterophony	h ɛ t ə ɹ ɒ f ə n i
 heteroradical	h ɛ t ɜ ɹ ə ɹ æ d ɪ k ə l
 heterorganic	h ɛ t ə ɹ ɔː ɹ ɡ æ n ɪ k
-heteroscedasticity	h ɛ t ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
+heteroscedasticity	h ɛ t ə ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
 heterosexual	h ɛ t ə ɹ ə s ɛ k ʃ u ə l
 heterosexual	h ɛ t ɹ ə s ɛ k ʃ u ə l
 heterotroph	h ɛ t ə ɹ ə ʊ t ɹ ɒ f
@@ -31309,9 +31617,11 @@ hew	h j uː
 hewed	h j uː d
 hewing	h j uː ɪ ŋ
 hewings	h j uː ɪ ŋ z
+hewitt	h j uː ɪ t
 hewn	h j uː n
 hews	h j uː z
 hex	h ɛ k s
+hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hexad	h ɛ k s æ d
 hexadecile	h ɛ k s ə d ɛ s a ɪ ɫ
 hexadecimal	h ɛ k s ə d ɛ s ɪ m ə l
@@ -31604,6 +31914,8 @@ hitchy	h ɪ t͡ʃ i
 hithe	h ʌ ɪ ð
 hither	h ɪ ð ə
 hitherto	h ɪ ð ə t uː
+hitman	h ɪ t m æː n
+hitman	h ɪ t m ə n
 hits	h ɪ t s
 hitter	h ɪ t ə ɹ
 hitting	h ɪ t ɪ ŋ
@@ -31681,6 +31993,7 @@ hogshead	h ɒ ɡ z h ɛ d
 hogwarts	h ɒ ɡ w ɔː t s
 hogwash	h ɒ ɡ w ɒ ʃ
 hohenzollern	h ə ʊ ə n z ɒ l ə n
+hohhot	h o ʊ h ɒ t
 hoik	h ɔ ɪ k
 hoise	h ɔ ɪ z
 hoisin	h ɔ ɪ s ɪ n
@@ -31788,6 +32101,7 @@ homie	h ə ʊ m i
 homiletical	h ɒ m ɪ l ɛ t ɪ k ə l
 homily	h ɒ m ɪ l i
 homing	h ə ʊ m ɪ ŋ
+hominy	h ɒ m ɪ n i
 hommage	o ʊ m ɑː ʒ
 hommage	ɒ m ɑː ʒ
 homo	h ɒ m ə ʊ
@@ -31873,6 +32187,7 @@ honeymoon	h ʌ n i m uː n
 honeymooner	h ʌ n i m u n ə
 honeys	h ʌ n i z
 honeysuckle	h ʌ n ɪ s ʌ k ə l
+honfidence	h ʌ n f ɪ d ə n s
 hongbao	h ɒ ŋ b a ʊ
 hongi	h ɒ ŋ i
 hongkong	h ɒ ŋ k ɒ ŋ
@@ -31890,6 +32205,7 @@ honor	ɒ n ə
 honorable	ɒ n ə ɹ ə b l̩
 honorable	ɒ n ɹ ə b l̩
 honorarium	ɒ n ə ɹ ɛ ɹ i ə m
+honoree	ɒ n ə iː
 honorific	ɒ n ə ɹ ɪ f ɪ k
 honorificabilitudinitatibus	ɒ n ə ɹ ɪ f ɪ k ə b ɪ l ɪ t j uː d ɪ n ɪ t e ɪ t ɪ b ə s
 honorificabilitudinity	h ɒ n ɒ ɹ ɪ f ɪ k ə b ɪ l ɪ t j uː d ɪ n ɪ t ɪ
@@ -31918,6 +32234,7 @@ hoofing	h ʊ f ɪ ŋ
 hoofy	h uː f i
 hook	h ʊ k
 hookah	h ʊ k ə
+hookaroon	h ʊ k ə ɹ uː n
 hooked	h ʊ k t
 hooker	h ʊ k ə ɹ
 hooking	h ʊ k ɪ ŋ
@@ -32039,8 +32356,6 @@ horsemen	h ɔː s m ə n
 horsepower	h ɔː s p a ʊ ə
 horseradish	h ɔː s ɹ æ d ɪ ʃ
 horseradished	h ɔː s ɹ æ d ɪ ʃ t
-horses	h ɔ r s ə z
-horses	h ɔ r s ɪ z
 horseshoe	h ɔː s ʃ uː
 horseshoe	h ɔː ʃ uː
 horsetail	h ɔː ɹ s t e ɪ l
@@ -32161,6 +32476,7 @@ hoveller	h ɒ v ə l ə ɹ
 hoven	h o ʊ v ə n
 hoven	h uː v ə n
 hover	h ɒ v ə
+hover	h ʌ v ə
 hoverboard	h ɒ v ə b ɔ ɹ d
 hovercraft	h ɒ v ə k ɹ æ f t
 hovercraft	h ɒ v ə k ɹ ɑː f t
@@ -32344,7 +32660,6 @@ humpback	h ʌ m p b æ k
 humped	h ʌ m p t
 humper	h ʌ m p ə
 humph	h ə m f
-humph	h ʌ m f
 humphrey	h ʌ m f ɹ i
 humping	h ʌ m p ɪ ŋ
 humpings	h ʌ m p ɪ ŋ z
@@ -32483,7 +32798,7 @@ hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ i ə
 hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ ə
 hydrant	h a ɪ d ɹ ə n t
 hydrargyron	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ɒ n
-hydrargyrum	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ə m
+hydrargyrum	h a ɪ d ɹ ɑː ɹ d͡ʒ ɪ ɹ ə m
 hydrate	h a ɪ d ɹ e ɪ t
 hydraulic	h a ɪ d ɹ ɒ l ɪ k
 hydraulicking	h ʌ ɪ d ɹ ɒ l ɪ k ɪ ŋ
@@ -32515,6 +32830,7 @@ hydroponic	h ʌ ɪ d ɹ ə p ɒ n ɪ k
 hydroponics	h a ɪ d ɹ ə ʊ p ɒ n ɪ k s
 hydropsy	h a ɪ d ɹ ɒ p s i
 hydroptic	h a ɪ d ɹ ɒ p t ɪ k
+hydroquinone	h a ɪ d ɹ ə k w ɪ n ə ʊ n
 hydrostatic	h a ɪ d ɹ ə ʊ s t æ t ɪ k
 hydrovolcanic	h a ɪ d ɹ ə v ɒ l k æ n ɪ k
 hydroxamate	h a ɪ d ɹ ɒ k s ə m e ɪ t
@@ -32555,6 +32871,7 @@ hymenopteran	h ʌ ɪ m ɪ n ɒ p t ə ɹ ə n
 hymie	h a ɪ m i
 hymn	h ɪ m
 hymnal	h ɪ m n ə l
+hymnic	h ɪ m n ɪ k
 hymnody	h ɪ m n ə d i
 hyoid	h a ɪ ɔ ɪ d
 hyoidal	h a ɪ ɔ ɪ d ə l
@@ -32612,6 +32929,7 @@ hypermyoglobinemia	h a ɪ p ə m a ɪ ə ʊ ɡ l ə ʊ b ɪ n iː m ɪ ə
 hypernatremia	h a ɪ p ə n ə t ɹ iː m i ə
 hypernatremic	h a ɪ p ə n ə t ɹ iː m ɪ k
 hypernym	h a ɪ p ə n ɪ m
+hyperon	h a ɪ p ə ɹ ɒ n
 hyperoodon	h a ɪ p ə ɹ ə ʊ ə d ɒ n
 hyperparasite	h a ɪ p ə p æ ɹ ə s a ɪ t
 hyperplasia	h a ɪ p ɚ p l e ɪ ʒ ə
@@ -32645,9 +32963,11 @@ hyphenation	h a ɪ f ə n e ɪ ʃ ə n
 hyphy	h a ɪ f iː
 hyping	h a ɪ p ɪ ŋ
 hypnagogic	h ɪ p n ə ɡ ɒ d ʒ ɪ k
+hypnic	h ɪ p n ɪ k
 hypnos	h ɪ p n o ʊ s
 hypnos	h ɪ p n ɒ s
 hypnotic	h ɪ p n ɒ t ɪ k
+hypnotism	h ɪ p n ə t ɪ z ə m
 hypnotist	h ɪ p n ə t ɪ s t
 hypnotize	h ɪ p n ə t a ɪ̯ z
 hypo	h a ɪ p ə ʊ
@@ -32671,6 +32991,7 @@ hypogeum	h ʌ ɪ p ə d͡ʒ iː ə m
 hypoglossal	h ʌ ɪ p ə ʊ ɡ l ɒ s l̩
 hypoglossal	h ʌ ɪ p ə ʊ ɡ l ɒ s ə l
 hypoglycemic	h a ɪ p ə ʊ ɡ l a ɪ s iː m ɪ k
+hypohalous	h a ɪ p ə ʊ h e ɪ l ə s
 hyponatremia	h ʌ ɪ p ə ʊ n ə t ɹ iː m i ə
 hyponym	h a ɪ p ə n ɪ m
 hyponym	h a ɪ p ə ʊ n ɪ m
@@ -32698,6 +33019,7 @@ hypotrichosis	h a ɪ p ə ʊ t ɹ a ɪ k ə ʊ s ɪ s
 hypotrochoid	h a ɪ p ə ʊ t ɹ ə ʊ k ɔ ɪ d
 hypsipyle	h ɪ p s ɪ p ɪ l iː
 hypsometry	h ɪ p s ɒ m ə t ɹ i
+hypural	h a ɪ p j ʊ ə ɹ ə l
 hyraceum	h a ɪ r e ɪ s i ə m
 hyrax	h a ɪ ɹ æ k s
 hyssop	h ɪ s ə p
@@ -32787,6 +33109,7 @@ ichnology	ɪ k n ɒ l ə d͡ʒ ɪ
 ichnusaite	ɪ k n u s ə a ɪ t
 ichor	a ɪ k ɔː
 ichor	ɪ k ə
+ichthyic	ɪ k θ iː ɪ k
 ichthyology	ɪ k θ i ɒ l ə d͡ʒ i
 ichthyonym	ɪ k θ i ə n ɪ m
 ichthyosaur	ɪ k θ i ə s ɔː ɹ
@@ -32813,6 +33136,7 @@ icosahedra	a ɪ k ɒ s ə h iː d ɹ ə
 icosahedron	a ɪ k o ʊ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɒ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɔ s ə h iː d ɹ ə n
+icositetrachoron	a ɪ k o ʊ s ɪ t ɛ t ɹ ə k o ʊ ɹ ɔ n
 icq	a ɪ s iː k j uː
 ictus	ɪ k t uː s
 ictus	ɪ k t ə s
@@ -32843,6 +33167,7 @@ ident	a ɪ d ɛ n t
 identic	a ɪ d ɛ n t ɪ k
 identical	a ɪ d ɛ n t ɪ k l̩
 identical	ɪ d ɛ n t ɪ k l̩
+identically	a ɪ d ɛ n t ɪ k ə l i
 identification	a ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identification	ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identified	a ɪ d ɛ n t ɪ f a ɪ d
@@ -32889,6 +33214,7 @@ idioticon	ɪ d ɪ ə ʊ t ɪ k ə n
 idiotropic	ɪ d ɪ ə t ɹ ə ʊ p ɪ k
 idiotropic	ɪ d ɪ ə ʊ t ɹ ɒ p ɪ k
 idiots	ɪ d iː ə t s
+idjit	ɪ d ʒ ɪ t
 idle	a ɪ d ə l
 idleness	a ɪ d ə l n ə s
 idlesse	a ɪ d l ə s
@@ -32916,6 +33242,7 @@ ifrit	ɪ f ɹ iː t
 ifs	ɪ f s
 iftar	ɪ f t ɑː ɹ
 igbo	iː b ə ʊ
+ight	a ɪ t
 igloo	ɪ ɡ l uː
 ignatius	ɪ ɡ n e ɪ ʃ ə s
 igneous	ɪ ɡ n i ə s
@@ -33063,6 +33390,7 @@ imbue	ɪ m b j uː
 imburse	ɪ m b əː s
 img	ɪ m ɪ d͡ʒ
 imide	a ɪ m a ɪ d
+imine	ɪ m iː n
 imipramine	ɪ m ɪ p ɹ ə m iː n
 immaculate	ɪ m æ k j ə l ɪ t
 immanant	ɪ m ə n ə n t
@@ -33074,6 +33402,7 @@ immarcescible	ɪ m ɑː ɹ s ɛ s ɪ b ə l
 immature	ɪ m ə t j ʊ ə ɹ
 immature	ɪ m ə t͡ʃ ə ɹ
 immature	ɪ m ə t͡ʃ ʊ ə ɹ
+immaturely	ɪ m ə t j ʊ ə ɹ l i
 immaturity	ɪ m ə t͡ʃ ʊ ɹ ɪ t i
 immeability	ɪ m i ə b ɪ l ɪ t i
 immeasurability	ɪ m ɛ ʒ ə ɹ ə b ɪ l ə t i
@@ -33136,6 +33465,7 @@ impactful	ɪ m p æ k t f ə l
 impaction	ɪ m p æ k ʃ ə n
 impactor	ɪ m p æ k t ə
 impair	ɪ m p ɛ ə
+impairment	ɪ m p ɛ ə ɹ m ə n t
 impala	ɪ m p ɑː l ə
 impale	ɪ m p e ɪ l
 impaled	ɪ m p e ɪ l d
@@ -33235,6 +33565,7 @@ implied	ɪ m p l a ɪ d
 implies	ɪ m p l a ɪ z
 implike	ɪ m p l a ɪ k
 implore	ɪ m p l ɔː
+implosion	ɪ m p l ə ʊ ʒ ə n
 imply	ɪ m p l a ɪ
 impolite	ɪ m p ə l a ɪ t
 impolitic	ɪ m p ɒ l ɪ t ɪ k
@@ -33629,6 +33960,7 @@ indirection	ɪ n d ɪ ɹ ɛ k ʃ ə n
 indirectly	ɪ n d a ɪ ɹ ɛ k t l i
 indirectly	ɪ n d ɪ ɹ ɛ k t l i
 indiscovery	ɪ n d ɪ s k ʌ v ə ɹ i
+indiscretion	ɪ n d ɪ s k ɹ ɛ ʃ ə n
 indiscriminate	ɪ n d ɪ s k ɹ ɪ m ɪ n ə t
 indispensable	ɪ n d ɪ s p ɛ n s ə b ə l
 indisputable	ɪ n d ɪ s p j uː t ə b ə ɫ
@@ -33736,6 +34068,7 @@ inexplicable	ɪ n ɪ k s p l ɪ k ə b l̩
 inexpugnable	ɪ n ɛ k s p ʌ ɡ n ə b ə l
 inexpugnable	ɪ n ɪ k s p ʌ ɡ n ə b ə l
 infallible	ɪ n f æ l ɪ b l̩
+infame	ɪ n f e ɪ m
 infamous	ɪ n f ə m ə s
 infamy	ɪ n f ə m i
 infancy	ɪ n f ə n s i
@@ -33770,7 +34103,6 @@ infibulation	ɪ n f ɪ b j ʊ l e ɪ ʃ ə n
 infidel	ɪ n f ə d l̩
 infidel	ɪ n f ə d ɛ l
 infidelity	ɪ n f ɪ d ɛ l ɪ t i
-infidelophobia	ɪ n f ə d ɛ l ə f ə ʊ b i ə
 infiltrate	ɪ n f ɪ l t ɹ e ɪ t
 infiltration	ɪ n f ɪ l t ɹ e ɪ ʃ ə n
 infiltrationism	ɪ n f ɪ l t ɹ e ɪ ʃ ə n ɪ z m̩
@@ -33868,6 +34200,7 @@ ingest	ɪ n d͡ʒ ɛ s t
 ingestion	ɪ n d͡ʒ ɛ s t͡ʃ ə n
 ingle	ɪ ŋ ɡ l̩
 ingle	ɪ ŋ ɡ ə l
+inglenook	ɪ ŋ ɡ ə l n ʊ k
 inglorious	ɪ n ɡ l o ʊ ɹ i ə s
 inglorious	ɪ n ɡ l ɔ ɹ i ə s
 ingot	ɪ ŋ ɡ ə t
@@ -33882,6 +34215,7 @@ ingredient	ɪ n ɡ ɹ iː d i ə n t
 ingression	ɪ n ɡ ɹ ɛ ʃ ə n
 ingrew	ɪ n ɡ r uː
 ingrow	ɪ n ɡ ɹ ə ʊ
+ingrown	ɪ n ɡ ɹ ə ʊ n
 ingrowth	ɪ n ɡ r ə ʊ θ
 inguinal	ɪ ŋ ɡ w ɪ n ə l
 ingurgitate	ɪ n ɡ ɜː d ʒ ɪ t e ɪ t
@@ -33896,13 +34230,17 @@ inhabitiveness	ɪ n h æ b ɪ t ɪ v n ə s
 inhalation	ɪ n h ə l e ɪ ʃ ə n
 inhere	ɪ n h ɪ ə
 inherence	ɪ n h ɪ ə ɹ ə n s
+inherent	ɪ n h ɛ ɹ ə n t
+inherent	ɪ n h ɪ ə ɹ ə n t
 inherit	ɪ n h ɛ ɹ ɪ t
 inheritance	ɪ n h ɛ ɹ ə t ə n s
 inherited	ɪ n h ɛ ɹ ɪ t ɪ d
 inhiation	ɪ n h a ɪ e ɪ ʃ ə n
+inhibit	ɪ n h ɪ b ɪ t
 inhibition	ɪ n h ɪ b ɪ ʃ ə n
 inhibition	ɪ n ɪ b ɪ ʃ ə n
 inhofe	ɪ n h o ʊ f
+inhospitable	ɪ n h ɒ s p ɪ t ə b ə l
 inhuman	ɪ n h j uː m ə n
 inhumane	ɪ n h j uː m e ɪ n
 inhumanly	ɪ n h j uː m ə n l i
@@ -33931,10 +34269,11 @@ injudiciously	ɪ n d͡ʒ ʊ d ɪ ʃ ə s l ɪ
 injunction	ɪ n d͡ʒ ʌ n k ʃ ə n
 injure	ɪ n d ʒ ə
 injured	ɪ n d ʒ ə d
+injuria	ɪ n d ʒ ʊ ə ɹ i ə
 injurious	ɪ n d ʒ ɔː ɹ ɪ ə s
 injurious	ɪ n d ʒ ʊ ə ɹ ɪ ə s
-injury	ɪ n d ʒ ə ɹ i
-injury	ɪ n d ʒ ɹ i
+injury	ɪ n d͡ʒ ə ɹ i
+injury	ɪ n d͡ʒ ɹ i
 ink	ɪ ŋ k
 inker	ɪ ŋ k ə ɹ
 inkhorn	ɪ ŋ k h ɔː ɹ n
@@ -33977,31 +34316,41 @@ innovation	ɪ n ə v e ɪ ʃ ə n
 innovative	ɪ n n ɒ v ə t ɪ v
 innovative	ɪ n ə v ə t ɪ v
 innovative	ɪ n ə ʊ v ə t ɪ v
+innovator	ɪ n ə v e ɪ t ə ɹ
 innovent	ɪ n ə v ɛ n t
 innovented	ɪ n ə v ɛ n t ɪ d
 innovention	ɪ n ə v ɛ n ʃ ə n
 innoventor	ɪ n ə v ɛ n t ə
 inns	ɪ n z
 innuendis	ɪ n j uː ɛ n d iː s
+innuendo	ɪ n j u ɛ n d ə ʊ
 innumerable	ɪ n j uː m ə ɹ ə b ə l
 innumerous	ɪ n n j u m ɝ ə s
+inoculate	ɪ n ɒ k j u l e ɪ t
 inoculation	ɪ n ɒ k j ʊ l e ɪ ʃ ə n
 inoculent	ɪ n ɒ k j ʊ l ə n t
+inodiate	ɪ n ə ʊ d i e ɪ t
 inoptimal	ɪ n ɒ p t ɪ m ə l
+inordinate	ɪ n ɔː d ɪ n ə t
+inorganic	ɪ n ɔː ɡ æ n ɪ k
 inorganity	ɪ n ɔː ɹ ɡ æ n ɪ t i
 inosculate	ɪ n ɒ s k j ʊ l e ɪ t
 inosite	ɪ n ə s ʌ ɪ t
+inositol	ʌ ɪ n ə ʊ s ɪ t ɒ l
 inotropic	ɪ n ə t ɹ ɒ p ɪ k
 inotropic	ɪ n ə t ɹ ə ʊ p ɪ k
 inpat	ɪ n p æ t
+input	ɪ n p ʊ t
 inquest	ɪ ŋ k w ɛ s t
 inquiet	ɪ ŋ k w a ɪ ə t
 inquiline	ɪ ŋ k w ɪ l a ɪ n
 inquinate	ɪ n k w ɪ n e ɪ t
+inquiration	ɪ ŋ k w ɪ ɹ e ɪ ʃ ə n
 inquire	ɪ n k w a ɪ ə
 inquired	ɪ n k w a ɪ ə d
+inquirer	ɪ n k w a ɪ ə ɹ ə ɹ
 inquiries	ɪ n k w a ɪ ə ɹ i z
-inquiry	ɪ n k w a ɪ ə ɹ i
+inquiring	ɪ n k w a ɪ ə ɹ ɪ ŋ
 inquisition	ɪ ŋ k w ɪ z ɪ ʃ ə n
 inquisitive	ɪ ŋ k w ɪ z ə t ɪ v
 inroad	ɪ n ɹ ə ʊ d
@@ -34022,20 +34371,26 @@ insect	ɪ n s ɛ k t
 insectivore	ɪ n s ɛ k t ə v ɔː
 insectivorous	ɪ n s ɛ k t ɪ v ə ɹ ə s
 insects	ɪ n s ɛ k t s
+insecure	ɪ n s ə k j ɔː ɹ
+insecure	ɪ n s ə k j ʊ ə ɹ
 inselberg	ɪ n s ə l b ɜː ɡ
 inseminate	ɪ n s ɛ m ɪ n e ɪ t
+insensate	ɪ n s ɛ n s ə t
 insensible	ɪ n s ɛ n s ɪ b l̩
 inseparable	i n s ɛ p ə ɹ ə b l
 insert	ɪ n s ɜː t
 inserted	ɪ n s ɜː t ɪ d
 insession	ɪ n s ɛ ʃ ə n
+insessorial	ɪ n s ɛ s ɔː ɹ ɪ ə l
 inset	ɪ n s ɛ t
+inship	i n ʃ i p
 inside	ɪ n s a ɪ d
 insides	ɪ n s a ɪ d z
 insidious	ɪ n s ɪ d i ə s
 insidiously	ɪ n s ɪ d i ə s l i
 insight	ɪ n s a ɪ t
 insightful	ɪ n s a ɪ t f ə l
+insignia	ɪ n s ɪ ɡ n i ə
 insignificant	ɪ n s ɪ ɡ n ɪ f ɪ k ə n t
 insinuate	ɪ n s ɪ n j u e ɪ t
 insinuation	ɪ n s ɪ n j u e ɪ ʃ ə n
@@ -34043,8 +34398,10 @@ insipid	ɪ n s ɪ p ɪ d
 insipience	ɪ n s ɪ p i ə n s
 insist	ɪ n s ɪ s t
 insisted	ɪ n s ɪ s t ɪ d
+insistence	ɪ n s ɪ s t ə n s
 insistent	ɪ n s ɪ s t ə n t
 insisting	ɪ n s ɪ s t ɪ ŋ
+insists	ɪ n s ɪ s t s
 insofar	ɪ n s ə ʊ f ɑː ɹ
 insole	ɪ n s ə ʊ l
 insolence	ɪ n s ə l ə n s
@@ -34062,11 +34419,13 @@ inspect	ɪ n s p ɛ k t
 inspection	ɪ n s p ɛ k ʃ ə n
 inspector	ɪ n s p ɛ k t ə
 inspiration	ɪ n s p ə ɹ e ɪ ʃ ə n
+inspirational	ɪ n s p ə ɹ e ɪ ʃ ə n ə l
 inspire	ɪ n s p a ɪ ə ɹ
 inspired	ɪ n s p a ɪ ə d
 inspiring	ɪ n s p a ɪ ə ɹ ɪ ŋ
 inspissate	ɪ n s p ɪ s e ɪ t
 inspo	ɪ n s p ə ʊ
+insta	ɪ n s t ə
 instadeath	ɪ n s t ə d ɛ θ
 instagram	ɪ n s t ə ɡ ɹ æ m
 instagrammable	ɪ n s t ə ɡ r æ m ə b ə l
@@ -34082,7 +34441,9 @@ instantaneous	ɪ n s t ə n t e ɪ n i ə s
 instanter	ɪ n s t a n t ə
 instanter	ɪ n s t æ n t ə
 instantial	ɪ n s t æ n ʃ ə l
+instantially	ɪ n s t æ n ʃ ə l i
 instantiate	ɪ n s t æ n ʃ i e ɪ t
+instantiation	ɪ n s t æ n ʃ i e ɪ ʃ ə n
 instantly	ɪ n s t ə n t l i
 instar	ɪ n s t ɑː
 instate	ɪ n s t e ɪ t
@@ -34095,6 +34456,7 @@ instill	ɪ n s t ɪ l
 instinct	ɪ n s t ɪ ŋ k t
 instinctive	ɪ n s t ɪ ŋ k t ɪ v
 instinctively	ɪ n s t ɪ ŋ k t ɪ v l i
+instincts	ɪ n s t ɪ ŋ k t s
 instinctual	ɪ n s t ɪ ŋ k t j uː ə l
 instinctual	ɪ n s t ɪ ŋ k t͡ʃ uː ə l
 instinctual	ɪ n s t ɪ ŋ k t͡ʃ ə l
@@ -34158,9 +34520,10 @@ insusurration	ɪ n s uː s ə ɹ e ɪ ʃ ə n
 int'resting	ɪ n t ɹ ɛ s t ɪ ŋ
 intact	ɪ n t æ k t
 intaglio	ɪ n t æ l j ə ʊ
+intaglio	ɪ n t ɑ l i ə ʊ
 intaglio	ɪ n t ɑ l j ə ʊ
 intake	ɪ n t e ɪ k
-intangible	ɪ n t a n d ʒ ɪ b l
+intangible	ɪ n t æ n d͡ʒ ɪ b ə l
 intarweb	ɪ n t ɑ ɚ w ɛ b
 intarweb	ɪ n t ɑ ɹ w ɛ b
 intarweb	ɪ n t ɑː w ɛ b
@@ -34187,6 +34550,8 @@ intelligence	ɪ n t ɛ l ɪ d͡ʒ ə n s
 intelligent	ɪ n t ɛ l ɪ d͡ʒ ə n t
 intelligentsia	ɪ n t ɛ l ɪ d͡ʒ ɛ n t s ɪ ə
 intelligentsia	ɪ n t ɛ l ɪ ɡ ɛ n t s ɪ ə
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ə t i
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ɪ t i
 intemperance	ɪ n t ɛ m p ɛ ɹ ə n s
 intempestive	ɪ n t ɛ m p ɛ s t ɪ v
 intempestivity	ɪ n t ɛ m p ɛ s t ɪ v ɪ t ɪ
@@ -34206,6 +34571,7 @@ intention	ɪ n t ɛ n ʃ ə n
 intentional	ɪ n t ɛ n ʃ ə n ə l
 intentions	ɪ n t ɛ n ʃ ə n z
 intentive	ɪ n t ɛ n t ɪ v
+intentively	ɪ n t ɛ n t ɪ v l i
 intently	ɪ n t ɛ n t l i
 inter	ɪ n t ɜː ɹ
 interabled	ɪ n t ɚ e ɪ b l̩ d
@@ -34215,6 +34581,7 @@ interactive	ɪ n t ə ɹ æ k t ɪ v
 interactor	ɪ n t ə ɹ æ k t ə
 interacts	ɪ n t ə ɹ æ k t s
 interagency	ɪ n t ə ɹ e ɪ d͡ʒ ə n s i
+interaxillary	ɪ n t ə ɹ æ k s ɪ l ə ɹ i
 interbred	ɪ n t ɚ b ɹ ɛ d
 interbreed	ɪ n t e ɹ b ɹ i d
 intercalate	ɪ n t ə k ə l e ɪ t
@@ -34252,7 +34619,7 @@ interference	ɪ n t ə ɹ f ɪ ə ɹ ə n s
 interfrastically	ɪ n t ɚ f ɹ æ s t ɪ k ʌ l i
 interfulgent	ɪ n t ə f ʌ l d ʒ ə n t
 interim	ɪ n t ə ɹ ɪ m
-interior	ɪ n t ɪ ə ɹ iː ə
+interior	ɪ n t ɪ ə ɹ ɪ ə
 interiorscaper	ɪ n t ɪ ə ɹ ɪ ə ɹ s k e ɪ p ə ɹ
 interisland	ɪ n t ə ɹ a ɪ l ə n d
 interjacence	ɪ n t ə ɹ d͡ʒ e ɪ s ə n s
@@ -34267,6 +34634,7 @@ interlard	ɪ n t ə l ɑː d
 interlingua	ɪ n t ə ɹ l ɪ ŋ ɡ w ə
 interlocutor	ɪ n t ə l ɒ k j ʊ t ə
 interlocutory	ɪ n t ə ɹ l ə k j uː t ə ɹ i
+interloper	ɪ n t ə l ə ʊ̯ p ə
 interlude	ɪ n t ə ɹ l j uː d
 interlude	ɪ n t ə ɹ l uː d
 intermarry	ɪ n t ə ɹ m æ ɹ i
@@ -34311,6 +34679,7 @@ interoperability	ɪ n t ə ɹ ɒ p ə ɹ ə b ɪ l ə t i
 interosseus	ɪ n t ə ɹ ɒ s i ə s
 interpellate	ɪ n t ə ɹ p ɛ l e ɪ t
 interpellate	ɪ n t ɜ ɹ p ə l e ɪ t
+interpetiolar	ɪ n t ə ɹ p ɛ t i ə ʊ l ə ɹ
 interphrasally	ɪ n t ɚ f ɹ e ɪ z ʌ l i
 interphrasic	ɪ n t ɚ f ɹ æ s ɪ k
 interphrastic	ɪ n t ɚ f ɹ æ s t ɪ k
@@ -34340,6 +34709,7 @@ intersectionality	ɪ n t ə s ɛ k ʃ ə n æ l ɪ t i
 intersex	ɪ n t ə s ɛ k s
 interslavic	ɪ n t ɚ s l ɑː v ɪ k
 intersow	ɪ n t ə ɹ s ə ʊ
+interspecial	ɪ n t ə s p iː ʃ i ə l
 interspecific	ɪ n t ə s p ə s ɪ f ɪ k
 intersperse	ɪ n t ə ɹ s p ɜː ɹ s
 interstice	ɪ n t ɜː s t ɪ s
@@ -34508,7 +34878,7 @@ invert	ɪ n v ɜː t
 invertebrate	ɪ n v əː t ɪ b r ə t
 invest	ɪ n v ɛ s t
 invested	ɪ n v ɛ s t ɪ d
-investigation	ɪ n v ɛ s t ə ɡ e ɪ ʃ ə n
+investigation	ɪ n v ɛ s t ɪ ɡ e ɪ ʃ ə n
 investigative	ɪ n v ɛ s t ɪ ɡ e ɪ t ɪ v
 investigative	ɪ n v ɛ s t ɪ ɡ ə t ɪ v
 investment	ɪ n v ɛ s m ə n t
@@ -34522,6 +34892,8 @@ invidious	ɪ n v ɪ d i ə s
 invigilator	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ə ɹ
 invigilatrix	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ɹ ɪ k s
 invigorate	ɪ n v ɪ ɡ ə ɹ e ɪ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə t i
+invincible	ɪ n v ɪ n s ə b ə l
 invincible	ɪ n v ɪ n s ɪ b ə l
 inviolable	ɪ n v a ɪ ə l ə b l̩
 inviolate	ɪ n v a ɪ ə l ə t
@@ -34538,6 +34910,7 @@ inviting	ɪ n v a ɪ t ɪ ŋ
 invocation	ɪ n v o ʊ k e ɪ ʃ ə n
 invoice	ɪ n v ɔ ɪ s
 invoiceability	ɪ n v ɔ ɪ s ə b ɪ l ɪ t i
+invoiceable	ɪ n v ɔ ɪ s ə b l̩
 invoke	ɪ n v ə ʊ k
 involucre	ɪ n v ə l uː k ə ɹ
 involuntarily	ɪ n v ɒ l ə n t ɹ ɪ l i
@@ -34556,6 +34929,7 @@ iodide	ɑ ɪ ə d ɑ ɪ d
 iodochlorhydroxyquin	a ɪ ɒ d ə ʊ k l ɔː ɹ h a ɪ d ɹ ɒ k s ɪ k w ɪ n
 iododeoxyuridine	a ɪ ɒ d ə ʊ d iː ɒ k s i j ʊ ə ɹ ɪ d iː n
 iodophenpropit	a ɪ ɒ d ə ʊ f ɛ n p ɹ ə p ɪ t
+iolo	j ɒ l ə ʊ
 ion	a ɪ o ʊ n
 ion	a ɪ ɒ n
 ion	a ɪ ə n
@@ -34568,6 +34942,7 @@ ionization	a ɪ ə n ɪ z e ɪ ʃ ə n
 ionize	a ɪ ə n a ɪ z
 iopidine	a ɪ ɒ p ɪ d iː n
 iopidine	a ɪ ɒ p ɪ d ɪ n
+iota	a ɪ ə ʊ t ə
 iotation	a ɪ ə ʊ t e ɪ ʃ ə n
 iotize	a ɪ ə t a ɪ z
 ipa	a ɪ p iː e ɪ
@@ -34577,9 +34952,12 @@ iphigenia	ɪ f ɪ d͡ʒ iː n ɪ ə
 iphigenia	ɪ f ɪ d͡ʒ ɪ n a ɪ ə
 ipof	a ɪ p ɒ f
 ipof	ɪ p ɒ f
+iproclozide	a ɪ p ɹ ə ʊ k l ə z a ɪ d
 ipsapirone	ɪ p s ə p a ɪ ɹ ə ʊ n
+ipsative	ɪ p s ə t ɪ v
 ipsedixitism	ɪ p s iː d ɪ k s ɪ t ɪ z ə m
 ipseity	ɪ p s iː ɪ t i
+ipsilateral	ɪ p s ɪ l æ t ə ɹ ə l
 ipswich	ɪ p s w ɪ t͡ʃ
 ipu	iː p uː
 iqaluit	ɪ k æ l ʊ ɪ t
@@ -34603,7 +34981,6 @@ ireland	a ɪ ə ɹ l ə n d
 irenarch	a ɪ ɹ ɪ n ɑː ɹ k
 irene	a ɪ ɹ iː n
 irenic	a ɪ ɹ iː n ɪ k
-irenic	a ɪ ɹ ɛ n ɪ k
 iri	a ɪ ɑː ɹ a ɪ
 iridal	ʌ ɪ ɹ ɪ d ə l
 irides	a ɪ ɹ ɪ d i z
@@ -34631,6 +35008,7 @@ irony	a ɪ ə ɹ ə n i
 iroquois	ɪ ɹ ə k w ɔ ɪ
 iroquois	ɪ ɹ ə k ɔ ɪ
 irp	ɜː ɹ p
+irradicate	ɪ ɹ æ d ɪ k e ɪ t
 irrational	ɪ ɹ æ ʃ ə n ə l
 irrawaddy	ɪ ɹ ə w ɑ d i
 irrealis	ɪ ɹ i æ l ɪ s
@@ -34679,6 +35057,7 @@ irritated	ɪ ɹ ɪ t e ɪ t ɪ d
 irritation	ɪ ɹ ɪ t e ɪ ʃ ə n
 irruent	ɪ ɹ ɪ ʊ ə n t
 irrumation	ɪ ɹ ʊ m e i ʃ ə n
+irtysh	ɪ ə ɹ t ɪ ʃ
 irukandji	ɪ ɹ ə k æ n d͡ʒ i
 irv	ɜː v
 irvine	ɜ ɹ v a ɪ n
@@ -34741,6 +35120,8 @@ isleworth	ʌ ɪ z ə l w ɜː θ
 islington	ɪ z l ɪ ŋ t ə n
 islingtonian	ɪ z l ɪ ŋ t ə ʊ n i ə n
 ism	ɪ z ə m
+ismael	ɪ z m e ɪ l
+ismael	ɪ z m e ɪ ə l
 ismahel	ɪ z m ə h ɛ l
 ismaili	ɪ s m ɑː i l i
 ismaili	ɪ s m ʌ ɪ iː l i
@@ -34790,6 +35171,7 @@ israel	ɪ z ɹ i ə l
 israeli	ɪ z ɹ e ɪ l i
 israelite	ɪ z ɹ e ɪ ə l a ɪ t
 israelite	ɪ z ɹ i ə l a ɪ t
+israelite	ɪ z ɹ ɪ l a ɪ t
 isro	ɪ s ɹ ə ʊ
 issue	ɪ s j uː
 issue	ɪ ʃ j uː
@@ -34907,6 +35289,7 @@ jabs	d͡ʒ æ b z
 jacal	h ə k ɑː l
 jacana	d͡ʒ æ k ɑː n ə
 jace	d͡ʒ e ɪ s
+jacent	d ʒ e ɪ s ə n t
 jacinda	d͡ʒ ə s ɪ n d ə
 jacinth	d͡ʒ e ɪ s ɪ n θ
 jacinth	d͡ʒ æ s ɪ n θ
@@ -34941,6 +35324,7 @@ jacobite	d͡ʒ æ k ə b a ɪ t
 jacobs	d͡ʒ e ɪ k ə b z
 jacobson	d͡ʒ e ɪ k ə b s ə n
 jaconet	d͡ʒ æ k ə n ɪ t
+jacqueline	d ʒ æ k ə l ɪ n
 jacquerie	ʒ a k ə ɹ i
 jacquerie	ʒ a k ɹ i
 jacques	d͡ʒ æ k
@@ -35091,6 +35475,7 @@ javan	d͡ʒ ɑː v ə n
 javanese	d ʒ ɑː v ə n iː z
 javanka	d͡ʒ ə v ɑː ŋ k ə
 javans	d͡ʒ ɑː v ə n z
+javascript	d ʒ ɑː v ə s k ɹ ɪ p t
 javel	d͡ʒ æ v ə l
 javelin	d͡ʒ æ v ə l ɪ n
 javelina	h a v ə l iː n ə
@@ -35148,6 +35533,7 @@ jeffrey	d͡ʒ ɛ f ɹ i
 jegging	d͡ʒ ɛ ɡ ɪ ŋ
 jeggings	d͡ʒ ɛ ɡ ɪ ŋ z
 jehovah	d͡ʒ ə h o ʊ v ə
+jehovist	d͡ʒ ə h o ʊ v ɪ s t
 jehovistic	d͡ʒ i h o ʊ v ɪ s t ɪ k
 jehovistic	d͡ʒ ə h o ʊ v ɪ s t ɪ k
 jejune	d͡ʒ i d ʒ uː n
@@ -35183,6 +35569,7 @@ jeopard	d͡ʒ ɛ p ə ɹ d
 jeopardize	d͡ʒ ɛ p ə d ʌ ɪ z
 jeopardy	d͡ʒ ɛ p ə d i
 jepson	d͡ʒ ɛ p s ə n
+jerboa	d ʒ ɜː ɹ b ə ʊ ə
 jeremiad	d͡ʒ ɛ ɹ ə m a ɪ ə d
 jeremiah	d͡ʒ ɛ ɹ ə m a ɪ ə
 jeremias	d͡ʒ ɛ ɹ ə m a ɪ ə s
@@ -35277,6 +35664,8 @@ jiangshi	d͡ʒ i ɑ ŋ ʃ iː
 jiangwan	d͡ʒ ɑ ŋ w ɑ n
 jiangyin	d͡ʒ ɑ ŋ j ɪ n
 jianzhi	d͡ʒ i æ n d͡ʒ iː
+jianzi	d͡ʒ i æ n d z i
+jianzi	d͡ʒ i æ n d z ə
 jiaozi	d͡ʒ j a ʊ d͡ʒ i
 jib	d͡ʒ ɪ b
 jibber	d͡ʒ ɪ b ə ɹ
@@ -35311,15 +35700,22 @@ jildy	d͡ʒ ɪ l d i
 jilin	d͡ʒ iː l ɪ n
 jill	d͡ʒ ɪ l
 jillion	j ɪ l j ə n
+jilt	d͡ʒ ɪ l t
 jilted	d͡ʒ ɪ l t ɪ d
+jilter	d͡ʒ ɪ l t ə
 jilting	d͡ʒ ɪ l t ɪ ŋ
 jiltings	d͡ʒ ɪ l t ɪ ŋ z
+jilts	d͡ʒ ɪ l t s
 jim	d͡ʒ ɪ m
 jimbo	d͡ʒ ɪ m b ə ʊ
+jimmer	d͡ʒ ɪ m ə ɹ
 jimmie	d͡ʒ ɪ m i
 jimmy	d͡ʒ ɪ m i
 jimps	d͡ʒ ɪ m p s
+jin	d͡ʒ ɪ n
 jinan	d͡ʒ iː n ɑː n
+jing'an	d͡ʒ ɪ ŋ æ n
+jing'an	d͡ʒ ɪ ŋ ɑ n
 jingal	d͡ʒ ɪ n ɡ ɔː l
 jingal	d͡ʒ ɪ n ɡ ə l
 jingle	d͡ʒ ɪ ŋ l ɛ
@@ -35328,37 +35724,48 @@ jingle	d͡ʒ ɪ ŋ ɡ l̩
 jingly	d͡ʒ ɪ ŋ ɡ l i
 jingo	d͡ʒ ɪ ŋ ɡ ə ʊ
 jingoish	d ʒ ɪ ŋ ɡ ə ʊ ɪ ʃ
+jingoism	d͡ʒ ɪ ŋ ɡ ə ʊ ɪ z ə m
 jingoistic	d͡ʒ ɪ ŋ ɡ ə ʊ ɪ s t ɪ k
 jingpo	d͡ʒ ɪ ŋ p o ʊ
+jingxin	d͡ʒ ɪ ŋ ʃ iː n
 jingzhe	t͡ʃ i ŋ t͡ʃ ʌ
+jingzhou	d͡ʒ ɪ ŋ d͡ʒ o ʊ
 jinhua	d͡ʒ ɪ n h w ɑː
 jink	d͡ʒ ɪ ŋ k
 jinker	d ʒ ɪ ŋ k ə
 jinks	d͡ʒ ɪ ŋ k s
 jinn	d͡ʒ ɪ n
 jinricksha	d͡ʒ ɪ n ɹ ɪ k ʃ ə
+jinrickshaw	d͡ʒ ɪ n ɹ ɪ k ʃ ɔː
 jinriksha	d͡ʒ ɪ n ɹ ɪ k ʃ ə
 jint	d͡ʒ a ɪ n t
 jinx	d͡ʒ ɪ ŋ k s
 jipijapa	h i p i h ɑ p ə
 jiqui	h iː k iː
+jirga	d ʒ ɪ ə ɡ ə
 jislaaik	j ɪ s l a ɪ k
+jism	d͡ʒ ɪ z ə m
 jit	d͡ʒ ɪ t
 jitter	d͡ʒ ɪ t ə ɹ
 jitterbug	d͡ʒ ɪ t ə ɹ b ʌ ɡ
+jittery	d͡ʒ ɪ t ɹ i
 jive	d͡ʒ a ɪ v
 jived	d͡ʒ a ɪ v d
 jives	d͡ʒ a ɪ v z
+jiving	d͡ʒ a ɪ v ɪ ŋ
 jizz	d͡ʒ ɪ z
 jnana	d ʒ ə n ɑː n ə
 jo	d͡ʒ ə ʊ
 joab	d͡ʒ ə ʊ æ b
+joachim	d͡ʒ ə ʊ ə k ɪ m
 joan	d͡ʒ ə ʊ n
 joanna	d͡ʒ ə ʊ æ n ə
 joanne	d͡ʒ ə ʊ n
 joanne	d͡ʒ ə ʊ æ n
 joanne	ʒ o ʊ n
 joao	d͡ʒ o ʊ a ʊ
+joaquin	h w ɑ k iː n
+joaquin	w ɑ k iː n
 job	d͡ʒ ɒ b
 job	d͡ʒ ə ʊ b
 jobation	d͡ʒ ə ʊ b e ɪ ʃ ə n
@@ -35392,6 +35799,7 @@ joggle	d͡ʒ ɒ ɡ ə l
 joh	d͡ʒ ə ʊ
 johanna	d͡ʒ ə ʊ h æ n ə
 johanna	d͡ʒ ə ʊ æ n ə
+johannes	d ʒ ə ʊ h æ n ɪ s
 johannesburg	d͡ʒ o ʊ h æ n ɪ s b ɜː r ɡ
 johannine	d͡ʒ ə ʊ h æ n a ɪ n
 johar	d ʒ ə ʊ h ɑː
@@ -35455,6 +35863,7 @@ joss	d ʒ ɒ s
 josser	d͡ʒ ɒ s ə ɹ
 jostle	d͡ʒ ɒ s ə l
 josue	d͡ʒ ɒ s j u iː
+josue	h o ʊ s w e ɪ
 jot	d͡ʒ ɒ t
 jota	h o ʊ t ə
 jotation	d͡ʒ ə ʊ t e ɪ ʃ ə n
@@ -35599,6 +36008,7 @@ jumping	d͡ʒ ʌ m p ɪ ŋ
 jumpings	d͡ʒ ʌ m p ɪ ŋ z
 jumps	d͡ʒ ʌ m p s
 jumpy	d͡ʒ ʌ m p i
+jun	d ʒ ʌ n
 juncate	d͡ʒ ʌ ŋ k ɪ t
 junco	d͡ʒ ʌ ŋ k ə ʊ
 junction	d͡ʒ ʌ ŋ k ʃ ə n
@@ -35629,6 +36039,7 @@ jupe	d͡ʒ uː p
 jupe	ʒ uː p
 jupon	d͡ʒ u p ɒ n
 jura	d͡ʒ ʊ ə ɹ ə
+jural	d ʒ ʊ ə ɹ ə l
 jurat	d͡ʒ ʊ ə ɹ æ t
 jurat	ʒ ʊ ə ɹ æ
 jurator	d͡ʒ ʊ r e ɪ t ə r
@@ -35653,6 +36064,7 @@ justice	d͡ʒ ʌ s t ɪ s
 justiciar	d͡ʒ ʌ s t ɪ s i ɑː ɹ
 justifiability	d͡ʒ ʌ s t ɪ f a ɪ ə b ɪ l ɪ t ɪ
 justification	d͡ʒ ʌ s t ɪ f ɪ k e ɪ ʃ ə n
+justificatory	d͡ʒ ʌ s t ɪ f ə k e ɪ t ə ɹ i
 justified	d͡ʒ ʌ s t ɪ f a ɪ d
 justify	d͡ʒ ʌ s t ɪ f a ɪ
 justin	d͡ʒ ʌ s t ɪ n
@@ -35676,6 +36088,7 @@ juxtapose	d͡ʒ ʌ k s t ə p ə ʊ z
 juxtaposit	d͡ʒ ʌ k s t ə p ɒ z ɪ t
 juxtaposition	d͡ʒ ʌ k s t ə p ə z ɪ ʃ ə n
 juxtology	d͡ʒ ʌ k s t ɑ l ə d͡ʒ i
+jwics	d ʒ e ɪ w ɪ k s
 jy	d͡ʒ a ɪ
 jynges	d͡ʒ ɪ n d͡ʒ iː z
 jynges	d͡ʒ ɪ n d͡ʒ ɪ z
@@ -35683,6 +36096,7 @@ jyngine	d͡ʒ ɪ n d͡ʒ a ɪ n
 jynx	d͡ʒ ɪ ŋ k s
 jyothis	d͡ʒ o ʊ t ɪ s
 jäger	j e ɪ ɡ ə
+jägermeister	j e ɪ ɡ ə r m a ɪ s t ə r
 jèrriais	ʒ ɛ ɹ i e ɪ
 jõgeva	j ə ʊ ɡ ɪ v ə
 jõgeva	j ʊ ɡ ɪ v ə
@@ -35794,6 +36208,7 @@ kangchenjunga	k ʌ ŋ t͡ʃ ə n d͡ʒ ʌ ŋ ɡ ə
 kangding	k ɒ ŋ d ɪ ŋ
 kanghui	k ɒ ŋ h w i
 kangling	k æ ŋ ɡ ə l ɪ ŋ ɡ
+kango	k ɑ ŋ ɡ o ʊ
 kangri	k æ ŋ ɡ ɹ i
 kangxi	k ɑ ŋ ʃ iː
 kanigget	k ə n ɪ ɡ ə t
@@ -35879,6 +36294,7 @@ kashered	k æ ʃ ə d
 kashering	k æ ʃ ə ɹ ɪ ŋ
 kashers	k æ ʃ ə z
 kashmiri	k æ ʃ m i ɹ i
+kashrut	k ɑː ʃ ɹ uː t
 kashubian	k ə ʃ uː b ɪ ə n
 kastom	k ɑː s t ɒ m
 kasundi	k ə s ʊ n d i
@@ -36037,33 +36453,46 @@ kerala	k ɛ ɹ ə l ə
 keratin	k ɛ r ə t ɪ n
 keratinization	k ə ɹ æ t ɪ n a ɪ z e ɪ ʃ ə n
 keratinize	k ɛ r ə t n a ɪ z
+keratomileusis	k ɛ ɹ ə t ə ʊ m a ɪ l j uː s ɪ s
 keratophyte	k ɛ ɹ ə t ə ʊ f a ɪ t
+keratosis	k ɛ ɹ ə t ə ʊ s ɪ s
 kerb	k ɜː b
 kerberos	k ɜː b ə ɹ ə s
 kerby	k ɜː b i
 kercher	k ɜː ɹ t͡ʃ ə ɹ
+kerchief	k ɜː t ʃ iː f
+kerchief	k ɜː t ʃ ɪ f
 kerching	k ə t͡ʃ ɪ ŋ
+kereru	k ɛ ɹ ə ɹ uː
 kerf	k ɜː ɹ f
 kerflooey	k ə ɹ f l uː i
 kerfuffle	k ə f ʌ f ə l
 kerikeri	k ɛ ɹ iː k ɛ ɹ iː
 keriorrhea	k ɛ ɹ ɪ ə ɹ iː ə
+kermit	k ɜː m ɪ t
 kern	k ɜː n
 kernahan	k ɜː ɹ n ə h ə n
 kernel	k ɜː n ə l
 kernicterus	k ɜː n ɪ k t ə ɹ ə s
 kerning	k ɜː n ɪ ŋ
 kernow	k ɜː n ə ʊ
+kerosene	k ɛ ɹ ə s iː n
 kerplunk	k ə ɹ p l ʌ ŋ k
+kerr	k ɛ ə
+kerr	k ɜː
 kerry	k ɛ ɹ i
 kers	k ɜː ɹ z
+kersey	k ɜː z i
 kerseymere	k əː z ɪ m ɪ ə
 kershaw	k ə r ʃ ɔː r
 kersley	k ɜː z l i
+kerygma	k ə ɹ ɪ ɡ m ə
 kesar	k e ɪ s ə
 kesar	k e ɪ z ə
 kesteven	k ɛ s t ə v ə n
+kestrel	k ɛ s t ɹ ə l
 keswick	k ɛ z ɪ k
+keszthely	k ɛ s t e ɪ
 ket	k ɛ t
 ketamine	k iː t ə m iː n
 ketamine	k ɛ t ə m ɪ n
@@ -36075,6 +36504,7 @@ ketogenic	k iː t ə ʊ d͡ʒ ɛ n ɪ k
 ketone	k iː t ə ʊ n
 ketosis	k iː t ə ʊ s ɪ s
 kettell	k ɛ t ə l
+kettering	k ɛ t ə ɹ ɪ ŋ
 kettle	k ɛ t ə l
 kev	k ɛ v
 kevaughn	k ə v ɔː n
@@ -36082,6 +36512,7 @@ kevin	k ɛ v ə n
 kevin	k ɛ v ɪ n
 kevlar	k ɛ v l ɑː
 kevorkian	k ɛ v ɔ ɹ k iː ɛ n
+kevvy	k ɛ v i
 kew	k j u ʊ̯
 kew	k j uː
 kewl	k j uː l
@@ -36100,16 +36531,32 @@ keynesianism	k e ɪ n z i ə n ɪ z m̩
 keynesianist	k e ɪ n z i ə n ɪ s t
 keynsham	k e ɪ n ʃ ə m
 keypad	k iː p æ d
+keys	k iː z
 keystone	k iː s t ə ʊ n
 keyword	k iː w ɜː d
 kez	k ɛ z
+khabarovsk	k ɑː b ə ɹ ɒ f s k
 khachapuri	h ɑː t ʃ ə p uː ɹ i
 khachaturian	k ɑː t ʃ ə t ʊ ə ɹ i ə n
+khachkar	h ɑ t͡ʃ k ɑ ɹ
+khaki	k ɑː k i
+khaleesi	k ə l iː s i
 khamenei	k ɑː m ə n e ɪ iː
+khamsin	k æ m s i n
+khamsin	k æ m s ɪ n
 khan	k ɑː n
 khanate	k ɑː n e ɪ t
 khanjar	k a n d͡ʒ ə
 khanji	k ɑː n d͡ʒ i
+khariboli	k a ɹ iː b o ʊ ɫ iː
+kharkiv	h ɑ ɹ k i v
+kharkiv	h ɑ ɹ k ɪ v
+kharkiv	h ɑː k iː v
+kharkiv	h ɑː k ɪ v
+kharkiv	k ɑ ɹ k i v
+kharkiv	k ɑ ɹ k ɪ v
+kharkiv	k ɑː k iː v
+kharkiv	k ɑː k ɪ v
 kharkov	k ɑː k ə v
 khartoum	k ɑː ɹ t uː m
 khat	k ɑː t
@@ -36117,12 +36564,17 @@ khata	k ɑ t ɑ
 khatyrkite	k ə t ɪ ə ɹ k a ɪ t
 khayyamian	k a ɪ j æ m i ə n
 khayyamian	k a ɪ j ɑː m i ə n
+khazar	k ə z ɑː
 khazi	k ɑː z i
 khediva	k ə d iː v ə
+khedive	k ə d iː v
 khedivial	k ə d ɪ v i ə l
 khene	k ɛː n
+kherson	h ɜː ɹ s ɔː n
+kherson	k ɜː ɹ s ɔː n
 khichdi	k ɪ t͡ʃ d i
 khimar	k ɪ m ɑː ɹ
+khitmatgar	k ɪ t m ə t ɡ ɑː
 khiva	k iː v ə
 khmelnytskyi	k ə m e l l n ɪ t s k i
 khmer	k m ɛ ə ɹ
@@ -36133,14 +36585,20 @@ khoisan	k ɔ ɪ s ɑː n
 kholop	k ə l o ʊ p
 khomeini	k ɒ m e ɪ n i
 khomeini	k ə ʊ m e ɪ n i
+khoomei	h o ʊ m e ɪ
+khoomei	k o ʊ m i
+khoomei	k u m i
 khotanese	k ə ʊ t ə n iː z
 khu	k uː
 khud	k ʌ d
+khufi	k uː f i
 khukhrain	k ʊ k ɹ ɛː n
+khula	k uː l ɑː
 khutbah	k ʊ t b ə
 khutor	k uː t ɔː ɹ
 khyber	k a ɪ b ə ɹ
 ki	k iː
+kiai	k iː a ɪ
 kiang	k i æ ŋ
 kiang	k i ɑ ŋ
 kiang	k j æ ŋ
@@ -36187,6 +36645,8 @@ kieselguhr	k iː z ə l ɡ ʊ ə
 kiev	k iː ɛ f
 kiev	k iː ɛ v
 kiev	k iː ɪ v
+kiev	k j ɛ f
+kiev	k j ɛ v
 kievan	k iː ɛ f ə n
 kievan	k iː ɛ v ə n
 kif	k iː f
@@ -36198,30 +36658,42 @@ kikoi	k i k ɔ i
 kikongo	k ɪ k ɒ ŋ ɡ ə ʊ
 kilburn	k ɪ l b əː n
 kildare	k ɪ l d ɛ ə
+kile	k a ɪ l
+kilim	k iː l ɪ m
+kilim	k ɪ l iː m
 kilimanjaro	k ɪ l ə m ə n d͡ʒ ɑ ɹ o ʊ
 kilimanjaro	k ɪ l ɪ m ə n d͡ʒ ɑː ɹ ə ʊ
 kilkenny	k ɪ l k ɛ n i
+kill	k ɪ l
 killable	k ɪ l ə b ə l
+killam	k ɪ l ə m
 killdeer	k ɪ l d ɪ ə
 killed	k ɪ l d
+killer	k ɪ l ə ɹ
 killing	k ɪ l ɪ ŋ
 kills	k ɪ l z
+killurin	k ɪ l ʊ ə ɹ ɪ n
 kilmallock	k ɪ l m æ l ə k
 kiln	k ɪ l n
 kilncadzow	k ɪ l k e ɪ ɡ i
+kilo	k iː l ə ʊ
 kilobase	k ɪ l ə b e ɪ s
+kilogram	k ɪ l ə ɡ ɹ æ m
 kilometer	k ɪ l ɒ m ɪ t ə
 kilometer	k ɪ l ə m iː t ə
 kilometre	k ɪ l ɒ m ɪ t ə
 kilometre	k ɪ l ə m iː t ə
 kilopond	k ɪ l ə p ɒ n d
 kilos	k iː l ə ʊ z
+kilroy	k ɪ l ɹ ɔ ɪ
 kilt	k ɪ l t
 kilter	k ɪ l t ə
 kiltie	k ɪ l t iː
 kilton	k ɪ l t ə n
+kilwinning	k ɪ l w ɪ n ɪ ŋ
 kim	k ɪ m
 kimmy	k ɪ m i
+kimnel	k ɪ m n ə l
 kin	k ɪ n
 kinara	k ɪ n ɑː ɹ ə
 kinase	k a ɪ n e ɪ z
@@ -36249,6 +36721,7 @@ kinematic	k a ɪ n ɪ m æ t ɪ k
 kinematic	k ɪ n ɪ m æ t ɪ k
 kines	k a ɪ n z
 kineses	k a ɪ n z ɪ z
+kinesics	k ɪ n iː s ɪ k s
 kinesiology	k ə n i z i ɔ l ə d͡ʒ ɪ
 kinesis	k ə n iː s ɪ s
 kinesthetic	k ɪ n ɪ s θ ɛ t ɪ k
@@ -36301,6 +36774,9 @@ kippens	k ɪ p ə n z
 kipper	k ɪ p ə ɹ
 kirby	k ɜː b i
 kirghiz	k ɜː ɡ ɪ z
+kiribati	k iː ɹ ɪ b æ s
+kiribati	k iː ɹ ɪ b ɑ s
+kiribati	k iː ɹ ɪ b ɑ t i
 kirigami	k ɪ ɹ ɪ ɡ ɑː m ɪ
 kiritimati	k ə ɹ ɪ s m ə s
 kirk	k ɜː k
@@ -36310,6 +36786,7 @@ kirkcudbright	k ə k uː b ɹ i
 kirkheaton	k ə r k h iː t ə n
 kirkwood	k ɝ k w ʊ d
 kirkyard	k əː k j ɑː d
+kirmess	k ɜː ɹ m ə s
 kirpan	k ɪ ə ɹ p ɑː n
 kirsch	k ɜː ɹ ʃ
 kirsch	k ɪ ə ɹ ʃ
@@ -36426,6 +36903,7 @@ knapweed	n æ p w iː d
 knar	n ɑː ɹ
 knarr	n ɔː ɹ
 knarred	n ɑː ɹ d
+knarry	n ɑː ɹ i
 knave	n e ɪ v
 knavery	n e ɪ v ə ɹ i
 knaves	n e ɪ v z
@@ -36498,6 +36976,7 @@ knockout	n ɒ k a ʊ t
 knoll	n ə ʊ l
 knollys	n o ʊ l z
 knook	n ʊ k
+knork	n ɔː k
 knosp	n ɒ s p
 knot	n ɒ t
 knots	n ɒ t s
@@ -36519,6 +36998,7 @@ knuff	n ʌ f
 knur	n ɜː ɹ
 knurl	n ɜː l
 knurly	n ɜː ɹ l i
+knurry	n ɜː ɹ i
 knuth	k ə n uː θ
 knysna	n a ɪ z n ə
 ko	k ə ʊ
@@ -36560,6 +37040,7 @@ kolkata	k ɔː l k ɑː t ə
 kolkhoz	k ə l k ɒ z
 kolkhozy	k ə l k ɒ z ɪ
 kolo	k ə ʊ l ə ʊ
+kolyma	k ə l ɪ m a
 kombu	k ɒ m b uː
 komi	k o ʊ m i
 komodo	k ə ʊ m ə ʊ d ə ʊ
@@ -36618,6 +37099,7 @@ kraken	k ɹ e ɪ k ə n
 kraken	k ɹ æ k ə n
 kraken	k ɹ ɑː k ə n
 kramatorsk	k ɹ æ m ə t ɔː s k
+krang	k ɹ æ ŋ
 kratos	k ɹ a t ɒ s
 kraut	k ɹ a ʊ t
 kremlin	k ɹ e m l ɪ n
@@ -36684,6 +37166,7 @@ kurd	k ɜː ɹ d
 kurdish	k ɜː ɹ d ɪ ʃ
 kurgan	k ʊ ə ɡ ɑː n
 kuroshio	k ʊ ə ɹ ə ʊ ʃ iː ə ʊ
+kurow	k uː ɹ a ʊ
 kurt	k ɜː t
 kuru	k ʊ ɹ uː
 kush	k ʊ ʃ
@@ -36694,26 +37177,35 @@ kutcha	k ʌ t ʃ ə
 kutenai	k uː t ə n e ɪ
 kuvasz	k u v a s
 kuvasz	k u v ɑ s
+kuwait	k j uː w e ɪ t
 kuybyshev	k uː ɪ b ɪ ʃ ɛ v
+kvass	k v ɑː s
 kvell	k v ɛ l
+kvetch	k v ɛ t͡ʃ
 kwaito	k w a ɪ t o ʊ
+kwanza	k w ɑː n z ə
 kwanzaa	k w ɑ n z ə
 kwashiorkor	k w æ ʃ i ɔː k ɔː
 kwashiorkor	k w ɒ ʃ i ɔː k ɔː
+kwedini	k w iː d ɪ n i
 kwok	k w ɔ k
 kyat	k iː ɑː t
 kye	k a ɪ
 kye	k j e ɪ
 kyiv	k iː v
 kyiv	k iː ɪ v
+kyiv	k j ɪ v
 kyivan	k iː ɪ v ə n
 kyke	k a ɪ k
 kyla	k a ɪ l ə
 kyle	k a ɪ l
 kylie	k a ɪ l i
 kylix	k a ɪ l ɪ k s
+kyloe	k ʌ ɪ l ə
 kylym	k ɪ l ɪ m
+kynodesme	k a ɪ n ə ʊ d ɛ z m i
 kyphotone	k a ɪ f ə t ə ʊ n
+kyra	k a ɪ ɹ ə
 kyrgyz	k ɜː ɹ ɡ ɪ z
 kyrgyz	k ɪ ə ɹ ɡ ɪ z
 kyrgyzstan	k ɛː ɹ ɡ ɪ s t ɑː n
@@ -36724,6 +37216,7 @@ kyrie	k ɪ ə ɹ ɪ e ɪ
 kyrielle	k ɪ ɹ i ɛ l
 kyushu	k j uː ʃ uː
 königsberg	k ɜː n ɪ ɡ z b ɜː ɡ
+künstlerroman	k ʊ n s t l ə ɹ ə ʊ m ɑː n
 kırklareli	k ɝ k l ə ɹ ɛ l i
 l	l
 l	ɛ l
@@ -36846,6 +37339,7 @@ lagerstätte	l ɑː ɡ ə ʃ t ɛ t ə
 laggard	l æ ɡ ə d
 laggy	l æ ɡ i
 lagid	l æ d͡ʒ ɪ d
+lagids	l æ d͡ʒ ɪ d z
 lagniappe	l æ n j æ p
 lagomorphic	l æ ɡ ə m ɔ ɹ f ɪ k
 lagoon	l ə ɡ uː n
@@ -36854,6 +37348,8 @@ lagopodes	l ə ɡ ə ʊ p ə ʊ d z
 lagopus	l ə ɡ ə ʊ p ə s
 lagos	l e ɪ ɡ ɒ s
 lagtime	l æ ɡ t a ɪ m
+lagune	l ə ɡ j uː n
+lagune	l ə ɡ uː n
 lah	l ɑ
 lahar	l ɑ h ɑ ɹ
 lahore	l ə h ɔː r
@@ -37084,15 +37580,14 @@ lardy	l ɑː d i
 lare	l ɛ ə ɹ
 laredo	l ə r e ɪ d o ʊ
 large	l ɑː d͡ʒ
-largely	l ɑ ɹ d͡ʒ l i
+largely	l ɑː d͡ʒ l i
 largeness	l ɑː d͡ʒ n ə s
 larger	l ɑː d͡ʒ ə
-largess	l ɑː d͡ʒ ɛ s
-largess	l ɑː ʒ ɛ s
-largesse	l ɑː d͡ʒ ɛ s
+largesse	l ɑː d ʒ ɛ s
 largest	l ɑː d͡ʒ ɪ s t
 lariat	l æ ɹ ɪ ə t
 larissa	l ə ɹ ɪ s ə
+larixinic	l æ ɹ ɪ k s ɪ n ɪ k
 lark	l ɑː k
 larnax	l ɑː n æ k s
 larne	l ɑː ɹ n
@@ -37104,10 +37599,12 @@ larry	l æ ɹ i
 lart	l ɑː ɹ t
 larva	l ɑː v ə
 larvae	l ɑː v i
+larve	l ɑː ɹ v
 laryngeal	l ə ɹ ɪ n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n ʒ i ə l
 larynges	l ə ɹ ɪ n d͡ʒ iː z
 laryngismus	l æ ɹ ɪ n d͡ʒ ɪ z m ə s
+laryngitis	l æ ɹ ɪ n d͡ʒ a ɪ t ɪ s
 larynx	l a ɹ ɪ ŋ k s
 las	l ɑː z
 lasagna	l ə s ɑ n j ə
@@ -37201,6 +37698,7 @@ latium	l e ɪ ʃ i ə m
 lative	l e ɪ t ɪ v
 latke	l ɑː t k i
 latke	l ɑː t k ə
+latona	l ə t ə ʊ n ə
 latreutic	l ə t ɹ uː t ɪ k
 latria	l ə t ɹ a ɪ ə
 latrine	l ə t ɹ iː n
@@ -37254,7 +37752,9 @@ laundromat	l ɔː n d ɹ ə m æ t
 laundromat	l ɔː n d ɹ ə ʊ m æ t
 laundry	l ɔː n d ɹ i
 laura	l ɔː ɹ ə
+laureate	l ɒ ɹ i e ɪ t
 laureate	l ɒ ɹ i ə t
+laureate	l ɔː ɹ i e ɪ t
 laureate	l ɔː ɹ i ə t
 laureation	l ɔː ɹ i e ɪ ʃ ə n
 laurel	l ɒ ɹ ə l
@@ -37457,6 +37957,7 @@ lebanese	l ɛ b ə n iː z
 lebanon	l ɛ b ə n ə n
 lebensraum	l eː b ə n s ɹ a ʊ m
 lebenswelt	l eː b ə n z v ɛ l t
+lecce	l ɛ t ʃ e ɪ
 lech	l ɛ k
 lech	l ɛ t͡ʃ
 lechayim	l ə h a ɪ ɪ m
@@ -37473,6 +37974,7 @@ lectin	l ɛ k t ɪ n
 lectinological	l ɛ k t ɪ n ə l ɒ d͡ʒ ɪ k ə l
 lectinologist	l ɛ k t ɪ n ɒ l ə d͡ʒ ɪ s t
 lection	l ɛ k ʃ ə n
+lector	l ɛ k t ə ɹ
 lecture	l ɛ k t͡ʃ ə
 lecturer	l ɛ k t ʃ ə ɹ ə
 lectures	l ɛ k t͡ʃ ə z
@@ -37511,6 +38013,7 @@ lefty	l ɛ f t i
 leg	l ɛ ɡ
 legacy	l ɛ ɡ ə s i
 legal	l iː ɡ ə l
+legal	l ɪ ɡ æ l
 legalize	l iː ɡ ə l a ɪ z
 legally	l iː ɡ ə l i
 legate	l ɛ ɡ ə t
@@ -37553,6 +38056,7 @@ leguleian	l ɛ ɡ j ʊ l iː ə n
 legume	l ə ɡ j uː m
 legume	l ɛ ɡ j uː m
 legume	l ɪ ɡ j uː m
+legumen	l ɪ ɡ j uː m ə n
 legumes	l ɛ ɡ j uː m z
 legumes	l ɪ ɡ j uː m z
 legwork	l ɛ ɡ w əː k
@@ -37613,7 +38117,8 @@ length	l ɛ ŋ k θ
 lengthen	l ɛ ŋ k θ ə n
 lengthening	l ɛ ŋ k θ n ɪ ŋ
 lengthening	l ɛ ŋ k θ ə n ɪ ŋ
-lengthman	l ɛ ŋ θ m ə n
+lengthman	l ɛ ŋ θ m n̩
+lengthsman	l ɛ ŋ θ s m n̩
 lenient	l iː n i ə n t
 lenify	l iː n ɪ f a ɪ
 lenify	l ɛ n ɪ f a ɪ
@@ -37630,6 +38135,7 @@ lenite	l iː n a ɪ t
 lenite	l ə n a ɪ t
 lenition	l iː n ɪ ʃ ə n
 lenition	l ɪ n ɪ ʃ ə n
+lenity	l ɛ n ɪ t i
 lennon	l ɛ n ə n
 lens	l ɛ n z
 lenses	l ɛ n z ɪ z
@@ -37724,6 +38230,7 @@ lettuce	l ɛ t ə s
 lettuce	l ɛ t ɪ s
 leu	l e ɪ uː
 leuchars	l uː k ə ɹ z
+leucinemia	l j uː s ɪ n iː m i ə
 leucoderm	l uː k ə d ɝ m
 leucodermic	l uː k ə d ɜː m ɪ k
 leucophanite	l j uː k ɒ f ə n a ɪ t
@@ -37760,7 +38267,8 @@ leveret	l ɛ v ə ɹ ɪ t
 leveret	l ɛ v ɹ ɪ t
 leverpostej	l e ɪ v ə ɹ p ɒ s t a ɪ
 levet	l ɛ v ɪ t
-levi	l iː v a ɪ
+levetiracetam	l ɛ v ɪ t ɪ r æ s ɪ t æ m
+levi	l iː v a j
 leviathan	l ə v a ɪ ə θ ə n
 levidrome	l iː v a ɪ d ɹ ə ʊ m
 levidrome	l iː v ɪ d ɹ ə ʊ m
@@ -37813,9 +38321,6 @@ liability	l a ɪ ə b ɪ l ɪ t i
 liable	l a ɪ̯ ə b ə l
 liaise	l iː e ɪ z
 liaison	l a ɪ e ɪ z ɒ n
-liaison	l a ɪ e ɪ z ə n
-liaison	l i e ɪ z ɒ n
-liaison	l i e ɪ z ə n
 liam	l iː ə m
 liana	l iː ɑː n ə
 liangpi	l i æ ŋ p iː
@@ -37886,7 +38391,6 @@ licorice	l ɪ k ə ɹ ɪ s
 licorice	l ɪ k ə ɹ ɪ ʃ
 lictor	l ɪ k t ə
 lid	l ɪ d
-liddat	l a ɪ d ɛ t
 lidge	l ɪ d͡ʒ
 lido	l a ɪ d ə ʊ
 lido	l iː d ə ʊ
@@ -37965,6 +38469,8 @@ ligma	l ɪ ɡ m ə
 lignify	l ɪ ɡ n ɪ f a ɪ
 lignite	l ɪ ɡ n a ɪ̯ t
 lignocaine	l ɪ ɡ n ə ʊ k e ɪ n
+lignose	l ɪ ɡ n ə ʊ s
+lignose	l ɪ ɡ n ə ʊ z
 ligula	l ɪ ɡ j ʊ l ə
 liguria	l ɪ ɡ j ʊ ə ɹ i ə
 lihou	l iː uː
@@ -38072,6 +38578,7 @@ lindsey	l ɪ n z i
 lindworm	l ɪ n d w ɜː ɹ m
 line	l a ɪ n
 lineage	l ɪ n i ɪ d͡ʒ
+lineages	l ɪ n i ɪ d ʒ ɪ z
 lineal	l ɪ n iː ə l
 lineament	l ɪ n i ə m ə n t
 linear	l ɪ n i ə
@@ -38365,6 +38872,7 @@ lobster	l ɒ b s t ə
 lobsterman	l ɒ b s t ə ɹ m ə n
 lobsterwoman	l ɒ b s t ə ɹ w ʊ m ə n
 lobule	l ɒ b j uː l
+loc	l ə ʊ k
 local	l ə ʊ k l̩
 locale	l ə ʊ k ɑː l
 localism	l ə ʊ k ə l ɪ z ə m
@@ -38422,6 +38930,7 @@ loeffler	l ɜː f l ə ɹ
 loess	l ə ʊ ɪ s
 loess	l ɜː s
 loft	l ɒ f t
+lofton	l ɒ f t ə n
 lofty	l ɒ f t i
 log	l ɒ ɡ
 logarithmancy	l ɒ ɡ ə ɹ ɪ ð m ə n s i
@@ -38482,12 +38991,12 @@ lojban	l ɒ ʒ b æ n
 loki	l ə ʊ k i
 lol	l ɒ l
 lol	l ɔː l
-lol	ɛ l ə u ɛ l
 lol	ɛ l ə ʊ ɛ l
 lola	l ə ʊ l ə
 lolita	l ə ʊ l l i t ə
 loll	l ɒ l
 lollapalooza	l ɒ l ə p ə l uː z ə
+lollard	l ɒ l ɑː ɹ d
 lollipop	l ɒ l i p ɒ p
 lollop	l ɒ l ə p
 lollygag	l ɒ l ɪ ɡ æ ɡ
@@ -38510,6 +39019,7 @@ loneness	l ə ʊ n n ə s
 lonesome	l ə ʊ n s ə m
 long	l ɒ ŋ
 long	l ɔː ŋ
+long	l ʊ ŋ
 longan	l ɒ ŋ ɡ ə n
 longanimity	l ɒ ŋ ɡ ə n ɪ m ɪ t i
 longbow	l ɒ ŋ b ə ʊ
@@ -38699,6 +39209,7 @@ lovage	l ʌ v ɪ d͡ʒ
 lovanenty	l ə ʊ v ə n ɛ n t i
 lovastatin	l ə ʊ v a s t ə t ɪ n
 lovastatin	l ə ʊ v ə s t a t ɪ n
+love	l ʊ v
 love	l ʌ v
 lovecraftian	l ʌ v k ɹ æ f t i ə n
 loved	l ʌ v d
@@ -38818,7 +39329,6 @@ luftwaffe	l ʊ f t w ɑ f ə
 lug	l ʌ ɡ
 luganda	l uː ɡ æ n d ə
 luganda	l uː ɡ ɑː n d ə
-luge	l uː d ʒ
 luged	l uː ʒ d
 luger	l uː ɡ ə ɹ
 luger	l uː ʒ ə ɹ
@@ -38914,6 +39424,7 @@ lupine	l uː p a ɪ n
 lupine	l uː p ɪ n
 lupulin	l u p j ə l ɪ n
 lupus	l uː p ə s
+lur	l ʊ ə ɹ
 lure	l j ʊ ə
 lure	l ɔː ɹ
 lure	l ɜː
@@ -38981,6 +39492,7 @@ luxurious	l ʌ ɡ z j ʊ ə ɹ ɪ ə s
 luxurious	l ʌ ɡ ʒ ʊ ə ɹ ɪ ə s
 luxury	l ʌ k ʃ ə ɹ i
 lviv	l ə v iː v
+lyam	l a ɪ ə m
 lycan	l a ɪ k ə n
 lycanthrope	l a ɪ k æ n θ ɹ o ʊ p
 lycanthrope	l a ɪ k ə n θ ɹ o ʊ p
@@ -39027,6 +39539,7 @@ lyra	l a ɪ ɹ ə
 lyra	l ɪ ə ɹ ə
 lyre	l a ɪ ə
 lyric	l ɪ ɹ ɪ k
+lyrical	l ɪ ɹ ɪ k ə l
 lyricist	l ɪ ɹ ɪ s ɪ s t
 lyrics	l ɪ ɹ ɪ k s
 lyrid	l a ɪ ɹ ɪ d
@@ -39070,7 +39583,7 @@ macajuel	m æ k ə w ɛ l
 macajuel	m ɑ k ɑ w ɛ l
 macanese	m æ k ə n i z
 macaque	m ə k æ k
-macaque	m ə k ɒ k
+macaque	m ə k ɑː k
 macarena	m æ k ə ɹ a ɪ n ə
 macaron	m æ k ə ɹ ɒ n
 macaronesia	m a k ə ɹ ə n iː ʒ ə
@@ -39119,6 +39632,7 @@ machismo	m ə k ɪ z m ə ʊ
 macho	m æ t͡ʃ ə ʊ
 machoness	m ɑ t ʃ ə ʊ n ə s
 macilent	m a s ɪ l ə n t
+macitentan	m æ s ɪ t ɛ n t æ n
 mack	m æ k
 mackem	m a k ə m
 mackerel	m æ k ɹ ə l
@@ -39136,6 +39650,8 @@ macolyte	m æ k ə l a ɪ t
 macomb	m ə k o ʊ m
 macon	m e ɪ k ə n
 maconochie	m ə k ɒ n ə k i
+macquarie	m ə k w ɑː r i
+macquarie	m ə k w ɔː r i
 macra	m æ k ɹ ə
 macramé	m æ k ɹ ə m e ɪ
 macramé	m ə k ɹ ɑː m e ɪ
@@ -39166,6 +39682,7 @@ macrovirus	m æ k ɹ o ʊ v a ɪ ɹ ə s
 macs	m æ k s
 macspaunday	m ə k s p ɔː n d e ɪ
 mactate	m æ k t e ɪ t
+macula	m æ k j ʊ l ə
 maculature	m æ k j ʊ l ə t j ʊ ə ɹ
 maculature	m æ k j ʊ l ə t͡ʃ ə ɹ
 maculele	m ɑː k u l e ɪ l e ɪ
@@ -39249,6 +39766,7 @@ maggot	m æ ɡ ə t
 maggots	m æ ɡ ə t s
 maggoty	m æ ɡ ə t i
 maghreb	m ɑː ɡ ɹ ɛ b
+maghreb	m ʌ ɡ ɹ ə b
 maghull	m ə ɡ ʌ l
 magi	m e ɪ d͡ʒ a ɪ
 magi	m e ɪ ɡ a ɪ
@@ -39438,8 +39956,8 @@ malagash	m æ l ə ɡ æ ʃ
 malagasy	m æ l ə ɡ e ɪ z i
 malagasy	m æ l ə ɡ æ s i
 malagueta	m a l ə ɡ ɛ t ə
+malai	m ə l a ɪ
 malaise	m æ l e ɪ z
-malaise	m ə l e ɪ z
 malamute	m æ l ə m j uː t
 malapert	m a l ə p əː t
 malapert	m æ l ə p ɜː t
@@ -39466,9 +39984,9 @@ malcolm	m æ l k ə m
 malcontent	m a l k ə n t ɛ n t
 mald	m ɔː l d
 mald	m ə ʊ l d
-maldives	m ɒ l d iː v s
-maldives	m ɔː l d a ɪ v s
-maldives	m ɔː l d iː v s
+maldives	m ɒ l d iː v z
+maldives	m ɔː l d a ɪ v z
+maldives	m ɔː l d iː v z
 male	m e ɪ l
 maledight	m æ l ə d a ɪ t
 malefic	m ə l ɛ f ɪ k
@@ -39534,6 +40052,7 @@ malodor	m æ l ə ʊ d ə ɹ
 malodorous	m æ l ə ʊ d ə ɹ ə s
 malta	m ɔː l t ə
 maltalent	m æ l t æ l ə n t
+maltaxation	m æ l t æ k s e ɪ ʃ ə n
 maltese	m ɒ l t iː z
 maltese	m ɔː l t iː z
 maltitol	m ɔː l t ə t ɑ l
@@ -39602,6 +40121,7 @@ manchuria	m æ n t͡ʃ ʊ ə ɹ i ə
 manchurian	m æ n t͡ʃ ʊ ə ɹ i ə n
 mancia	m æ n t͡ʃ ə
 mancipatory	m æ n s ɪ p e ɪ t ə ɹ i
+manciple	m æ n s ɪ p ə l
 mancunian	m a n k j uː n ɪ ə n
 mand	m æ n d
 mand	m ɑː n d
@@ -39616,6 +40136,7 @@ mandate	m æ n d e ɪ t
 mandatory	m æ n d ə t ə ɹ i
 mandela	m æ n d ɛ l ə
 mandement	m ɑː n d m ə n t
+mandeville	m æ n d ə v ɪ l
 mandible	m æ n d ɪ b ə l
 mandibles	m æ n d ə b ə l z
 mandibles	m æ n d ɪ b ə l z
@@ -39705,6 +40226,7 @@ manitoba	m æ n ɪ t ə ʊ b ə
 manitou	m a n ɪ t uː
 manitowoc	m æ n ɪ t ə w ɔː k
 manizer	m æ n a ɪ z ə ɹ
+manjuristics	m æ n d͡ʒ ə ɹ ɪ s t ɪ k s
 mank	m æ ŋ k
 mankind	m æ n k a ɪ n d
 mankiw	m æ n k j uː
@@ -39717,6 +40239,7 @@ manna	m æ n ə
 manned	m æ n d
 mannequin	m æ n ə k ɪ n
 manner	m æ n ə
+mannerism	m æ n ə ɹ ɪ z ə m
 mannish	m æ n ɪ ʃ
 mannopeptimycin	m n æ ə ʊ p ɛ p t ɪ m a ɪ s ɪ n
 manoeuvre	m ə n uː v ə
@@ -39735,6 +40258,7 @@ manship	m æ n ʃ ɪ p
 mansi	m æ n s i
 mansi	m ɑː n s i
 mansion	m æ n t͡ʃ ə n
+mansion	m æ n ʃ ə n
 manslot	m a n z l ɒ t
 mansonia	m æ n s ə ʊ n i ə
 mansplain	m a n s p l e ɪ n
@@ -39800,6 +40324,7 @@ maple	m e ɪ p l̩
 mapping	m æ p ɪ ŋ
 maprotiline	m ə p ɹ ə ʊ t ɪ l iː n
 maps	m æ p s
+mapuche	m ə p uː t ʃ e ɪ
 maputo	m ə p uː t ə ʊ
 maquette	m æ k ɛ t
 maquillage	m a k ɪ j ɑː ʒ
@@ -39839,6 +40364,7 @@ marches	m ɑː t͡ʃ ɪ z
 marches	m ɒ ɹ t͡ʃ ə z
 marching	m ɑː t͡ʃ ɪ ŋ
 marchioness	m ɑ ɹ ʃ ə n ɛ s
+marchioness	m ɑ ɹ ʃ ə n ɪ s
 marchland	m ɑː t͡ʃ l æ n d
 marchpane	m ɑː t ʃ p e ɪ n
 marcia	m ɑː ʃ ə
@@ -39897,8 +40423,8 @@ marinate	m æ ɹ ɪ n e ɪ t
 marine	m ə ɹ iː n
 mariner	m æ ɹ ɪ n ə
 marinette	m ɛ ɹ i n e t
-mario	m a ɹ iː ə ʊ
-mario	m ɑː ɹ iː ə ʊ
+mario	m a ɹ i ə ʊ
+mario	m ɑː ɹ i ə ʊ
 mariolatrous	m æ ɹ i ɒ l ə t ɹ ə s
 mariolatry	m ɛː ɹ i ɒ l ə t ɹ i
 marionette	m æ ɹ i ə n ɛ t
@@ -39928,6 +40454,7 @@ marks	m ɑː k s
 markstone	m ɑː k s t ə ʊ n
 markup	m ɑː ɹ k ʌ p
 markworthy	m ɑː k w ɜː ð i
+markèd	m ɑː k ɪ d
 marl	m ɑː l
 marlborough	m ɑː ɹ l b ɹ ə
 marlborough	m ɔː l b ɹ ə
@@ -40025,7 +40552,6 @@ maréchaussée	m a ɹ e ɪ ʃ ə ʊ s e ɪ
 masaccio	m æ s æ t͡ʃ i o ʊ
 masala	m ə s ɑː l ə
 masc	m æ s k
-masc	m ɑː s k
 mascara	m ə s k ɑː ɹ ə
 mascaron	m æ s k ə ɹ ɒ n
 mascarpone	m æ s k ə ɹ p ə ʊ n i
@@ -40205,6 +40731,7 @@ maturate	m æ t͡ʃ ə ɹ e ɪ t
 mature	m ə t j ʊ ə
 mature	m ə t͡ʃ ɔː
 mature	m ə t͡ʃ ʊ ə
+maturely	m ə t j ʊ ə ɹ l i
 maturity	m ə t j ʊ ə ɹ ə t i
 maturity	m ə t͡ʃ ʊ ə ɹ ə t i
 matutinal	m æ t j ʊ t a ɪ n l̩
@@ -40284,7 +40811,6 @@ maykop	m a ɪ k ɒ p
 mayn't	m e ɪ n t
 mayn't	m e ɪ ə n t
 maynooth	m ə n uː θ
-mayo	m e ɪ o ʊ
 mayo	m e ɪ ə ʊ
 mayonnaise	m e ɪ ə n e ɪ z
 mayor	m e ɪ ə
@@ -40311,6 +40837,7 @@ mcclusky	m ə k l ʌ s k i
 mccobb	m ə k ɑ b
 mcconaughey	m ə k k ɒ n ə h e ɪ̯
 mccoy	m ə k ɔ ɪ
+mccrum	m ɪ k ɹ ʌ m
 mcdonald	m ə k d ɒ n ə l d
 mcghie	m ɪ ɡ iː
 mcgough	m ə ɡ j uː
@@ -40362,6 +40889,7 @@ meant	m ɛ n t
 meantime	m iː n t a ɪ m
 meanwhile	m iː n w a ɪ l
 mear	m ɪ ə ɹ
+measle	m iː z ə l
 measles	m iː z ə l z
 measlings	m iː z l ɪ ŋ z
 measly	m iː z l i
@@ -40470,6 +40998,7 @@ medullary	m ɛ d͡ʒ u l ɛ ɹ i
 medusa	m ɪ d j uː s ə
 medusa	m ɪ d j uː z ə
 medusoid	m ə d j uː z ɔ ɪ d
+medway	m ɛ d w e ɪ
 meed	m iː d
 meedless	m iː d l ə s
 meef	m iː f
@@ -40532,6 +41061,7 @@ meghalaya	m e ɪ ɡ ɑː l ə j ə
 meghan	m e ɪ ɡ ə n
 meghan	m iː ɡ ə n
 meghan	m ɛ ɡ ə n
+meghna	m e ɡ n a
 megiddo	m ə ɡ ɪ d ə ʊ
 megillah	m ə ɡ ɪ l ə
 megilp	m ə ɡ ɪ l p
@@ -40570,6 +41100,7 @@ melee	m ɛ l e ɪ
 melee	m ɛ l i
 melena	m ə l iː n ə
 melena	m ɪ l iː n ə
+melete	m ɛ l ɪ t i
 melic	m ɛ l ɪ k
 melilot	m ɛ l ɪ l ɒ t
 melinda	m ə l ɪ n d ə
@@ -40591,6 +41122,7 @@ mellon	m ɛ l ɒ n
 mellow	m ɛ l ə ʊ
 melly	m ɛ l i
 melodeon	m ɪ l ə ʊ d ɪ ə n
+melodic	m ɪ l ɒ d ɪ k
 melodious	m ə l ə ʊ d i ə s
 melodrama	m ɛ l ə d ɹ ɑː m ə
 melodramata	m ɛ l ə d ɹ ɑː m ə t ə
@@ -40663,14 +41195,18 @@ mendoza	m ɛ n d o ʊ z ə
 menelaus	m ɛ n ɪ l e ɪ ə s
 menendez	m ə n ɛ n d ɛ z
 mengzhou	m ʌ ŋ d͡ʒ o ʊ
+menhaden	m ɛ n h e ɪ d ə n
 menhir	m ɛ n h ɪ ə
 menial	m iː n i ə l
 meningeal	m ɪ n ɪ n d͡ʒ i ə l
+meningitis	m ɛ n ɪ n d ʒ a ɪ t ɪ s
 meninx	m iː n ɪ ŋ k s
 meniscus	m ə n ɪ s k ə s
 meniscus	m ɛ n ɪ s k ə s
 mennish	m ɛ n ɪ ʃ
 menobranch	m ɛ n ə b ɹ æ ŋ k
+menoetius	m ɪ n iː ʃ i ə s
+menoetius	m ɪ n iː ʃ ə s
 menopause	m ɛ n o ʊ p ɔː z
 menopause	m ɛ n ə p ɔː z
 menorah	m ɪ n ɔː ɹ ə
@@ -40727,6 +41263,7 @@ mercaptopurine	m ɜː k a p t ə ʊ p j ɔː ɹ iː n
 mercaptopurine	m ɜː k a p t ə ʊ p j ʊ ə ɹ iː n
 mercator	m ə k e ɪ t ə
 mercator	m ɜː k e ɪ t ə
+merce	m ɜː ɹ s
 merced	m ɜː r s ɛ d
 mercedes	m ə s e ɪ d i z
 mercenary	m ɜː s ə n ə ɹ i
@@ -40954,6 +41491,7 @@ metempsychosis	m ɛ t ə m s ʌ ɪ k ə ʊ s ɪ s
 meteor	m iː t ɪ ɔː
 meteor	m iː t ɪ ə
 meteoric	m iː t i ɒ ɹ ɪ k
+meteorical	m iː t i ɒ ɹ ɪ k ə l
 meteorite	m iː t ɪ ə ɹ a ɪ t
 meteoritics	m iː t ɪ ə ɹ ɪ t ɪ k s
 meteoroidal	m iː t ɪ ə ɹ ɔ ɪ d l̩
@@ -40987,6 +41525,7 @@ methimazole	m ɪ θ ɪ m ə z ə ʊ l
 methinks	m ɪ θ ɪ ŋ k s
 methionine	m ɪ θ ʌ ɪ ə n iː n
 methionine	m ɪ θ ʌ ɪ ə n ɪ n
+methioninemia	m ə θ a ɪ ə n ɪ n iː m i ə
 method	m ɛ θ ə d
 methodist	m ɛ θ ə d ɪ s t
 methodology	m ɛ θ ə d ɒ l ə d͡ʒ i
@@ -41057,6 +41596,7 @@ metz	m ɛ t s
 metzian	m ɛ t s ɪ ə n
 meu	m j uː
 meum	m iː ə m
+meuse	m j uː z
 meute	m j uː t
 mevushal	m ɪ v uː ʃ ɑː l
 mevushal	m ɪ v ʊ ʃ ə l
@@ -41064,7 +41604,6 @@ mew	m j uː
 mewl	m j uː l
 mews	m j uː z
 mexicali	m ɛ k s ɪ k æ l i
-mexican	m ɛ k s ə k ə n
 mexican	m ɛ k s ɪ k ə n
 mexico	m ɛ k s ɪ k ə ʊ
 mexicoke	m ɛ k s ɪ k ə ʊ k
@@ -41087,6 +41626,7 @@ mi'kmaq	m ɪ ɡ m ɔː
 mi'kmaq	m ɪ ɡ ə m ɒ k
 mia	m iː ə
 miami	m a ɪ æ m i
+miami	m a ɪ æ m ə
 miasma	m a ɪ æ z m ə
 miasma	m i æ z m ə
 miasmatic	m a ɪ ə z m æ t ɪ k
@@ -41165,6 +41705,7 @@ micturate	m ɪ k t͡ʃ ə ɹ e ɪ t
 miculek	m ɪ t͡ʃ ə l ɛ k
 mid	m ɪ d
 midazolam	m ʌ ɪ d e ɪ z ə ʊ l a m
+midbroad	m ɪ d b ɹ ɔː d
 midday	m ɪ d d e ɪ
 middelmannetjie	m ɪ d ə l m a n ə k i
 middelmannetjie	m ɪ d ə l m a n ə t ʃ i
@@ -41476,6 +42017,8 @@ mirrors	m ɪ ɹ ə z
 mirrour	m ɪ ɹ ə
 mirrour	m ɪ ɹ ɚ
 mirth	m ɜː θ
+mirthless	m ɝ θ l ə s
+mirthless	m ɝ θ l ɪ s
 miry	m a ɪ ə ɹ i
 mirza	m əː z ə
 mirza	m ɪ ə z ə
@@ -41513,8 +42056,8 @@ mischanceful	m ɪ s t͡ʃ æ n s f ə l
 mischanceful	m ɪ s t͡ʃ ɑː n s f ə l
 mischaracterization	m ɪ s k æ ɹ ə k t ə ɹ a ɪ z e ɪ ʃ ə n
 mischevious	m ɪ s t͡ʃ iː v i ə s
-mischief	m ɪ s t ʃ iː f
-mischief	m ɪ ʃ t ʃ iː f
+mischief	m ɪ s t͡ʃ iː f
+mischief	m ɪ ʃ t͡ʃ iː f
 mischieve	m ɪ s t ʃ iː v
 mischievious	m ɪ s t͡ʃ iː v i ə s
 mischievous	m ɪ s t͡ʃ ə v ə s
@@ -41556,6 +42099,7 @@ miserabilism	m ɪ z ɹ ə b ə l ɪ z ə m
 miserabilist	m ɪ z ə ɹ ə b ə l ɪ s t
 miserable	m ɪ z ə ɹ ə b ə l
 miserabler	m ɪ z ɹ ə b ə l ə ɹ
+miserere	m ɪ z ə ɹ ɛ ə ɹ i
 misericordia	m ɪ s ə ɹ ɪ k ɔː ɹ d i ə
 miserly	m a ɪ z ə ɹ l i
 misery	m ɪ z ə ɹ ɪ
@@ -41640,6 +42184,7 @@ misregard	m ɪ s ɹ ɪ ɡ ɑː ɹ d
 misregister	m ɪ s ɹ ɛ d͡ʒ ɪ s t ə ɹ
 misremember	m ɪ s ɹ ɪ m ɛ m b ə
 misrepair	m ɪ s ɹ ɪ p ɛ ə ɹ
+misrepresentation	m ɪ s ɹ ɛ p ɹ ɪ z ɛ n t e ɪ ʃ ə n
 misrespect	m ɪ s ɹ ɪ s p ɛ k t
 misrule	m ɪ s ɹ uː l
 miss	m ɪ s
@@ -41865,6 +42410,7 @@ moffie	m ɒ f i
 moffitt	m ɒ f ɪ t
 mofo	m ə ʊ f ə ʊ
 mofussil	m ə ʊ f ʌ s ə l
+mog	m ɒ ɡ
 moggy	m ɒ ɡ i
 mogollon	m o ʊ ɡ ə j o ʊ n
 mogra	m ə ʊ ɡ ɹ ə
@@ -41929,6 +42475,7 @@ molestation	m ɒ l ɪ s t e ɪ ʃ ə n
 molestation	m ə ʊ l ɪ s t e ɪ ʃ ə n
 molester	m ə l ɛ s t ə ɹ
 moliminous	m ə ʊ l ɪ m ɪ n ə s
+molineux	m ɒ l ɪ n j uː
 moll	m ɒ l
 mollie	m ɒ l i
 mollie	m ɒ l ɪ
@@ -41984,6 +42531,7 @@ moncton	m ʌ ŋ k t ə n
 monday	m ʌ n d e ɪ
 monday	m ʌ n d i
 mondegreen	m ɒ n d ə ɡ ɹ iː n
+mondial	m ɒ n d i ə l
 monet	m o ʊ n e ɪ
 monetary	m ʌ n ɪ t ə ɹ i
 monetary	m ʌ n ɪ t ɹ i
@@ -42122,6 +42670,7 @@ montenegro	m ɒ n t ɪ n ɛ ɡ ɹ ə ʊ
 monterey	m ɒ n t ə ɹ e ɪ
 montero	m ɒ n t ɛ ə ɹ o ʊ
 monterrey	m ɒ n t ə ɹ e ɪ
+montes	m ɒ n t i z
 montevideo	m ɒ n t ɪ v ɪ d e ɪ ə ʊ
 montezuma	m ɒ n t ɪ z uː m ə
 montferrat	m ɒ n t f ə ɹ a t
@@ -42131,6 +42680,7 @@ montgomeryshire	m ɒ n t ɡ ʌ m ɹ i ʃ ɪ ə ɹ
 month	m ʌ n θ
 monthly	m ʌ n θ l i
 months	m ʌ n θ s
+montiform	m ɒ n t ɪ f ɔː m
 montjuïc	m ɒ n t ʒ uː iː k
 montpelier	m ɒ n t p iː l ɪ ə
 montpellier	m ɒ n p ɛ l i e ɪ
@@ -42143,6 +42693,7 @@ monument	m ɒ n j ʊ m ə n t
 monumental	m ɒ n j ʊ m ɛ n t ə l
 monumentally	m ɒ n j ʊ m ɛ n t ə l i
 monuments	m ɒ n j ʊ m ə n t s
+monyash	m ɒ n iː æ ʃ
 monégasque	m ɒ n ə ɡ a s k
 monégasque	m ɒ n ɪ ɡ a s k
 moo	m uː
@@ -42168,6 +42719,8 @@ moon	m uː n
 moonbat	m uː n b æ t
 mooncake	m uː n k e ɪ k
 mooncalf	m uː n k ɑː f
+moonflask	m uː n f l æ s k
+moonflask	m uː n f l ɑː s k
 moonflower	m uː n f l a ʊ ə
 moong	m ʊ ŋ
 moonlit	m uː n l ɪ t
@@ -42527,6 +43080,7 @@ mses	m ɪ z ə z
 mss	m ɪ z ə z
 mth	ɛ m θ
 mthwakazi	ə m t w ɑː k ɑː z i
+mtskheta	m ə t s k e ɪ t ə
 mtso	m ɛ t s ə ʊ
 mu	m j uː
 mu	m uː
@@ -42583,7 +43137,7 @@ muggy	m ʌ ɡ i
 mugham	m u ɡ ɑ m
 mugient	m j uː d͡ʒ i ə n t
 mugient	m j uː d͡ʒ ə n t
-mugwort	m ʌ ɡ w əː t
+mugwort	m ʌ ɡ w ɜː t
 mugwump	m ʌ ɡ w ʌ m p
 mugwumps	m ʌ ɡ w ʌ m p s
 muh	m ə
@@ -42623,6 +43177,7 @@ muleteer	m j uː l ə t ɪ ə ɹ
 mulga	m ʌ l ɡ ə
 mulgrave	m ʌ l ɡ ɹ e ɪ v
 mulhouse	m ə l uː z
+muliebral	m j uː l ɪ iː b ɹ ə l
 muliebrity	m j uː l ɪ ɛ b ɹ ɪ t i
 mulier	m j uː l ɪ ə
 mull	m ʌ l
@@ -42636,6 +43191,7 @@ mullered	m ʊ l ə ɹ d
 mullet	m ʌ l ə t
 mullet	m ʌ l ɪ t
 mulligan	m ʌ l ɪ ɡ ə n
+mulligatawny	m ʌ l ɪ ɡ ə t ɔː n i
 mullins	m ʌ l ɪ n z
 mullion	m ʌ l i ə n
 multibillion	m ʌ l t i b ɪ l j ə n
@@ -42687,7 +43243,7 @@ mumble	m ʌ m b ə l
 mumchance	m ʌ m t ʃ ɑː n s
 mummer	m ʌ m ə
 mummer	m ʌ m ɚ
-mummerset	m ʌ m ə ɹ s ɛ t
+mummerset	m ʌ m ə s ɛ t
 mummiform	m ʌ m ɪ f ɔː m
 mummy	m ʌ m i
 mump	m ʌ m p
@@ -42696,6 +43252,7 @@ mun	m ʌ n
 munch	m ʌ n t ʃ
 munchies	m ʌ n t͡ʃ i z
 munchkin	m ʌ n ʃ k ɪ n
+muncie	m ʌ n s i
 mund	m ʊ n d
 mund	m ʌ n d
 mundane	m ʌ n d e ɪ n
@@ -42706,12 +43263,18 @@ mung	m uː ŋ
 mung	m ʌ ŋ
 mungaree	m ʌ n d ʒ ɑː ɹ i
 munge	m ʌ n d͡ʒ
+munged	m ʌ n d͡ʒ d
+munged	m ʌ ŋ d
 munger	m ʌ n d͡ʒ ə
+munger	m ʌ ŋ ə
+munging	m ʌ n d͡ʒ ɪ ŋ
+munging	m ʌ ŋ ɪ ŋ
 munich	m j uː n ɪ k
 municipal	m j u n ɪ s ɪ p ə l
 municipality	m j ʊ n ɪ s ɪ p æ l ɪ t i
 municipium	m j uː n ɪ s ɪ p ɪ ə m
 munificence	m j uː n ɪ f ɪ s ə n s
+munificent	m j u n ɪ f ɪ s n̩ t
 muniment	m j uː n ɪ m ə n t
 munira	m uː n ɪ ə ɹ ə
 munite	m j uː n a ɪ t
@@ -42844,6 +43407,7 @@ mussed	m ʌ s t
 mussel	m ʌ s ə l
 musselburgh	m ʌ s ə l b ə ɹ ə
 mussitate	m ʌ s ɪ t e ɪ t
+mussitation	m ʌ s ɪ t e ɪ ʃ n̩
 mussolini	m ʊ s ə l iː n i
 mussuck	m ʌ s ə k
 mussulman	m ʌ s ə l m ə n
@@ -42940,6 +43504,7 @@ myoclonus	m a ɪ o ʊ k l o ʊ n ə s
 myofilament	m a ɪ o ʊ f ɪ l ə m ə n t
 myogenic	m ʌ ɪ ə d ʒ ɛ n ɪ k
 myoglobinemia	m a ɪ ə ʊ ɡ l ə ʊ b ɪ n iː m ɪ ə
+myokine	m a ɪ ə ʊ k a ɪ n
 myology	m ʌ ɪ ɒ l ə d ʒ i
 myometrium	m a ɪ ə ʊ m iː t ɹ i ə m
 myopia	m a ɪ ə ʊ p ɪ ə
@@ -43046,6 +43611,7 @@ nacelle	n ə s ɛ l
 nacho	n æ t͡ʃ ə ʊ
 nachos	n æ t ʃ ə ʊ z
 nack	n æ k
+nackawic	n æ k ə w ɪ k
 nacogdoches	n æ k ə d o ʊ t͡ʃ ɪ s
 nacre	n e ɪ k ə
 nacreous	n e ɪ k ɹ i ə s
@@ -43369,6 +43935,7 @@ neave	n iː v
 neb	n ɛ b
 nebbiolo	n ɛ b ɪ ə ʊ l ə ʊ
 nebbish	n ɛ b ɪ ʃ
+nebentan	n ə b ɛ n t æ n
 nebracetam	n ə b ɹ æ s ɪ t æ m
 nebris	n ɛ b ɹ ɪ s
 nebuchadnezzar	n ɛ b j ʊ k ə d n ɛ z ə
@@ -43404,6 +43971,8 @@ neckwear	n ɛ k w ɛ ɚ
 necrectomy	n ə k ɹ ɛ k t ə m i
 necrocracy	n ɛ k ɹ ɒ k ɹ ə s i
 necrology	n ɛ k ɹ ɒ l ə d ʒ i
+necrolysis	n ə k ɹ ɔ l ə s ə s
+necrolysis	n ə k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ɪ s ɪ s
 necromancer	n e k ɹ ə ʊ m æ n s ə
@@ -43425,7 +43994,7 @@ necropsy	n ɛ k ɹ ɒ p s i
 necropsy	n ɪ k ɹ ɒ p s i
 necrosectomy	n ɛ k ɹ o ʊ z ɛ k t ə m i
 nectar	n ɛ k t ə
-nectarine	n ɛ k t ə ɹ i n
+nectarine	n ɛ k t ə ɹ iː n
 ned	n ɛ d
 neddy	n ɛ d i
 neds	n ɛ d z
@@ -43692,6 +44261,7 @@ neville	n ɛ v ə l
 nevin	n ɛ v ɪ n
 nevirapine	n ɪ v ʌ ɪ ɹ ə p iː n
 nevis	n iː v ɪ s
+nevus	n iː v ə s
 new	n j uː
 newall	n uː ə l
 newark	n j uː ə k
@@ -44429,6 +44999,7 @@ numbered	n ʌ m b ə d
 numberous	n ʌ m b ə ɹ ə s
 numberous	n ʌ m b ɹ ə s
 numbers	n ʌ m b ə z
+numby	n ʌ m i
 numchuck	n ʌ m t͡ʃ ʌ k
 numen	n j uː m ə n
 numeral	n j uː m ə ɹ ə l
@@ -44611,10 +45182,9 @@ obedience	ə ʊ b iː d ɪ ə n s
 obedient	ə b iː d ɪ ə n t
 obedient	ə ʊ b iː d ɪ ə n t
 obediential	ə ʊ b iː d i ɛ n ʃ ə l
-obeisance	o ʊ b e ɪ s ə n s
-obeisance	o ʊ b iː s ə n s
 obeisance	ə b e ɪ s ə n s
 obeisance	ə b iː s ə n s
+obeisance	ə ʊ b e ɪ s ə n s
 obeli	ɒ b ɪ l a ɪ
 obelisk	ɒ b ə l ɪ s k
 obelized	ɒ b ə l a ɪ z d
@@ -44686,6 +45256,8 @@ oblique	ə b l iː k
 obliquity	ə b l ɪ k w ɪ t i
 oblite	ə b l a ɪ t
 obliterate	ə b l ɪ t ə ɹ e ɪ t
+obliterate	ə b l ɪ t ə ɹ ə t
+obliterated	ə b l ɪ t ə ɹ e ɪ t ɪ d
 obliviality	ə b l ɪ v i æ l ɪ t i
 oblivion	ə b l ɪ v iː ə n
 oblivious	ə b l ɪ v iː ə s
@@ -44894,7 +45466,6 @@ octogenary	ɒ k t ɒ d͡ʒ ɪ n ə r i
 octogram	ɒ k t o ʊ ɡ ɹ æ m
 octogram	ɒ k t ə ɡ ɹ æ m
 octopawn	ɒ k t ə p ɔː n
-octopodes	ɒ k t ɒ p ə d iː z
 octopus	ɒ k t ə p ə s
 octopus	ɒ k t ə p ʊ s
 octosyllabic	ɒ k t ə ʊ s ɪ l æ b ɪ k
@@ -44950,6 +45521,7 @@ odysseus	o ʊ d ɪ s i ə s
 odysseus	o ʊ d ɪ s j uː s
 odysseus	ə d ɪ s j uː s
 odyssey	ɒ d ə s i
+odyssey	ɒ d ɪ s i
 oe	o i
 oe	ɔ ɪ
 oe	ə ʊ
@@ -45013,6 +45585,7 @@ officer	ɒ f ə s ə
 officer	ɒ f ɪ s ə
 officers	ɒ f ɪ s ə z
 offices	ɒ f ɪ s ɪ z
+officetel	ɒ f ɪ s t ɛ l
 officey	ɒ f ɪ s i
 official	ə f ɪ ʃ ə l
 officialdom	ə f ɪ ʃ ə l d ə m
@@ -45064,7 +45637,6 @@ ogonek	ɒ ɡ ɒ n ɛ k
 ogonek	ə ʊ ɡ ə n ɛ k
 ogre	ə ʊ ɡ ə
 ogreishly	ə ʊ ɡ ə ɹ ɪ ʃ l i
-ogress	ə ʊ ɡ ɹ ə s
 ogress	ə ʊ ɡ ɹ ɛ s
 ogry	ə ʊ ɡ ɹ i
 ogun	ə ʊ ɡ ə n
@@ -45434,6 +46006,7 @@ ophthalmia	ɒ f θ æ l m i ə
 ophthalmia	ɒ p θ æ l m i ə
 ophthalmic	ɒ f θ a l m ɪ k
 ophthalmic	ɒ p θ a l m ɪ k
+ophthalmitis	ɒ f θ æ l m a ɪ t ɪ s
 ophthalmologist	ɒ f θ æ l m ɒ l ə d͡ʒ ɪ s t
 ophthalmology	ɒ f θ æ l m ɒ l ə d͡ʒ i
 ophthalmology	ɒ f θ ə l m ɒ l ə d͡ʒ i
@@ -45514,6 +46087,7 @@ optimistic	ɒ p t ɪ m ɪ s t ɪ k
 optimize	ɒ p t ɪ m a ɪ z
 optimum	ɒ p t ɪ m ə m
 option	ɒ p ʃ ə n
+optional	ɒ p ʃ ə n ə l
 optoacoustic	ɒ p t ə ʊ ə k uː s t ɪ k
 optocoupler	ɒ p t ə ʊ k ʌ p l ə
 optoelectronics	ɒ p t ə ʊ iː l ɛ k t ɹ ɒ n ɪ k s
@@ -45758,6 +46332,8 @@ orthopteroid	ɔː θ ɒ p t ə ɹ ɔ ɪ d
 orthopyroxene	ɔː θ ə ʊ p a ɪ ɹ ɒ k s iː n
 orthoquartzite	ɔː θ ə ʊ k w ɔː t s a ɪ t
 orthorhombic	ɔː ɹ θ ə ɹ ɒ m b ɪ k
+orthosexual	ɔː ɹ θ ə s ɛ k s j u ə l
+orthosexual	ɔː ɹ θ ə s ɛ k ʃ u ə l
 ortolan	ɔː t ə l æ n
 ortolan	ɔː t ə l ə n
 orvietan	ɔː v ɪ e ɪ t ə n
@@ -45822,6 +46398,7 @@ ossicone	ɒ s ɪ k ə ʊ n
 ossifier	ɒ s ɪ f a ɪ ə ɹ
 ossifrage	ɒ s ɪ f ɹ ɪ d͡ʒ
 ossify	ɒ s ɪ f a ɪ
+ossining	ɒ s ɪ n ɪ ŋ
 ossuarium	ɒ s j u ɛ ə ɹ i ə m
 ostend	ɒ s t ɛ n d
 ostensible	ɒ s t ɛ n s ɪ b ə l
@@ -45843,6 +46420,8 @@ ostiary	ɒ s t i ə ɹ i
 ostiary	ɒ s t͡ʃ ə ɹ i
 ostinato	ɒ s t ɪ n ɑ t o ʊ
 ostler	ɒ s l ə
+ostracean	ɒ s t ɹ e ɪ ʃ i ə n
+ostracean	ɒ s t ɹ e ɪ ʃ ə n
 ostracism	ɒ s t ɹ ə s ɪ z ə m
 ostracize	ɒ s t ɹ ə s a ɪ z
 ostracon	ɒ s t ɹ ə k ɒ n
@@ -45851,6 +46430,7 @@ ostrich	ɒ s t ɹ ɪ d͡ʒ
 ostrich	ɒ s t ɹ ɪ t͡ʃ
 ostrichism	ɒ s t ɹ ɪ t ʃ ɪ z ə m
 ostrobogulous	ɒ s t ɹ ə ʊ b ɒ ɡ j ʊ l ə s
+ostrogoth	ɒ s t r ə ɡ ɒ θ
 oswaldtwistle	ɒ z ə l t w ɪ z ə l
 oswego	ɒ s w iː ɡ o ʊ
 otacousticon	ə ʊ t ə k uː s t ɪ k ɒ n
@@ -45863,7 +46443,7 @@ othering	ʌ ð ə ɹ ɪ ŋ
 othering	ʌ ð ɹ ɪ ŋ
 others	ʌ ð ə z
 othersome	ʌ ð ə s ə m
-otherwhere	ʌ ð ə w ɛː
+otherwhere	ʌ ð ə ɹ w ɛː ɹ
 otherwise	ʌ ð ə w a ɪ z
 otic	ɒ t ɪ k
 otic	ə ʊ t ɪ k
@@ -45922,6 +46502,9 @@ ounce	a ʊ n s
 ounces	a ʊ n s ɪ z
 ouphe	a ʊ f
 ouphe	uː f
+ouppy	o ʊ ʌ p i
+ouppy	u p i
+ouppy	ʌ p i
 our	a ʊ ɚ
 our	æ ɔ ə
 our	ɑ ɹ
@@ -46159,7 +46742,7 @@ overridden	ə ʊ v ə ɹ ɪ d ə n
 override	ə ʊ v ə ɹ a ɪ d
 overriding	ə ʊ v ə ɹ ɹ a ɪ d ɪ ŋ
 overrode	ə ʊ v ə ɹ ə ʊ d
-overrule	ə ʊ v ə ɹ ɹ uː l
+overrule	ə ʊ v ə ɹ uː l
 overrun	ə ʊ v ə ɹ ʌ n
 oversanguine	ə ʊ v ə s a ŋ ɡ w ɪ n
 overscent	ə ʊ v ə s ɛ n t
@@ -46174,7 +46757,7 @@ overshadow	ə ʊ v ə ʃ æ d ə ʊ
 overshorten	ə ʊ v ə ʃ ɔː t ə n
 overshot	ə ʊ v ə ʃ ɒ t
 overside	ə ʊ v ə ɹ s a ɪ d
-oversight	o ʊ v ə ɹ s a ɪ t
+oversight	ə ʊ v ə s a ɪ t
 oversit	ə ʊ v ə ɹ s ɪ t
 overskirt	ə ʊ v ə s k ɜː t
 oversleep	ə ʊ v ə ɹ s l iː p
@@ -46210,6 +46793,7 @@ overtax	ə ʊ v ə ɹ t æ k s
 overthrow	ə ʊ v ə θ ɹ ə ʊ
 overthrowal	ə ʊ v ə θ ɹ ə ʊ ə l
 overthwart	ə ʊ v ə θ w ɔː t
+overtime	ə ʊ v ə t a ɪ m
 overton	ə ʊ v ə t ə n
 overtone	ə ʊ v ə t ə ʊ n
 overtop	ə ʊ v ə ɹ t ɒ p
@@ -46258,6 +46842,7 @@ owie	a ʊ w iː
 owing	ə ʊ ɪ ŋ
 owl	a ʊ l
 owler	a ʊ l ə
+owlet	a ʊ l ə t
 owlful	a ʊ l f l̩
 owlful	a ʊ l f ʊ l
 owling	a ʊ l ɪ ŋ
@@ -46426,6 +47011,7 @@ paedo	p iː d ə ʊ
 paedobaptism	p iː d ə ʊ b a p t ɪ z ə m
 paedomorphic	p iː d ə ʊ m ɔː f ɪ k
 paedophile	p e d ə f ɑ e l
+paedophile	p iː d ə f a ɪ l
 paedophilophile	p iː d ə ʊ f ɪ l ə ʊ f a ɪ l
 paedopsychology	p iː d ə ʊ p s a ɪ k ɒ l ə d͡ʒ ɪ
 paedopsychology	p iː d ə ʊ p s ʌ ɪ k ɒ l ə d͡ʒ i
@@ -46498,6 +47084,7 @@ pair	p ɛ ə ɹ
 pairs	p ɛ ə z
 paisa	p a ɪ s ə
 paise	p a ɪ s ə
+paise	p e ɪ z
 paisley	p e ɪ z l i
 pakeha	p aː k e h aː
 pakeha	p aː k ə h aː
@@ -46719,6 +47306,7 @@ pandour	p æ n d ɔː ɹ
 pandour	p æ n d ʊ ə ɹ
 pane	p e ɪ n
 paned	p e ɪ n d
+paneer	p ə n iː ɹ
 panegyric	p æ n ə d͡ʒ a ɪ ɹ ɪ k
 panegyric	p æ n ə d͡ʒ ɪ ɹ ɪ k
 panegyrically	p a n ɪ d͡ʒ ɪ ɹ ɪ k l i
@@ -46870,6 +47458,7 @@ papillomavirus	p a p ɪ l ə ʊ m ə v ʌ ɪ ɹ ə s
 papillon	p æ p i ɒ n
 papillon	p æ p ɪ l ɒ n
 papillon	p ə p ɪ l i ə n
+papio	p e ɪ p iː o ʊ
 papish	p e ɪ p ɪ ʃ
 papist	p e ɪ p ɪ s t
 papistical	p ə p ɪ s t ɪ k ə l
@@ -46877,6 +47466,7 @@ papoose	p ə p uː s
 pappardelle	p æ p ɑː d ɛ l e ɪ
 pappy	p æ p i
 paprika	p æ p ɹ iː k ə
+paprika	p æ p ɹ ɪ k ə
 paprika	p ə p ɹ iː k ə
 papula	p æ p j ʊ l ə
 papyri	p æ p ɚ a ɪ
@@ -46906,6 +47496,7 @@ paracrine	p æ ɹ ə k ɹ ɪ n
 parade	p ə r ɑː d
 parade	p ə ɹ e ɪ d
 parades	p ə ɹ e ɪ d z
+paradiastole	p æ r ə d a ɪ æ s t ə l i
 paradiddle	p æ ɹ ə d ɪ d ə l
 paradigm	p æ ɹ ə d a ɪ m
 paradigma	p æ ɹ ə d ɪ ɡ m a
@@ -47042,6 +47633,7 @@ parenthetical	p æ ɹ ə n θ ɛ t ɪ k l̩
 parenthetically	p æ ɹ ə n θ ɛ t ɪ k l i
 parenting	p ɛ ə ɹ ə n t ɪ ŋ
 parents	p ɛ ə ɹ ə n t s
+pareo	p ɑː ɹ i ə ʊ
 parergy	p æ ɹ ə ɹ d͡ʒ i
 paresis	p ə ɹ iː s ɪ s
 paresthesis	p ə ɹ iː s θ ɪ s ɪ s
@@ -47196,6 +47788,7 @@ paschal	p a s k ə l
 pasco	p æ s k ə ʊ
 pash	p æ ʃ
 pasha	p æ ʃ ə
+pashes	p æ ʃ ɪ z
 pashto	p æ ʃ t ə ʊ
 pashto	p ʌ ʃ t ə ʊ
 pasifika	p ʌ s ɪ f ɪ k ʌ
@@ -47222,8 +47815,6 @@ passengers	p æ s ə n d͡ʒ ə z
 passepied	p æ s p i e ɪ
 passer	p ɑː s ə ɹ
 passerine	p æ s ə ɹ a ɪ n
-passerine	p æ s ə ɹ iː n
-passerine	p æ s ə ɹ ə n
 passes	p ɑː s ɪ z
 passible	p a s ɪ b ə l
 passim	p æ s ɪ m
@@ -47427,6 +48018,7 @@ pawnshop	p ɔː n ʃ ɒ p
 pawpaw	p ɔː p ɔː
 pawprint	p ɔː p ɹ ɪ n t
 paws	p ɔː z
+pawtucket	p ə t ʌ k ɪ t
 pax	p æ k s
 paxis	p æ k s ɪ s
 pay	p e ɪ
@@ -47707,6 +48299,7 @@ pendragon	p ɛ n d ɹ æ ɡ ə n
 pends	p ɛ n d z
 pendulum	p ɛ n d͡ʒ ə l ə m
 pendulum	p ɪ n d͡ʒ ə l ə m
+penelope	p ɪ n ɛ l ə p i
 peneplain	p iː n ɪ p l e ɪ n
 peneplain	p ɛ n ɪ p l e ɪ n
 penes	p iː n iː z
@@ -47737,6 +48330,7 @@ peninsula	p ɛ n ɪ n s j ʊ l ə
 peninsular	p ə n ɪ n s j ə l ə ɹ
 peninsular	p ɛ n ɪ n s j ʊ l ə ɹ
 penis	p iː n ɪ s
+penises	p iː n ɪ s ɪ z
 penitent	p ɛ n ɪ t ə n t
 penitential	p ɛ n ɪ t ɛ n ʃ ə l
 penitentiary	p ɛ n ɪ t ɛ n ʃ ə ɹ i
@@ -48041,6 +48635,7 @@ perniones	p ɜː n i ə ʊ n iː z
 perniosis	p ɜː n i ə ʊ s ɪ s
 pernoctate	p ɜː n ɒ k t e ɪ t
 pernoctation	p ɜː n ɒ k t e ɪ ʃ n̩
+pernod	p ɛ ə n ə ʊ
 peroneal	p ɛː ɹ ə n iː ə l
 peroneus	p ɛ ɹ ə ʊ n iː ə s
 peroration	p ɛ ɹ ɒ ɹ e ɪ ʃ ə n
@@ -48116,6 +48711,7 @@ personal	p ɜː s ə n ə l
 personality	p ɜː s ə n æ l ə t ɪ
 personalization	p ɜː s ə n ə l a ɪ z e ɪ ʃ ə n
 personally	p ɜː s n ə l i
+personally	p ɜː s ə n ə l i
 personator	p ɜː ɹ s ə n e ɪ t ə ɹ
 personhood	p ɝ s ə n h ʊ d
 personification	p ɚ s ɑ n ə f ə k e ɪ ʃ ə n
@@ -48223,7 +48819,7 @@ peterborough	p iː t ə ɹ b ɹ ə
 petersham	p iː t ə ʃ ə m
 peterview	p iː t ɚ v j uː
 pethidine	p ɛ θ ɪ d iː n
-petiole	p ɛ t ɪ ə ʊ l
+petiole	p ɛ t i ə ʊ l
 petit	p ə t iː
 petit	p ɛ t i
 petite	p ə t iː t
@@ -48247,6 +48843,7 @@ petrol	p ɛ t ɹ ə l
 petrology	p ɪ t ɹ ɒ l ə d͡ʒ i
 petronel	p ɛ t ɹ ə n ə l
 petropavl	p ɛ t ɹ ə p ɑː v ə l
+petrophilic	p ɛ t ɹ ə f ɪ l ɪ k
 petrosal	p ɪ t ɹ ə ʊ s l̩
 petrosal	p ɪ t ɹ ə ʊ s ə l
 petrosyan	p ɛ t ɹ ə ʊ s i ə n
@@ -48368,6 +48965,7 @@ phatic	f æ t ɪ k
 phaëthon	f e ɪ ə t ə n
 phaëthon	f e ɪ ə θ ə n
 pheasant	f ɛ z ə n t
+pheic	f e ɪ k
 phelonion	f ə l ə ʊ n i ə n
 phelps	f ɛ l p s
 phencyclidine	f ɛ n s a ɪ k l ɪ d iː n
@@ -48612,6 +49210,7 @@ phthalic	f θ æ l ɪ k
 phthisis	f θ a ɪ s ɪ s
 phthisis	t a ɪ s ɪ s
 phthonus	θ o ʊ n ə s
+phub	f ʌ b
 phugoid	f j uː ɡ ɔ ɪ d
 phuket	p uː k ɛ t
 phumdi	f u m d i
@@ -48687,6 +49286,7 @@ pice	p a ɪ s
 picene	p a ɪ s iː n
 piceous	p a ɪ s iː ə s
 piceous	p ɪ s ɪ ə s
+picidae	p ɪ s ə d iː
 pick	p ɪ k
 pickaninny	p ɪ k ə n ɪ n i
 picked	p ɪ k t
@@ -49210,6 +49810,7 @@ plasterly	p l ɑː s t ə ɹ l i
 plastic	p l æ s t ɪ k
 plastic	p l ɑː s t ɪ k
 plastically	p l a s t ɪ k l i
+plastician	p l æ s t ɪ ʃ ə n
 plasticizer	p l æ s t ɪ s a ɪ z ə
 plastron	p l æ s t ɹ ə n
 plat	p l æ t
@@ -49305,6 +49906,7 @@ pleb	p l ɛ b
 plebe	p l iː b
 plebeian	p l i b iː ə n
 plebeian	p l ɛ b iː ə n
+plebiscite	p l ɛ b ɪ s a ɪ t
 plebs	p l ɛ b z
 pleck	p l ɛ k
 plectile	p l ɛ k t a ɪ l
@@ -49685,6 +50287,8 @@ pollard	p ɒ l ə d
 polled	p ə ʊ l d
 pollen	p ɒ l ə n
 pollicate	p ɒ l ɪ k e ɪ t
+pollinate	p ɒ l ɪ n e ɪ t
+pollination	p ɒ l ɪ n e ɪ ʃ ə n
 pollinator	p ɒ l ɪ n e ɪ t ə ɹ
 pollinivore	p ɒ l ɪ n ɪ v ɔː ɹ
 pollinosis	p ɒ l ə n ə ʊ s ɪ s
@@ -49716,6 +50320,7 @@ polyamory	p ɒ l i æ m ə ɹ i
 polyarch	p ɒ l i ɑː k
 polyaxial	p ɒ l i æ k s i ə l
 polychaete	p ɒ l ɪ k iː t
+polychoron	p ɔ l ɪ k o ʊ ɹ ɔ n
 polychrest	p ɒ l ɪ k ɹ ɛ s t
 polychromatic	p ɒ l i k ɹ ə ʊ m æ t ɪ k
 polycratic	p ɒ l ɪ k ɹ a t ɪ k
@@ -49764,6 +50369,7 @@ polynya	p ə ʊ l ɪ n j ə
 polyol	p ɒ l ɪ ɒ l
 polyp	p ɒ l ɪ p
 polypantheism	p ɒ l i p æ n θ i ɪ z ə m
+polyphemus	p ɒ l ɪ f iː m ə s
 polyphiloprogenitive	p ɒ l ɪ f ɪ l ə p ɹ ə d͡ʒ ɛ n ɪ t ɪ v
 polyphonic	p ɒ l ɪ f ɒ n ɪ k
 polyphony	p ə l ɪ f ə n i
@@ -49798,6 +50404,7 @@ polyzoary	p ɒ l i z ə ʊ ə ɹ i
 polyzoary	p ɒ l i z ə ʊ ə ɹ iː z
 polyzoic	p ɒ l i z ə ʊ ɪ k
 polyzoon	p ɒ l i z ə ʊ ɒ n
+polzeath	p ɒ l z iː θ
 pom	p ɒ m
 pomace	p ɒ m ɪ s
 pomace	p ʌ m ɪ s
@@ -50030,6 +50637,8 @@ portuguese	p ɔː t͡ʃ ə ɡ iː z
 portulent	p ɔː ɹ t j ə l ə n t
 portus	p ɔː t ə s
 pory	p ɔː ɹ i
+pos	p ɒ z
+pos	p ə ʊ z
 pose	p ə ʊ z
 posed	p ə ʊ z d
 posedown	p ə ʊ z d a ʊ n
@@ -50074,6 +50683,7 @@ possessorship	p ə z ɛ s ə ɹ ʃ ɪ p
 posset	p ɒ s ɪ t
 possibilities	p ɒ s ɪ b ɪ l i t i z
 possibility	p ɒ s ɪ b ɪ l ɪ t i
+possible	p ɒ s ə b l̩
 possible	p ɒ s ɪ b l̩
 possibly	p ɒ s ɪ b l i
 posslq	p ɒ s l̩ k j uː
@@ -50277,6 +50887,7 @@ prague	p ɹ ɑː ɡ
 prahok	p ɹ ə h ɒ k
 praia	p ɹ a ɪ ə
 prairial	p ɹ ɛː ɹ ɪ ə l
+prairies	p ɹ ɛ ə ɹ i z
 praise	p ɹ e ɪ z
 praised	p ɹ e ɪ z d
 praiser	p ɹ e ɪ z ə ɹ
@@ -50441,9 +51052,9 @@ preengage	p r iː ɪ n ɡ e ɪ d͡ʒ
 preeternity	p ɹ iː ɪ t ɜː ɹ n ɪ t i
 preface	p ɹ ɛ f ə s
 preface	p ɹ ɛ f ɪ s
-prefect	p ɹ ɪ f ɛ k t
+prefect	p ɹ iː f ɛ k t
 prefecture	p ɹ iː f ɛ k t j ʊ ə
-prefecture	p ɹ iː f ɛ k t ʃ ə
+prefecture	p ɹ iː f ɛ k t͡ʃ ə
 prefer	p ɹ ɪ f ɜː
 preferable	p ɹ ɛ f ə ɹ ə b ə l
 preferably	p ɹ ə f ɜː ɹ ə b l i
@@ -50490,6 +51101,8 @@ premalignant	p ɹ i m ə l ɪ ɡ n ə n t
 premarin	p ɹ ɛ m ə ɹ ɪ n
 premature	p ɹ ɛ m ə t j ə
 premature	p ɹ ɛ m ə t j ʊ ə
+prematurely	p ɹ iː m ə t j ʊ ə ɹ l i
+prematurely	p ɹ ɛ m ə t j ʊ ə ɹ l i
 premeditate	p r iː m ɛ d ɪ t e ɪ t
 premenstrual	p ɹ iː m ɛ n s t ɹ ʊ l
 premenstrual	p ɹ iː m ɛ n s t ɹ ʊ ə l
@@ -50529,11 +51142,9 @@ prepared	p ɹ ɪ p ɛ ə d
 preparing	p ɹ ɪ p ɛ ə ɹ ɪ ŋ
 prepend	p ɹ ɪ p ɛ n d
 prepense	p ɹ ɪ p ɛ n s
-preplied	p ɹ ɪ p l a ɪ d
-preplies	p ɹ ɪ p l a ɪ z
-preply	p ɹ iː p l a ɪ
 preponderance	p ɹ ɪ p ɒ n d ə ɹ ə n s
 preponderance	p ɹ ɪ p ɒ n d ɹ ə n s
+preported	p ɹ ɪ p ɔː t ɪ d
 prepose	p ɹ iː p ə ʊ z
 preposition	p ɹ iː p ə z ɪ ʃ ə n
 preposition	p ɹ ɛ p ə z ɪ ʃ ə n
@@ -50853,6 +51464,7 @@ prndl	p ɹ ɪ n d l̩
 pro	p ɹ ə ʊ
 proa	p ɹ ə ʊ ə
 proactive	p ɹ ə ʊ æ k t ɪ v
+proactively	p ɹ ə ʊ æ k t ɪ v l i
 prob'ly	p ɹ ɒ b l i
 probability	p ɹ ɒ b ə b ɪ l ɪ t i
 probable	p ɹ ɒ b ə b l̩
@@ -50999,7 +51611,7 @@ proggie	p ɹ ɒ ɡ i
 prognathous	p r ɑ ɡ n e ɪ θ ə s
 prognathous	p r ɑ ɡ n ə θ ə s
 prognoses	p ɹ ɒ ɡ n ə ʊ s iː z
-prognoses	p ɹ ɒ ɡ n ə ʊ z ə s
+prognoses	p ɹ ɒ ɡ n ə ʊ z ɪ z
 prognosis	p ɹ ɒ ɡ n ə ʊ s iː z
 prognosis	p ɹ ɒ ɡ n ə ʊ s ɪ s
 prognostic	p ɹ ɒ ɡ n ɒ s t ɪ k
@@ -51381,6 +51993,7 @@ provision	p ɹ ə v ɪ ʒ ə n
 provisional	p ɹ ə v ɪ ʒ ə n ə l
 provisions	p ɹ ə v ɪ ʒ ə n z
 proviso	p ɹ ə v a ɪ z o ʊ
+provisor	p ɹ ə v a ɪ z ə ɹ
 provisory	p ɹ ə v a ɪ z ə ɹ i
 provo	p ɹ ə ʊ v ə ʊ
 provocate	p ɹ ə v ɒ k e ɪ t
@@ -51593,6 +52206,7 @@ pubeless	p j uː b l ə s
 puberty	p j uː b ə t i
 pubes	p j uː b i z
 pubes	p j uː b z
+pubescence	p j uː b ɛ s ə n s
 pubescent	p j ʊ b ɛ s ə n t
 pubic	p j uː b ɪ k
 pubikini	p j uː b ɪ k iː n i
@@ -51735,6 +52349,7 @@ pultaceous	p ʌ l t e ɪ ʃ ə s
 pulverulent	p ʌ l v ɛ ɹ j ə l ə n t
 puma	p j uː m ə
 puma	p uː m ə
+pumicate	p j uː m ɪ k e ɪ t
 pumice	p ʌ m ɪ s
 pummel	p ʌ m ə l
 pump	p ʌ m p
@@ -51811,6 +52426,7 @@ punxsutawney	p ʌ ŋ k s ə t ɔː n i
 puny	p j uː n i
 pup	p ʌ p
 pupa	p j uː p ə
+pupal	p j uː p ə l
 pupe	p j u p
 pupil	p j uː p ə l
 pupils	p j uː p ə l z
@@ -51869,7 +52485,8 @@ purportion	p ə p ɔː ʃ ə n
 purpose	p ɜː p ə s
 purposed	p əː p ə s t
 purposedly	p ɜː ɹ p ə s ɪ d l i
-purposeful	p ɜː ɹ p ə s f ə l
+purposeful	p ɜː p ə s f ə l
+purposefully	p ɜː p ə s f ə l i
 purposely	p ɜː p ə s l i
 purposes	p ɜː p ə s ɪ z
 purposive	p əː p ə s ɪ v
@@ -52059,6 +52676,7 @@ python	p a ɪ θ ə n
 pythonista	p a ɪ θ ə n ɪ s t ə
 pythons	p a ɪ θ ə n z
 pyx	p ɪ k s
+pyxis	p ɪ k s ɪ s
 pâté	p æ t e ɪ
 pædion	p iː d ɪ ɒ n
 pædomorphic	p iː d ə m ɔː f ɪ k
@@ -52099,6 +52717,7 @@ qingdao	t͡ʃ ɪ ŋ d a ʊ
 qinghai	t͡ʃ ɪ ŋ h a ɪ
 qinghaosu	t͡ʃ ɪ ŋ h a ʊ s uː
 qingpu	t͡ʃ ɪ ŋ p u
+qingsongite	t͡ʃ ɪ ŋ s ɒ ŋ a ɪ t
 qinpu	t͡ʃ ɪ n p uː
 qipao	t͡ʃ iː p a ʊ
 qiqihar	t ʃ iː t ʃ iː h ɑː
@@ -52168,8 +52787,6 @@ quahog	k w ɑː h ɒ ɡ
 quahog	k w ə ʊ h ɒ ɡ
 quahog	k ə ʊ h ɒ ɡ
 quaich	k w e ɪ k
-quail	k w e ɪ l
-quail	k w e ɪ ə l
 quailed	k w e ɪ l d
 quailing	k w e ɪ l ɪ ŋ
 quailings	k w e ɪ l ɪ ŋ z
@@ -52216,6 +52833,9 @@ quantitative	k w ɒ n t ə t ɪ v
 quantitative	k w ɒ n t ɪ t ə t ɪ v
 quantities	k w ɒ n t ɪ t i z
 quantity	k w ɒ n t ɪ t i
+quantivalence	k w ɒ n t ɪ v ə l ə n s
+quantivalency	k w ɒ n t ɪ v l ə n s i
+quantivalency	k w ɒ n t ɪ v ə l ə n s i
 quantized	k w ɒ n t ʌ ɪ z d
 quantum	k w ɒ n t ə m
 quantumly	k w ɒ n t ə m l i
@@ -52301,6 +52921,7 @@ quentin	k w ɛ n t ɪ n
 quercetin	k w ɜː ɹ s ɪ t ɪ n
 quercine	k w ɜː s a ɪ n
 quercine	k w ɜː s ɪ n
+quercitin	k w ɜ ɹ s ɪ t ɪ n
 querencia	k ɛ ɹ ɛ n s ɪ ə
 querent	k w ɚ ɛ n t
 querimonious	k w ɛ ɹ ɪ m ə ʊ n ɪ ə s
@@ -52417,6 +53038,7 @@ quinnat	k w ɪ n ə t
 quinoa	k iː n w ɑː
 quinoa	k iː n ə ʊ ə
 quinolone	k w ɪ n ə l ə ʊ n
+quinone	k w ɪ n ə ʊ n
 quinquagenarian	k w ɪ ŋ k w ə d͡ʒ ɪ n ɛ ə ɹ ɪ ə n
 quinquagenary	k w ɪ ŋ k w æ d͡ʒ ɪ n ə r i
 quinquagenary	k w ɪ ŋ k w ə d͡ʒ iː n ə ɹ i
@@ -52441,8 +53063,9 @@ quintating	k w ɪ n t e ɪ t ɪ ŋ
 quintation	k w ɪ n t e ɪ ʃ ə n
 quinte	k w ɪ n t i
 quintessence	k w ɪ n t ɛ s ə n s
-quintessential	k w ɪ n t ə s ɛ n ʃ ə l
-quintessentially	k w ɪ n t ɛ s ɛ n t͡ʃ ə l i
+quintessence	k w ɪ n t ɛ s ɪ n s
+quintessential	k w ɪ n t ɪ s ɛ n ʃ ə l
+quintessentially	k w ɪ n t ɪ s ɛ n ʃ ə l i
 quintet	k w ɪ n t ɛ t
 quintillion	k w ɪ n t ɪ l j ə n
 quintillionth	k w ɪ n t ɪ l i ə n θ
@@ -52485,6 +53108,7 @@ quizzacious	k w ɪ z e ɪ ʃ ə s
 quizzaciously	k w ɪ z e ɪ ʃ ə s l i
 quizzical	k w ɪ z ɪ k ə l
 qujing	t͡ʃ uː d͡ʒ ɪ ŋ
+qulin	k j uː l ɪ n
 qumran	k ʊ m ɹ ɑː n
 quo	k w ə ʊ
 quoad	k w o ʊ æ d
@@ -52555,6 +53179,7 @@ racer	ɹ e ɪ s ə
 races	ɹ e ɪ s ɪ z
 racetrack	ɹ e ɪ s t ɹ æ k
 rach	ɹ e ɪ t͡ʃ
+rach	ɹ æ t ʃ
 rachel	ɹ e ɪ t͡ʃ ə l
 rachis	ɹ e ɪ k ɪ s
 rachitic	ɹ ə k ɪ t ɪ k
@@ -52770,6 +53395,7 @@ rang	ɹ æ ŋ
 range	ɹ e ɪ n d͡ʒ
 ranger	ɹ e ɪ n d͡ʒ ə ɹ
 ranges	ɹ e ɪ n d͡ʒ ɪ z
+rangifer	r æ n d ʒ ɪ f ə ɹ
 rangiora	ɹ a ŋ ɡ i ɔː ɹ ə
 rangle	ɹ æ ŋ ɡ l̩
 rangoli	ɹ a ŋ ɡ ə ʊ l i
@@ -52803,6 +53429,7 @@ raper	ɹ e ɪ p ə ɹ
 raphae	ɹ e ɪ f iː
 raphael	ɹ æ f e ɪ ɛ l
 raphael	ɹ æ f ɪ ə l
+raphanus	r æ f ə n ə s
 raphe	ɹ e ɪ f i
 rapid	ɹ æ p ɪ d
 rapidity	ɹ ə p ɪ d ɪ t i
@@ -52942,6 +53569,7 @@ razorback	ɹ e ɪ z ə b æ k
 razz	ɹ æ z
 razzmatazz	ɹ æ z m ə t æ z
 raï	ɹ a ɪ
+raï	ɹ ʌ iː
 re	ɹ e ɪ
 re	ɹ iː
 reaccept	ɹ i ə k s e p t
@@ -52967,6 +53595,7 @@ readiness	ɹ ɛ d i n ə s
 reading	ɹ i d i ŋ
 reading	ɹ iː d ɪ ŋ
 reading	ɹ ɛ d ɪ ŋ
+readmission	ɹ iː æ d m ɪ ʃ ə n
 readout	ɹ iː d a ʊ t
 reads	ɹ iː d z
 ready	ɹ ɛ d i
@@ -53022,6 +53651,7 @@ reard	ɹ ɛː d
 reard	ɹ ɪː d
 reared	ɹ ɪ ə d
 rearguard	ɹ ɪ ə ɹ ɡ ɑ ɹ d
+rearview	ɹ ɪ ə v j uː
 rearward	ɹ ɪ ə w ɜː d
 reason	ɹ iː z ə n
 reasonable	ɹ iː z n ə b ə l
@@ -53088,6 +53718,7 @@ recapitulate	ɹ iː k ə p ɪ t ʃ ʊ l e ɪ t
 recapitulation	ɹ iː k ə p ɪ t j ʊ l e ɪ ʃ ə n
 recatholicization	ɹ iː k ə θ ɒ l ɪ s ʌ ɪ z e ɪ ʃ ə n
 recce	ɹ ɛ k i
+recede	ɹ ɪ s iː d
 receipt	ɹ ɪ s iː t
 receive	ɹ ɪ s iː v
 received	ɹ ɪ s iː v d
@@ -53249,7 +53880,7 @@ redden	ɹ ɛ d n̩
 reddest	ɹ ɛ d ɪ s t
 reddish	ɹ ɛ d ɪ ʃ
 reddishness	ɹ ɛ d ɪ ʃ n ə s
-reddit	r ɛ d ɪ t
+reddit	ɹ ɛ d ɪ t
 reddition	ɹ ə d ɪ ʃ ə n
 redditor	ɹ ɛ d ɪ t ə ɹ
 reddy	ɹ ɛ d i
@@ -53257,7 +53888,7 @@ rede	ɹ iː d
 redebug	ɹ iː d iː b ʌ ɡ
 redeem	ɹ ɪ d iː m
 redeliver	ɹ iː d ɪ l ɪ v ə ɹ
-redemption	ɹ ɪ d ɛ m ʃ ə n
+redemption	ɹ ɪ d ɛ m p ʃ ə n
 redemptory	ɹ ɪ d ɛ m p t ə ɹ i
 redesign	ɹ iː d ɪ z a ɪ n
 redesmouth	ɹ iː d z m ə θ
@@ -53386,6 +54017,7 @@ reflet	ɹ ə f l e ɪ
 reflexible	ɹ ɪ f l ɛ k s ɪ b ə l
 reflexion	ɹ ɪ f l ɛ k ʃ ə n
 reflexive	ɹ ə f l ɛ k s ɪ v
+refluent	ɹ ɛ f l u ə n t
 reflux	ɹ iː f l ʌ k s
 refold	ɹ iː f o ʊ l d
 reforecast	ɹ iː f ɔː k ɑː s t
@@ -53555,6 +54187,7 @@ reinstate	ɹ iː ɪ n s t e ɪ t
 reinter	ɹ iː ɪ n t ɝ
 reird	ɹ ɪ ə d
 reisz	ɹ a ɪ s
+reit	ɹ iː t
 reiter	ɹ ʌ ɪ t ə
 reiterant	ɹ i ɪ t ɝ ə n t
 reiterate	ɹ i ɪ t ə ɹ e ɪ t
@@ -53746,6 +54379,7 @@ renaissance	ɹ ə n e ɪ s ə n s
 renal	ɹ iː n ə l
 renaldo	ɹ ɪ n æ l d ə ʊ
 renaldo	ɹ ɪ n ɑ l d ə ʊ
+renarrative	ɹ iː n æ ɹ ə t ɪ v
 renascence	ɹ ɪ n a s ə n s
 renascence	ɹ ɪ n e ɪ s ə n s
 renascent	ɹ ɪ n e ɪ s ə n t
@@ -53882,6 +54516,7 @@ represented	ɹ ɛ p ɹ ɪ z ɛ n t ɪ d
 representing	ɹ ɛ p ɹ ɪ z ɛ n t ɪ ŋ
 repress	ɹ ə p ɹ ɛ s
 repressed	ɹ i p ɹ ɛ s t
+repressed	ɹ ɪ p ɹ ɛ s t
 reprieve	ɹ ɪ p ɹ iː v
 reprimand	ɹ ɛ p ɹ ɪ m ɑː n d
 reprinted	ɹ iː p ɹ ɪ n t ɪ d
@@ -53932,9 +54567,8 @@ request	ɹ ɪ k w ɛ s t
 requested	ɹ ɪ k w ɛ s t ɪ d
 requeue	ɹ iː k j uː
 requicken	r iː k w ɪ k ə n
+requiem	ɹ ɛ k w i ə m
 requiem	ɹ ɛ k w i ɛ m
-requiem	ɹ ɛ k w ɪ ə m
-requiem	ɹ ɛː k w i ə m
 requiescat	ɹ ɛ k w ɪ ɛ s k æ t
 require	ɹ ɪ k w a ɪ ə
 required	ɹ ɪ k w a ɪ ə d
@@ -53963,6 +54597,8 @@ rerun	ɹ iː ɹ ʌ n
 res	ɹ e ɪ z
 res	ɹ ɛ z
 resalute	ɹ iː s ə l uː t
+resched	ɹ iː s k ɛ d
+resched	ɹ iː ʃ ɛ d
 reschedule	ɹ iː s k ɛ d j uː l
 reschedule	ɹ iː s k ɛ d͡ʒ uː l
 reschedule	ɹ iː ʃ ɛ d j uː l
@@ -53973,8 +54609,8 @@ rescrutiny	ɹ iː s k ɹ uː t ɪ n i
 rescue	ɹ ɛ s k j uː
 rescued	ɹ ɛ s k j uː d
 rese	ɹ iː z
-research	ɹ iː s ɜː t ʃ
-research	ɹ ɪ s ɜː t ʃ
+research	ɹ iː s ɜː t͡ʃ
+research	ɹ ɪ s ɜː t͡ʃ
 researcher	ɹ ɪ s ɜː t͡ʃ ə
 researches	ɹ ɪ s ɜː t͡ʃ ɪ z
 reseat	ɹ iː s iː t
@@ -54045,6 +54681,7 @@ resonance	ɹ ɛ z ə n ə n s
 resonant	ɹ ɛ z ə n ə n t
 resonate	ɹ ɛ z ə n e ɪ t
 resorbable	ɹ ɪ z ɔː ɹ b ə b ə l
+resorcinol	ɹ ə z ɔː ɹ s ɪ n ɒ l
 resort	ɹ iː s ɔ ɹ t
 resound	ɹ iː s a ʊ n d
 resound	ɹ ɪ s a ʊ n d
@@ -54084,7 +54721,9 @@ resplendence	ɹ ɪ s p l ɛ n d ə n s
 resplendent	ɹ ɪ s p l ɛ n d ə n t
 respond	ɹ iː s p ɒ n d
 respond	ɹ ə s p ɒ n d
+respond	ɹ ɪ s p ɒ n d
 responded	ɹ ə s p ɒ n d ɪ d
+responded	ɹ ɪ s p ɒ n d ɪ d
 respondee	ɹ ɪ s p ɒ n d iː
 respondence	ɹ ɪ s p ɒ n d ə n s
 responder	ɹ ə s p ɒ n d ə
@@ -54204,6 +54843,7 @@ reticuloid	ɹ ɪ t ɪ k j ʊ l ɔ ɪ d
 retina	ɹ ɛ t ɪ n ə
 retinaculum	r ɛ t ɪ n æ k j ʊ l ə m
 retinal	ɹ ɛ t ɪ n ə l
+retinopathy	ɹ ɛ t ɪ n ɑː p ə θ i
 retinue	ɹ ɛ t ɪ n j uː
 retiral	ɹ ɪ t ʌ ɪ ə ɹ ə l
 retire	ɹ ə t a ɪ ə ɹ
@@ -54304,8 +54944,8 @@ reverberate	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ t
 reverberation	ɹ i v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ə v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ ʃ ə n
-reverberative	ɹ ə v ɜː b ə ɹ ə t ɪ v
 reverberative	ɹ ə v ɜː b ɹ ə t ɪ v
+reverberative	ɹ ɪ v ɜː b ə ɹ ə t ɪ v
 revere	ɹ ə v iː ɹ
 revered	ɹ ɪ v ɪ ə d
 reverence	ɹ ɛ v ə ɹ ə n s
@@ -54323,6 +54963,7 @@ reversion	ɹ ɪ v ɜː ʒ ə n̩
 reversionary	ɹ ɪ v ɜː ɹ ʒ ə n ə ɹ i
 reversionary	ɹ ɪ v ɜː ɹ ʒ ə n ɹ i
 revert	ɹ iː v ɜː t
+revert	ɹ ɪ v ɜː t
 revertent	ɹ ɪ v ɜː ɹ t ə n t
 revertible	ɹ ɪ v ɜː t ɪ b l̩
 revest	ɹ iː v ɛ s t
@@ -54547,7 +55188,6 @@ rictus	ɹ ɪ k t ə s
 rictus	ɹ ɪ k t ʊ s
 rid	ɹ ɪ d
 riddance	ɹ ɪ d ə n s
-ridden	ɹ ɪ d n̩
 riddle	ɹ ɪ d ə l
 riddled	ɹ ɪ d ə l d
 ride	ɹ a ɪ d
@@ -54788,6 +55428,7 @@ rochester	ɹ ɒ t͡ʃ ɪ s t ə
 rochet	ɹ ɒ t ʃ ɪ t
 rock	ɹ ɒ k
 rockabilly	ɹ ɒ k ə b ɪ l i
+rockall	ɹ ɒ k ɔː l
 rocker	ɹ ɒ k ə ɹ
 rockery	ɹ ɒ k ə ɹ i
 rocket	ɹ ɒ k ɪ t
@@ -54883,6 +55524,7 @@ romanization	ɹ ə ʊ m ə n a ɪ z e ɪ ʃ ə n
 romans	ɹ ə ʊ m ə n z
 romansch	ɹ ə ʊ m a n ʃ
 romantic	ɹ ə ʊ m æ n t ɪ k
+romanticism	ɹ ə ʊ m æ n t ɪ s ɪ z ə m
 romaphobia	ɹ o ʊ m ə f o ʊ b i ə
 romaphobia	ɹ ə ʊ m ə f ə ʊ b i ə
 romaunt	ɹ ə m ɔː n t
@@ -54964,7 +55606,7 @@ roration	r ə ʊ r e ɪ ʃ ə n
 rore	ɹ ɔː
 roriferous	ɹ o ʊ ɹ ɪ f ɚ ə s
 roriferous	ɹ ə ʊ ɹ ɪ f ə ɹ ə s
-rorqual	ɹ ɒ ɹ k w ə l
+rorqual	ɹ ɔː k w ə l
 rort	ɹ ɔː ɹ t
 rorty	ɹ ɔː t i
 rory	ɹ o ə ɹ i
@@ -55162,6 +55804,7 @@ rubescent	ɹ uː b ɛ s ə n t
 rubicon	ɹ uː b ɪ k ɒ n
 rubicund	ɹ uː b ɪ k ə n d
 rubidium	ɹ uː b ɪ d i ə m
+rubigo	ɹ uː b a ɪ ɡ ə ʊ
 rubin	ɹ uː b ɪ n
 ruble	ɹ uː b ə l
 rubric	ɹ uː b ɹ ɪ k
@@ -55264,7 +55907,7 @@ runned	ɹ ʌ n d
 runnel	ɹ ʌ n l
 runnel	ɹ ʌ n ə l
 runner	ɹ ʌ n ə
-running	ɹ ʌ n ɪ ŋ
+running	ɹ ʌ n i ŋ
 runny	ɹ ʌ n i
 runout	ɹ ʌ n a ʊ t
 runs	ɹ ʌ n z
@@ -55304,6 +55947,8 @@ russet	ɹ ʌ s ɪ t
 russia	ɹ ʌ ʃ ə
 russian	ɹ ʌ ʃ ə n
 russias	ɹ ʌ ʃ ə s
+russify	ɹ uː s ɪ f a ɪ̯
+russify	ɹ ʌ s ɪ f a ɪ̯
 russki	ɹ ʌ s k i
 russophilia	ɹ ʌ s ə f ɪ l i ə
 russophobe	ɹ ʌ s ə ʊ f ə ʊ b
@@ -55354,6 +55999,8 @@ rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ɒ l ɪ t ə
 rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ə l a ɪ t ə
 rzeszów	ʒ ɛ ʃ uː f
 réaumur	ɹ e ɪ ə ʊ m j ʊ ə ɹ
+résumé	ɹ ɛ z j ʊ m e ɪ
+résumé	ɹ ɪ z j uː m e ɪ
 röntgen	ɹ ɜː n t ɡ ə n
 rösti	ɹ ɒ s t ɪ
 rösti	ɹ ɜː s t ɪ
@@ -55390,8 +56037,6 @@ sable	s e ɪ b ə l
 sable	s e ɪ b ɫ
 sables	s e ɪ b ə l z
 sabot	s æ b ə ʊ
-sabotage	s æ b ɒ t ɑː ʒ
-sabotage	s æ b ɒ t ɪ d͡ʒ
 sabotage	s æ b ə t ɑː ʒ
 saboteur	s æ b ə t ɜː ɹ
 saboteur	s æ b ə t ʊ ə ɹ
@@ -55556,7 +56201,7 @@ salak	s ə l æ k
 salamanca	s æ l ə m æ ŋ k ə
 salamander	s æ l ə m æ n d ə
 salamander	s æ l ə m ɑː n d ə
-salary	s æ l ɚ i
+salary	s æ l ə ɹ i
 salaryman	s æ l ə ɹ i m æ n
 salat	s ə l ɑː t
 salateen	s a l ə t iː n
@@ -55598,6 +56243,7 @@ salination	s æ l ə n e ɪ ʃ ə n
 saline	s e ɪ l a ɪ n
 salinely	s ə l iː n l i
 salinification	s ə l ɪ n ə f ə k e ɪ ʃ ə n
+saliniform	s ə l ɪ n ɪ f ɒ ɹ m
 salinity	s e ɪ l ɪ n ə t i
 salinize	s æ l ɪ n a ɪ z
 salipenter	s æ l ɪ p ɛ n t ə
@@ -55607,6 +56253,7 @@ salique	s ə l iː k
 salishan	s e ɪ l ɪ ʃ ə n
 saliva	s ə l a ɪ v ə
 salivant	s æ l ə v ə n t
+salivarium	s æ l ɪ v ɛ ɹ iː ə m
 salivary	s æ l ɪ v ə ɹ i
 salivary	s ə l a ɪ v ə ɹ i
 salivate	s æ l ɪ v e ɪ t
@@ -55703,6 +56350,8 @@ sammamish	s ə m æ m ɪ ʃ
 sammy	s æ m i
 samnite	s æ m n a ɪ t
 samoa	s ə m ə ʊ ə
+samogitia	s a m ə ʊ ɡ iː ʃ ə
+samogitian	s a m ə ʊ ɡ iː ʃ ə n
 samos	s e ɪ m ɒ s
 samosata	s ə m ɒ s ə t ə
 samothracian	s æ m ə ʊ θ ɹ e ɪ ʃ i ə n
@@ -55715,6 +56364,7 @@ samp	s a m p
 sampa	s æ m p ə
 samphire	s æ m f a ɪ ə ɹ
 samphire	s æ m f ə ɹ
+sample	s æ m p ə l
 sample	s ɑː m p ə l
 sampler	s a m p l ɚ
 sampler	s a m p ə l ɚ
@@ -55826,6 +56476,7 @@ sapphic	s æ f ɪ k
 sapphire	s æ f a ɪ̯ ə ɹ
 sapphism	s æ f ɪ z m̩
 sappho	s æ f ə ʊ
+sappie	s æ p i
 sappy	s æ p i
 sapropel	s a p ɹ ə ʊ p ɛ l
 saprophyte	s æ p ɹ ə ʊ f a ɪ t
@@ -56118,7 +56769,7 @@ scarify	s k ɑː ɹ ɪ f a ɪ
 scaring	s k ɛː ɹ ɪ ŋ
 scarlet	s k ɑː l ɪ t
 scarp	s k ɑː p
-scarper	s k ɑː ɹ p ə ɹ
+scarper	s k ɑː p ə
 scarred	s k ɑː ɹ d
 scarry	s k ɑː ɹ i
 scars	s k ɑː ɹ z
@@ -56163,11 +56814,13 @@ sceptic	s k ɛ p t ɪ k
 sceptral	s ɛ p t ɹ ə l
 sceptre	s ɛ p t ə
 scetavajasse	ʃ e ɪ t ə v a ɪ ɑː s e ɪ
+schachter	ʃ æ k t ɚ
 schadenfreude	ʃ ɑː d ə n f ɹ ɔ ɪ d ə
 schappe	ʃ æ p
 schappe	ʃ ɑ p ə
 scharnhorst	ʃ ɑː ɹ n h ɔː ɹ s t
 schatz	ʃ æ t s
+sched	s k ɛ d͡ʒ
 schediaphilia	s k ɛ d i ə f ɪ l i ə
 schedule	s k ɛ d j uː l
 schedule	s k ɛ d ʒ uː l
@@ -56232,6 +56885,7 @@ schloop	ʃ l uː p
 schloopy	ʃ l uː p i
 schlub	ʃ l ʌ b
 schlubby	ʃ l ʌ b i
+schlump	ʃ l ʌ m p
 schmaltz	ʃ m ɒ l t s
 schmaltzy	ʃ m ɒ l t s i
 schmear	ʃ m ɪ ə ɹ
@@ -56293,6 +56947,7 @@ scialytic	s ʌ ɪ ə l ɪ t ɪ k
 sciamachy	s ʌ ɪ æ m ə k i
 sciapod	s ʌ ɪ ə p ɒ d
 sciatheric	s a ɪ ə θ ɛ ɹ ɪ k
+sciatic	s a ɪ æ t ɪ k
 sciatica	s a ɪ æ t ɪ k ə
 scicli	ʃ i k l i
 science	s a ɪ ə n s
@@ -56398,13 +57053,13 @@ scotchka	s k ɒ t ʃ k ə
 scotchman	s k ɒ t͡ʃ m ə n
 scoter	s k ə ʊ t ə
 scotia	s k o ʊ ʃ ə
+scotia	s k ə ʊ ʃ ə
 scotland	s k ɒ t l ə n d
 scotoma	s k ə t o ʊ m ə
 scotopic	s k ə ʊ t ɒ p ɪ k
 scots	s k ɒ t s
 scott	s k ɒ t
 scottish	s k ɒ t ɪ ʃ
-scotus	s k o ʊ t ə s
 scoundrel	s k a ʊ̯ n d ɹ ə l
 scour	s k a ʊ ə
 scourer	s k a ʊ ɹ ə
@@ -56587,7 +57242,7 @@ seals	s iː l z
 seam	s iː m
 seaman	s iː m ə n
 seamanship	s iː m ə n ʃ ɪ p
-seamen	s iː m ə n
+seamen	s iː m ɛ n
 seaming	s iː m ɪ ŋ
 seams	s iː m z
 seamus	ʃ e ɪ m ə s
@@ -56941,6 +57596,7 @@ senegal	s ɛ n ɪ ɡ ɑː l
 senegal	s ɛ n ɪ ɡ ɔː l
 senegalese	s ɛ n ə ɡ ə l iː z
 senesce	s ə n ɛ s
+senescence	s ɪ n ɛ s ə n s
 seneschal	s ɛ n ə ʃ ə l
 senex	s ɛ n ɛ k s
 sengi	s ɛ ŋ ɡ i
@@ -57072,6 +57728,7 @@ sequester	s ɪ k w ɛ s t ə
 sequestrate	s iː k w ə s t ɹ e ɪ t
 sequestrator	s iː k w ə s t ɹ e ɪ t ə ɹ
 sequin	s iː k w ɪ n
+sequined	s iː k w ɪ n d
 sequoia	s ə k w ɔ ɪ ə
 sequuntur	s ɛ k w ʊ n t ʊ ə
 serac	s ɛ ɹ æ k
@@ -57109,7 +57766,6 @@ sericulture	s ɛ ɹ ɪ k ʌ l t ʃ ə
 seriema	s ɛ ɹ ɪ iː m ə
 series	s ɪ ə ɹ iː z
 serif	s ə ɹ i f
-serif	s ɛ ɹ ə f
 serif	s ɛ ɹ ɪ f
 seriocomical	s ɪ ə ɹ i ə ʊ k ɒ m ɪ k ə l
 serious	s ɪ ə ɹ ɪ ə s
@@ -57185,6 +57841,7 @@ setebos	s ɛ t ɛ b ʌ s
 setfast	s ɛ t f ɑː s t
 seth	s ɛ θ
 setiferous	s iː t ɪ f ə ɹ ə s
+setiger	s iː t ɪ d ʒ ə ɹ
 setim	s iː t ɪ m
 setpoint	s ɛ t p ɔ ɪ n t
 setpoints	s ɛ t p ɔ ɪ n t s
@@ -57214,7 +57871,7 @@ sevastopol	s ɛ v ə s t o ʊ p ə l
 seven	s ɛ v ə n
 sevennight	s ɛ v ə n n ɑ ɪ t
 seventeenth	s ɛ v ə n t iː n θ
-seventh	s ɛ v ə n θ
+seventh	s ɛ v n θ
 seventieth	s ɛ v n t i ə θ
 seventy	s ɛ v ə n t i
 several	s ɛ v ə ɹ ə l
@@ -57233,6 +57890,8 @@ sewed	s ə ʊ d
 sewell	s u ə l
 sewer	s j uː ə
 sewer	s ə ʊ ə
+sewerage	s uː ə ɹ ɪ d͡ʒ
+sewerage	s uː ɹ ɪ d͡ʒ
 sewing	s ə ʊ ɪ ŋ
 sewn	s ə ʊ n
 sex	s ɛ k s
@@ -57475,6 +58134,7 @@ sheathbill	ʃ iː θ b ɪ l
 sheathe	ʃ iː ð
 sheathed	ʃ iː ð d
 sheathed	ʃ iː θ t
+sheaths	ʃ iː ð z
 sheathy	ʃ iː θ i
 sheave	ʃ iː v
 sheba	ʃ iː b ə
@@ -57504,6 +58164,7 @@ sheet	ʃ iː t
 sheets	ʃ iː t s
 sheffield	ʃ ɛ f iː l d
 sheik	ʃ e ɪ k
+sheik	ʃ i k
 sheikdom	ʃ e ɪ k d ə m
 sheikdom	ʃ iː k d ə m
 sheila	ʃ iː l ə
@@ -57535,6 +58196,7 @@ shelve	ʃ ɛ l v
 shelves	ʃ ɛ l v z
 shemagh	ʃ ə m ɑː ɡ
 shemaiah	ʃ ɛ m ɛ j ɑː
+shen	ʃ ɛ n
 shenanigan	ʃ ə n æ n ɪ ɡ ə n
 shenanigans	ʃ ɪ n æ n ɪ ɡ ə n z
 shend	ʃ ɛ n d
@@ -57748,8 +58410,8 @@ shooter	ʃ uː t ə ɹ
 shooting	ʃ uː t ɪ ŋ
 shootout	ʃ uː t a ʊ t
 shoots	ʃ uː t s
-shop	ʃ o p
-shopkeeper	ʃ ɒ p k iː p ə
+shop	ʃ ɒ p
+shopkeeper	ʃ ɒ p k iː p ɚ
 shoplet	ʃ ɒ p l ə t
 shoplift	ʃ ɒ p l ɪ f t
 shopper	ʃ ɒ p ə
@@ -57822,8 +58484,8 @@ shreddy	ʃ ɹ ɛ d i
 shrek	ʃ ɹ ɛ k
 shrew	ʃ ɹ uː
 shrewd	ʃ ɹ uː d
-shrewsbury	ʃ ɹ uː z b ɹ ɪ
-shrewsbury	ʃ ɹ ə ʊ z b ɹ ɪ
+shrewsbury	ʃ ɹ uː z b ɹ i
+shrewsbury	ʃ ɹ ə ʊ z b ɹ i
 shriek	ʃ ɹ iː k
 shrieky	ʃ ɹ iː k i
 shrieval	ʃ ɹ iː v ə l
@@ -57888,6 +58550,9 @@ shunt	ʃ ʌ n t
 shuntak	ʃ ʌ n t æ k
 shunto	ʃ ʊ n t o ʊ
 shup	ʃ ʌ p
+shuriken	ʃ uː ɹ ɪ k ə n
+shuriken	ʃ ɝ ɪ k ə n
+shuriken	ʃ ʊ ə ɹ ɪ k ə n
 shush	ʃ ʊ ʃ
 shush	ʃ ʌ ʃ
 shuswap	ʃ uː ʃ w ɑː p
@@ -57934,12 +58599,15 @@ sic	s ɪ k
 siccawei	s ɪː k ɑː w e ɪ
 siccawei	s ɪː k ə w e ɪ
 sice	s a ɪ s
+sicel	s ɪ k ə l
+sicel	s ɪ s ə l
 sich	s iː t͡ʃ
 sichuan	s ɛ t͡ʃ w ɑ n
 sichuan	s ɛ ʃ w ɑ n
 sichuan	s ɪ t͡ʃ w ɑ n
 sicilia	s ɪ s ɪ l j ə
 sicilicus	s ɪ s ɪ l ɪ k ə s
+sicily	s ɪ s ɪ l i
 sick	s ɪ k
 sickbed	s ɪ k b ɛ d
 sicken	s ɪ k ə n
@@ -57958,6 +58626,7 @@ sidcup	s ɪ d k ʌ p
 siddur	s ɪ d ʊ ə
 side	s a ɪ d
 sideburns	s a ɪ d b ɜː ɹ n z
+sidecar	s a ɪ d k ɑ ɹ
 sidekick	s a ɪ d k ɪ k
 sideline	s a ɪ d l a ɪ n
 sidequest	s a ɪ d k w ɛ s t
@@ -58133,7 +58802,7 @@ simoom	s ɪ m uː m
 simp	s ɪ m p
 simpatico	s ɪ m p a t ɪ k ə ʊ
 simper	s ɪ m p ə
-simple	s ɪ m p ə l
+simple	s ɪ m p l̩
 simpler	s ɪ m p l ə
 simpler	s ɪ m p l̩ ə
 simplest	s ɪ m p l ə s t
@@ -58152,6 +58821,7 @@ simply	s ɪ m p l i
 simpson	s ɪ m p s ə n
 simul	s ɪ m ə l
 simulacrum	s i m j ə l e ɪ k ɹ ə m
+simulant	s ɪ m j ʊ l ə n t
 simular	s ɪ m j ʊ l ə ɹ
 simulate	s ɪ m j ʊ l e ɪ t
 simulate	s ɪ m j ʊ l ɪ t
@@ -58461,6 +59131,7 @@ skoliosexual	s k o ʊ l i o ʊ s ɛ k ʃ u ə l
 skookum	s k uː k ə m
 skoosh	s k u ʃ
 skopje	s k ɔ p j ɛ
+skopostheorie	s k ə ʊ p ə ʊ s t e ɪ ə ɹ iː
 skoracki	s k ə ɹ æ k i
 skraeling	s k ɹ e ɪ l ɪ ŋ
 skrike	s k ɹ a ɪ k
@@ -58579,6 +59250,7 @@ sleazy	s l iː z i
 sleb	s l ɛ b
 sled	s l ɛ d
 sledge	s l ɛ d͡ʒ
+sledgehammer	s l ɛ d͡ʒ h æ m ə
 sledger	s l ɛ d͡ʒ ə ɹ
 sleek	s l iː k
 sleekly	s l iː k l i
@@ -58690,10 +59362,12 @@ slope	s l ə ʊ p
 sloping	s l ə ʊ p ɪ ŋ
 sloppy	s l ɒ p i
 slopy	s l ə ʊ p i
+slosh	s l ɒ ʃ
 sloshed	s l ɒ ʃ t
 sloshy	s l ɒ ʃ i
 slot	s l ɒ t
 sloth	s l ə ʊ θ
+slothen	s l ə ʊ θ ə n
 slouch	s l a ʊ t͡ʃ
 slough	s l a ʊ
 slough	s l ʌ f
@@ -58880,6 +59554,7 @@ snack	s n æ k
 snacker	s n æ k ə ɹ
 snackery	s n æ k ə ɹ iː
 snacky	s n æ k i
+snaefell	s n e ɪ f ɛ l
 snaffle	s n æ f ə l
 snafu	s n æ f uː
 snafu	s n ɑː f uː
@@ -59092,6 +59767,7 @@ sodcast	s ɒ d k æ s t
 sodcast	s ɒ d k ɑː s t
 sodden	s ɒ d ə n
 sodger	s ɒ d ʒ ə
+sodiasm	s ə ʊ d ɪ ə z ə m
 sodium	s ə ʊ d ɪ ə m
 sodom	s ɒ d ə m
 sodomise	s ɒ d ə m a ɪ z
@@ -59126,11 +59802,12 @@ sohcahtoa	s ɒ k ə t o ʊ ə
 soho	s ə ʊ h ə ʊ
 soigneur	s w ʌ n j ɜː
 soigné	s w ɑː n j e ɪ
-soil	s ɔ ɪ l
+soil	s ɔ ɪ l̩
 soilage	s ɔ ɪ l ɪ d͡ʒ
 soilure	s ɔ ɪ l j ə
 soilure	s ɔ ɪ l j ʊ ə
 soiree	s w ɑː ɹ e ɪ
+soja	s ə ʊ d ʒ ə
 sojourn	s ɒ d͡ʒ ə n
 sojourn	s ɒ d͡ʒ ɜː n
 sojourn	s ə ʊ d͡ʒ ɜː n
@@ -59167,6 +59844,7 @@ solely	s ə ʊ l l i
 solemn	s ɒ l ə m
 solemnity	s ə l ɛ m n ɪ t i
 solemnly	s ɒ l ə m l i
+solen	s ə ʊ l ə n
 solent	s ə ʊ l ə n t
 soleus	s ə l iː ə s
 soleus	s ə ʊ l iː ə s
@@ -59545,6 +60223,7 @@ sparql	s p ɑː k ə l
 sparring	s p ɑː ɹ ɪ ŋ
 sparrow	s p æ ɹ ə ʊ
 sparse	s p ɑː s
+sparsentan	s p ɑː ɹ s ɛ n t æ n
 sparta	s p ɑː ɹ t ə
 spartacus	s p ɑː t ə k ə s
 spartan	s p ɑː ɹ t ə n
@@ -59555,6 +60234,8 @@ spasmodic	s p æ z m ɒ d ɪ k
 spastic	s p a s t ɪ k
 spat	s p æ t
 spatchcock	s p æ t͡ʃ k ɒ k
+spatchcocked	s p æ t͡ʃ k ɒ k t
+spatchcocking	s p æ t͡ʃ k ɒ k ɪ ŋ
 spate	s p e ɪ t
 spathal	s p e ɪ ð ə l
 spathe	s p e ɪ ð
@@ -59677,6 +60358,7 @@ spending	s p ɛ n d ɪ ŋ
 spendthrift	s p ɛ n d θ ɹ ɪ f t
 spenser	s p ɛ n s ə ɹ
 spent	s p ɛ n t
+sperage	s p ɛ ɹ ɪ d ʒ
 sperate	s p ɪ ə ɹ ə t
 sperge	s p ɜː ɹ d͡ʒ
 sperm	s p ɜː m
@@ -59735,6 +60417,7 @@ spider	s p a ɪ̯ d ə
 spiderling	s p a ɪ d ə l ɪ ŋ
 spiderweb	s p a ɪ̯ d ə w ɛ b
 spidey	s p a ɪ d i
+spie	s p a ɪ
 spiedie	s p iː d i
 spiel	s p iː l
 spiel	ʃ p iː l
@@ -59810,7 +60493,11 @@ spiritualism	s p ɪ ɹ ɪ t j u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ ə l ɪ z ə m
 spirituality	s p ɪ ɹ ə t͡ʃ u æ l ə t ɪ
+spirocheticidal	s p a ɪ r o ʊ k i t ɪ s a ɪ d ə l
 spirochetocidal	s p a ɪ r o ʊ k i t ə s a ɪ d ə l
+spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɪ s ɪ s
+spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɪ k
+spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɪ k
 spirometer	s p ʌ ɪ ɹ ɒ m ɪ t ə
 spironolactone	s p ʌ ɪ ɹ ə n ə ʊ l æ k t ə ʊ n
 spirulina	s p a ɪ ɹ ə l iː n ə
@@ -59886,6 +60573,7 @@ spondulicks	s p ɒ n d j uː l ɪ k s
 spondylosis	s p ɒ n d ɪ l ə ʊ s ɪ s
 sponge	s p ʌ n d͡ʒ
 spongy	s p ʌ n d͡ʒ i
+sponk	s p ɒ ŋ k
 sponsor	s p ɒ n s ə
 spontaneity	s p ɒ n t ə n e ɪ ə t i
 spontaneous	s p ɒ n t e ɪ n i ə s
@@ -59943,6 +60631,8 @@ spotter	s p ɒ t ə
 spouge	s p uː d͡ʒ
 spousal	s p a ʊ z ə l
 spouse	s p a ʊ s
+spouses	s p a ʊ s ɪ z
+spouses	s p a ʊ z ɪ z
 spout	s p a ʊ t
 spouty	s p a ʊ t i
 sprachbund	s p ɹ ɑː k b ʊ n d
@@ -60144,7 +60834,6 @@ stabbed	s t æ b d
 stabbing	s t æ b ɪ ŋ
 stabenow	s t æ b ɪ n a ʊ
 stabiliment	s t ə b ɪ l ɪ m ə n t
-stability	s t ə b ɪ l ɪ d i
 stability	s t ə b ɪ l ɪ t i
 stabilization	s t e ɪ b ə l a ɪ z e ɪ ʃ ə n
 stabilization	s t e ɪ b ə l ɪ z e ɪ ʃ ə n
@@ -60302,6 +60991,7 @@ starvation	s t ɑː v e ɪ ʃ ə n
 starve	s t ɑː v
 starven	s t ɑː v ə n
 starving	s t ɑː v ɪ ŋ
+stary	s t ɛ ə ɹ ɪ
 stash	s t æ ʃ
 stasi	s t ɑː z i
 stasi	ʃ t ɑː z i
@@ -60351,6 +61041,8 @@ statue	s t æ t j uː
 statue	s t æ t͡ʃ uː
 statuesque	s t a t j ʊ ɛ s k
 statuesque	s t a t ʃ ʊ ɛ s k
+statuette	s t æ t j u ɛ t
+statuette	s t æ t ʃ u ɛ t
 statuminate	s t ə t j uː m ɪ n e ɪ t
 statuminate	s t ə t uː m ɪ n e ɪ t
 stature	s t æ t͡ʃ ə
@@ -60572,7 +61264,8 @@ stilboestrol	s t ɪ l b iː s t ɹ ɒ l
 stilbon	s t ɪ l b ɒ n
 stile	s t a ɪ l
 stiletto	s t ɪ l e t ə ʊ
-still	s t ɪ ɫ
+still	s t ɪ l
+stillborn	s t ɪ l b ɔː ɹ n
 stillicide	s t ɪ l ɪ s ʌ ɪ d
 stillness	s t ɪ l n ə s
 stilt	s t ɪ l t
@@ -60582,6 +61275,7 @@ stilus	s t a ɪ l ə s
 stime	s t a ɪ m
 stimmy	s t ɪ m i
 stimulable	s t ɪ m j ʊ l ə b l̩
+stimulant	s t ɪ m j ʊ l ə n t
 stimulate	s t ɪ m j ʊ l e ɪ t
 stimulated	s t ɪ m j ʊ l e ɪ t ɪ d
 stimuli	s t ɪ m j ʊ l a ɪ̯
@@ -61095,6 +61789,7 @@ subglacial	s ʌ b ɡ l e ɪ ʃ i ə l
 subglacial	s ʌ b ɡ l e ɪ ʃ ə l
 subgroup	s ʌ b ɡ ɹ uː p
 subindication	s ʌ b ɪ n d ɪ k e ɪ ʃ ə n
+subitize	s ʌ b ɪ t a ɪ z
 subito	s uː b ɪ t ə ʊ
 subjacency	s ə b d͡ʒ e ɪ s ə n s i
 subjacent	s ʌ b d ʒ e ɪ s ə n t
@@ -61153,6 +61848,7 @@ subperiosteal	s ʌ b p ɛ ɹ i ɒ s t ɪ ə l
 subpoena	s ə p iː n ə
 subpoenable	s ə p i n ə b ə l
 subprime	s ʌ b p ɹ ʌ ɪ m
+subq	s ʌ b k j uː
 subreption	s ʌ b ɹ ɛ p ʃ ə n
 subsaltation	s ʌ b s l t e ɪ ʃ n
 subsaltation	s ʌ b s ə l t e ɪ ʃ n
@@ -61461,7 +62157,7 @@ sunspot	s ʌ n s p ɒ t
 sunstead	s ʌ n s t ɛ d
 sunup	s ʌ n ʌ p
 suny	s u n i
-suomi	s uː ɔ m ɪ
+suomi	s w ɔː m ɪ
 suona	s w o ʊ n ɑː
 sup	s ʌ p
 super	s j uː p ə ɹ
@@ -61656,6 +62352,8 @@ suprareligious	s j uː p ɹ ə ɹ ɪ l ɪ d͡ʒ ə s
 suprasegmental	s uː p ɹ ə s ɛ ɡ m ɛ n t ə l
 suprasternal	s uː p ɹ ə s t ɜː n ə l
 supremacy	s u p ɹ ɛ m ə s i
+suprematism	s j uː p ɹ ɛ m ə t ɪ z ə m
+suprematist	s j uː p ɹ ɛ m ə t ɪ s t
 supreme	s j uː p ɹ iː m
 supreme	s j ə p ɹ iː m
 supreme	s j ʊ p ɹ iː m
@@ -61701,6 +62399,7 @@ surimi	s ʊ ə ɹ iː m i
 surimi	s ʊ ə ɹ ɪ m i
 suriname	s j ʊ ə ɹ ɪ n æ m
 suriname	s ʊ ə ɹ ɪ n æ m
+surinamese	s ʊ ə ɹ ɪ n ə m iː z
 surjection	s ɜː ɹ d͡ʒ ɛ k ʃ ə n
 surly	s ɜː l i
 surmise	s ɜː m a ɪ z
@@ -61719,7 +62418,6 @@ surrealism	s ə ɹ iː ə l ɪ z ə m
 surrealistic	s ə ɹ iː ə l ɪ s t ɪ k
 surrebutter	s ʌ ɹ ɪ b ʌ t ɚ
 surrect	s ə ɹ ɛ k t
-surrender	s ə ɹ ɛ n d ə ɹ
 surreptitious	s ʌ ɹ ɪ p t ɪ ʃ ə s
 surreptitiously	s ʌ ɹ ə p t ɪ ʃ ə s l i
 surrey	s ʌ ɹ i
@@ -61733,7 +62431,7 @@ surroundings	s ə ɹ a ʊ n d ɪ ŋ z
 surseance	s ɜː ɹ s i ə n s
 surströmming	s ʊ ə ɹ s t ɹ ɒ m ɪ ŋ
 surströmming	s ʊ ə ɹ s t ɹ ɜː m ɪ ŋ
-surtout	s əː t uː t
+surtout	s ɜː t uː t
 surveil	s ə v e ɪ l
 surveillance	s ə v e ɪ l ə n s
 survey	s ə v e ɪ
@@ -61750,6 +62448,7 @@ sus	s ʌ s
 susa	s uː z ə
 susceptibility	s ə s ɛ p t ə b ɪ l ɪ t i
 susceptible	s ə s ɛ p t ɪ b l̩
+suscitate	s ʌ s ɪ t e ɪ t
 sushen	s uː ʃ ʌ n
 sushi	s uː ʃ i
 sushi	s ʊ ʃ i
@@ -62031,6 +62730,7 @@ sylvester	s ɪ l v ɛ s t ɚ
 symbiotic	s ɪ m b a ɪ ɒ t ɪ k
 symbiotic	s ɪ m b i ɒ t ɪ k
 symbol	s ɪ m b ə l
+symbolically	s ɪ m b ɒ l ɪ k l ɪ
 symbolism	s ɪ m b ə l ɪ z ə m
 symbolize	s ɪ m b ə l a ɪ z
 symboloid	s ɪ m b ə l ɔ ɪ d
@@ -62075,6 +62775,7 @@ synchronic	s ɪ ŋ k ɹ ɒ n ɪ k
 synchronize	s ɪ ŋ k ɹ ə n a ɪ z
 synchronous	s ɪ ŋ k ɹ ə n ə s
 synchrotron	s ɪ ŋ k ɹ ə ʊ t ɹ ɒ n
+synchysis	s ɪ n k ə s ɪ s
 syncope	s ɪ ŋ k ə p i
 syncranterian	s ɪ ŋ k ɹ æ n t i ɹ i ə n
 syncranteric	s ɪ ŋ k ɹ æ n t i ɹ i k
@@ -62180,6 +62881,7 @@ t	t iː
 t'internet	t ɪ n t ə n ɛ t
 t'othersider	t ʌ ð ə ɹ s a ɪ d ə ɹ
 ta	t ɑː
+ta	t ə
 ta'en	t e ɪ n
 taaffeite	t ɑː f ʌ ɪ t
 tab	t æ b
@@ -62259,6 +62961,7 @@ taenifuge	t iː n ɪ f j uː d͡ʒ
 tafe	t e ɪ f
 taffaty	t æ f ə t i
 taffeta	t æ f ə t ə
+taffeta	t æ f ɪ t ə
 taffety	t æ f ə t i
 taffy	t æ f i
 tafsir	t æ f s ɪ ə r
@@ -62352,6 +63055,7 @@ tales	t e ɪ l z
 taliban	t æ l ɪ b æ n
 taliban	t æ l ɪ b ɑː n
 taliban	t ɑː l ɪ b ɑː n
+taliesin	t æ l i ɛ s ɪ n
 taligrade	t æ l ɪ ɡ ɹ e ɪ d
 talion	t a l ɪ ə n
 talisman	t æ l ɪ s m æ n
@@ -62388,6 +63092,7 @@ talmud	t æ l m ə d
 talmud	t æ l m ʊ d
 talmudic	t æ l m ʊ d ɪ k
 talon	t æ l ə n
+talpidae	t æ l p ɪ d iː
 talus	t e ɪ l ə s
 tam	t æ m
 tamada	t ɑː m ə d ɑː
@@ -62445,7 +63150,7 @@ tangential	t æ n d͡ʒ ɛ n t͡ʃ ə l
 tangentially	t æ n d͡ʒ ɛ n ʃ i ə l i
 tangentially	t æ n d͡ʒ ɛ n ʃ ə l i
 tangerine	t æ n d͡ʒ ə ɹ i n
-tangerine	t æ n d͡ʒ ɜ ɹ i n
+tangerine	t æ n d͡ʒ ə ɹ iː n
 tangible	t æ n d͡ʒ ɪ b ə l
 tangier	t æ ŋ ɪ ə
 tangle	t æ ŋ ɡ ə l
@@ -62469,6 +63174,8 @@ tannery	t æ n ə ɹ i
 tannin	t æ n ɪ n
 tanning	t æ n ɪ ŋ
 tannoy	t æ n ɔ ɪ
+tanpura	t æ m p ʊ ə ɹ ə
+tanpura	t ɑ m p ʊ ə ɹ ə
 tanru	t æ n ɹ uː
 tansy	t a n z i
 tansy	t æ n z i
@@ -62481,6 +63188,9 @@ tantamount	t æ n t ə m a ʊ n t
 tantara	t æ n t ə ɹ ɑː
 tantivy	t æ n t ɪ v i
 tanto	t ɑ n t ə ʊ
+tantra	t æ n t ɹ ə
+tantra	t ɑː n t ɹ ə
+tantra	t ʌ n t ɹ ə
 tantrum	t æ n t ɹ ə m
 tanuki	t ə n ʊ k ɪ
 tanya	t æ n j ə
@@ -62489,7 +63199,8 @@ tanzania	t æ n z ə n iː ə
 tanzanite	t æ n z ə n a ɪ t
 tao	d a ʊ
 tao	t a ʊ
-taoiseach	t iː ʃ ə k
+taoiseach	t iː ʃ i
+taoisigh	t iː ʃ i
 taotie	t a ʊ t j e ɪ
 tap	t æ p
 tapa	t ɑː p ə
@@ -62572,7 +63283,7 @@ tarry	t ɑː ɹ i
 tarsal	t ɑː s ə l
 tarsand	t ɑː ɹ s æ n d
 tarse	t ɑː ɹ s
-tarsier	t a ɹ s i ə ɹ
+tarsier	t ɑ ɹ s i ə ɹ
 tarsus	t ɑː s ə s
 tart	t ɑː t
 tartan	t ɑː t n̩
@@ -62648,6 +63359,7 @@ taupe	t ə ʊ p
 taupo	t a ʊ p ə ʊ
 taur	t ɑː r
 taur	t ɔː r
+taurida	t ɔː ɹ ɪ d ə
 taurine	t ɔː ɹ a ɪ n
 taurine	t ɔː ɹ iː n
 taurocholic	t ɔː ɹ ə k ɒ l ɪ k
@@ -62712,6 +63424,7 @@ teachy	t iː t͡ʃ i
 teacup	t iː k ʌ p
 teade	t iː d
 teak	t iː k
+teaky	t iː k i
 teal	t iː l
 team	t iː m
 teammate	t iː m m e ɪ t
@@ -62744,7 +63457,7 @@ teasable	t iː z ə b ə l
 tease	t iː z
 teased	t iː z d
 teasing	t iː z ɪ ŋ
-teaspoon	t i s p u n
+teaspoon	t iː s p uː n
 teaspoonful	t iː s p uː n f ə l
 teat	t iː t
 teazer	t iː z ə ɹ
@@ -62765,6 +63478,7 @@ technobabble	t ɛ k n ə ʊ b æ b ə l
 technocracy	t ɛ k n ɒ k ɹ ə s i
 technocrat	t ɛ k n ə ʊ k ɹ a t
 technocratic	t ɛ k n ə k ɹ æ t ɪ k
+technological	t ɛ k n ə l ɒ d͡ʒ ɪ k ə l
 technologist	t ɛ k n ɒ l ə d͡ʒ ɪ s t
 technology	t ɛ k n ɒ l ə d͡ʒ i
 technopeasant	t ɛ k n ə ʊ p ɛ z ə n t
@@ -62783,6 +63497,7 @@ teddington	t ɛ d ɪ ŋ t ə n
 teddy	t ɛ d i
 tedge	t ɛ d͡ʒ
 tedious	t iː d ɪ ə s
+tedisome	t iː d ɪ s ə m
 tedium	t iː d i ə m
 tee	t iː
 teegeeack	t iː ɡ i æ k
@@ -62796,6 +63511,7 @@ teenage	t iː n ɪ d͡ʒ
 teenager	t iː n e ɪ d͡ʒ ə ɹ
 teener	t iː n ə
 teens	t iː n z
+teensy	t iː n s i
 teeny	t iː n i
 teenybopper	t iː n i b ɒ p ə
 teep	t iː p
@@ -62843,6 +63559,7 @@ telco	t ɛ l k ə ʊ
 tele	t ɛ l i
 telecabin	t ɛ l ɪ k æ b ɪ n
 telecine	t ɛ l ə s ɪ n e ɪ
+telega	t ɪ l e ɪ ɡ ə
 telegram	t ɛ l ə ɡ ɹ æ m
 telegraph	t ɛ l ə ɡ ɹ æ f
 telegraph	t ɛ l ɪ ɡ ɹ æ f
@@ -62927,7 +63644,7 @@ temp	t ɛ m p
 tempeh	t ɛ m p e ɪ
 temper	t ɛ m p ə
 tempera	t ɛ m p ə ɹ ə
-temperament	t ɛ m p ə ɹ m ə n t
+temperament	t ɛ m p ə m ə n t
 temperament	t ɛ m p ə ɹ ə m ə n t
 temperament	t ɛ m p ɹ ə m ə n t
 temperance	t ɛ m p ə ɹ ə n s
@@ -63006,6 +63723,7 @@ tenge	t ɛ ŋ ɡ e ɪ
 tengrism	t ɛ ŋ ɡ ɹ ɪ z ə m
 tengwar	t ɛ ŋ ɡ w ɑː
 tenible	t ɛ n ɪ b l
+teniposide	t ɛ n ɪ p ə s a ɪ d
 tenner	t ɛ n ə ɹ
 tennessee	t ɛ n ə s iː
 tennis	t ɛ n ɪ s
@@ -63028,6 +63746,7 @@ tensor	t ɛ n s ə
 tent	t ɛ n t
 tent	t ɪ n t
 tentacle	t ɛ n t ə k ə l
+tentacle	t ɛ n t ɪ k ə l
 tentacular	t ɛ n t æ k j uː l ə ɹ
 tentative	t ɛ n t ə t ɪ v
 tentatively	t ɛ n t ə t ɪ v l i
@@ -63101,6 +63820,7 @@ termitarium	t ɜ ɹ m ɪ t ɛ ə ɹ i ə m
 termite	t ɜː ɹ m a ɪ t
 termites	t ɜː m a ɪ t s
 termites	t ɜː m ɪ t iː z
+termless	t ɝ m l ɪ s
 terms	t ɜː m z
 tern	t ɜː n
 ternary	t ɜː n ə ɹ i
@@ -63266,6 +63986,7 @@ textspeak	t ɛ k s t s p i k
 textual	t ɛ k s t j u ə l
 textual	t ɛ k s t ʃ u ə l
 textual	t ɛ k s t ʃ ə l
+tezosentan	t ɛ z ə ʊ s ɛ n t æ n
 tečka	t ɛ t͡ʃ k a
 tečka	t ɛ t͡ʃ k ə
 th'	ð
@@ -63321,6 +64042,7 @@ tharf	θ ɑː ɹ f
 thass	ð æ s
 that	ð æ t
 that'd	ð æ d
+that'd	ð æ t ə d
 that's	ð æ t s
 thatch	θ æ t͡ʃ
 thatcher	θ a t͡ʃ ə ɹ
@@ -63376,6 +64098,7 @@ thematic	θ ɪ m æ t ɪ k
 thematise	θ iː m ə t a ɪ z
 thembo	ð ɛ m b ə ʊ
 theme	θ iː m
+themis	θ iː m ɪ s
 themistius	θ ɛ m ɪ s t ɪ ə s
 themistius	θ ɪ m ɪ s t ɪ ə s
 themself	ð ɛ m s ɛ l f
@@ -63410,6 +64133,7 @@ theomachy	θ i ɒ m ə k i
 theopathic	θ iː ə ʊ p a θ ɪ k
 theophany	θ iː ɒ f ə n i
 theophilanthropy	θ iː ə ʊ f ɪ l a n θ ɹ ə p i
+theophilus	θ iː ɒ f ɪ l ə s
 theophylline	θ i ə f ɪ l iː n
 theophylline	θ i ə f ɪ l ɪ n
 theopneust	θ ɪ ə p n j uː s t
@@ -63451,6 +64175,7 @@ therefrom	ð e ə f ɹ ɒ m
 therein	ð e ə ɹ ɪ n
 thereinto	ð ɛ ə ɹ ɪ n t uː
 theremin	θ ɛ ə ɹ ə m ɪ n
+theremin	θ ɛ ɹ ɪ m ɪ n
 thereof	ð ɛ ə ɹ ɒ v
 thereon	ð ɛ ə ɹ ɒ n
 thereout	ð ɛ ə ɹ a ʊ t
@@ -63582,8 +64307,8 @@ this'll	ð ɪ s l̩
 this's	ð ɪ s ɪ z
 this've	ð ɪ s ə v
 thistle	θ ɪ s l̩
-thither	ð ɪ ð ə ɹ
-thither	θ ɪ ð ə ɹ
+thither	ð ɪ ð ə
+thither	θ ɪ ð ə
 thitherward	ð ɪ ð ə w ə d
 thlipsis	θ l ɪ p s ɪ s
 thneed	θ n iː d
@@ -63625,6 +64350,7 @@ thoroughly	θ ʌ ɹ ə l i
 thoroughness	θ ʌ ɹ ə n ə s
 thoroughness	θ ʌ ɹ ə ʊ n ə s
 thorp	θ ɔː p
+thorpe	θ ɔː p
 those	ð ə ʊ z
 thot	θ ɒ t
 thoth	θ ə ʊ θ
@@ -63664,7 +64390,8 @@ thousandth	θ a ʊ z ə n θ
 thousandths	θ a ʊ z ə n t θ s
 thowel	θ ə ʊ w ə l
 thrace	θ ɹ e ɪ s
-thracian	θ ɹ e ɪ s iː ə n
+thracian	θ ɹ e ɪ ʃ i ə n
+thracian	θ ɹ e ɪ ʃ ə n
 thrack	θ ɹ æ k
 thrall	θ ɹ ɔː l
 thralldom	θ ɹ ɔː l d ə m
@@ -63838,12 +64565,14 @@ tiberius	t ɪ b ɛ ɹ i ʊ s
 tibet	t ə b e t
 tibet	t ɪ b e t
 tibetan	t ɪ b ɛ t n̩
+tibia	t ɪ b i ə
 tibial	t ɪ b i ə l
 tibicen	t ɪ b a ɪ s ɪ n
 tibicines	t ɪ b a ɪ s ɪ n iː z
 tic	t ɪ k
+tical	t iː k ə l
 tical	t ɪ k ɑː l
-tical	t ɪ k ə l
+tical	t ɪ k ɔː l
 tice	t a ɪ s
 tich	t ɪ t͡ʃ
 tick	t ɪ k
@@ -63860,6 +64589,7 @@ ticklishness	t ɪ k l ɪ ʃ n ɛ s
 ticks	t ɪ k s
 ticrynafen	t ɪ k ɹ ɪ n ə f ɛ n
 tics	t ɪ k s
+tid	t ɪ d
 tidal	t a ɪ d ə l
 tidbit	t ɪ d b ɪ t
 tiddly	t ɪ d l i
@@ -64114,6 +64844,7 @@ tlaloc	t l ə l o ʊ k
 tlaxcala	t l ɑː s k ɑː l ə
 tlaxcala	t l ɑː ʃ k ɑː l ə
 tlayuda	t l ɑ j u d ə
+tlemcen	t l ɛ m s ɛ n
 tlingit	k l ɪ ŋ k ɪ t
 tlingit	t l ɪ ŋ ɡ ɪ t
 tmesis	m iː s ɪ s
@@ -64201,6 +64932,7 @@ tokenist	t ə ʊ k ə n ɪ s t
 toki	t o ʊ k i
 toki	t ə ʊ k i
 tokin	t ə ʊ k ɪ n
+tokkaebi	t o ʊ k e ɪ b i
 tokomaru	t ə ʊ k ə ʊ m ɑː ɹ uː
 tokophobia	t ə ʊ k ə f ə ʊ b i ə
 tokoroa	t ə ʊ k ə ʊ ɹ ə ʊ ə
@@ -64236,7 +64968,6 @@ toman	t o ʊ m ɑː n
 toman	t o ʊ m ə n
 toman	t ʊ m ə n
 toman	t ʌ m ə n
-tomato	t ə m e ɪ t o ʊ
 tomato	t ə m ɑː t o ʊ
 tomb	t uː m
 tombal	t uː m b ə l
@@ -64423,6 +65154,7 @@ tortoiseshell	t ɔː ɹ t ə s ʃ ɛ l
 tortoiseshell	t ɔː ɹ t ə ʃ ɛ l
 tortola	t ɔː t ə ʊ l ə
 tortoni	t ɔː t ə ʊ n i
+torts	t ɔː t s
 tortuous	t ɔː t͡ʃ uː ə s
 torture	t ɔː t͡ʃ ə ɹ
 tortured	t ɔː t͡ʃ ə d
@@ -64584,7 +65316,6 @@ trader	t ɹ e ɪ d ə ɹ
 trades	t ɹ e ɪ d z
 tradescantia	t ɹ æ d ɪ s k æ n t i ə
 trading	t ɹ e ɪ d ɪ ŋ
-tradition	t ɹ ə d ɪ ʃ n̩
 tradition	t ɹ ə d ɪ ʃ ə n
 traditional	t ɹ ə d ɪ ʃ n ə l
 traditional	t ɹ ə d ɪ ʃ ə n ə l
@@ -64617,6 +65348,7 @@ trainer	t ɹ e ɪ n ə
 trainers	t ɹ e ɪ n ə ɹ z
 trainiac	t ɹ e ɪ n i æ k
 training	t ɹ e ɪ n ɪ ŋ
+traino	t ɹ e ɪ n ə ʊ
 trains	t ɹ e ɪ n z
 traipse	t ɹ e ɪ p s
 traipse	t͡ʃ ɹ e ɪ p s
@@ -64654,7 +65386,7 @@ tranquil	t ɹ æ ŋ k w ɪ l
 tranquility	t r æ ŋ k w ɪ l ɪ t i
 tranquilize	t ɹ æ ŋ k w ɪ l a ɪ z
 tranquilizing	t ɹ æ ŋ k w ɪ l a ɪ z ɪ ŋ
-tranquillity	t r æ ŋ k w ɪ l ɪ t i
+tranquillity	t ɹ æ ŋ k w ɪ l ɪ t i
 trans	t ɹ æ n z
 transact	t ɹ æ n z æ k t
 transaction	t ɹ æ n z æ k ʃ ə n
@@ -64929,6 +65661,7 @@ treechange	t ɹ i t͡ʃ e ɪ n d͡ʒ
 treehouse	t ɹ iː h a ʊ s
 treemapping	t ɹ iː m æ p ɪ ŋ
 treen	t ɹ iː n
+treeness	t ɹ iː n ɪ s
 treenware	t ɹ iː n w ɛ ə ɹ
 trees	t ɹ iː z
 treey	t ɹ i i
@@ -64990,6 +65723,8 @@ trepopnea	t ɹ ɛ p ə ʊ p n iː ə
 trespass	t ɹ ɛ s p ə s
 tress	t ɹ ɛ s
 tressel	t ɹ ɛ s ə l
+tressure	t ɹ ɛ s j ʊ ə ɹ
+tressure	t ɹ ɛ ʃ ə ɹ
 tressy	t ɹ ɛ s i
 trestle	t ɹ ɛ s ə l
 tret	t ɹ ɛ t
@@ -65071,6 +65806,7 @@ tricks	t ɹ ɪ k s
 tricky	t ɹ ɪ k i
 triclosan	t ɹ ɪ k l ə s æ n
 tricot	t ɹ i k o ʊ
+tricrotous	t ɹ a ɪ k ɹ ə t ə s
 tricuspid	t ɹ a ɪ k ʌ s p ɪ d
 tridem	t ɹ a ɪ d ə m
 trident	t ɹ a ɪ̯ d ə n t
@@ -65174,6 +65910,7 @@ tripod	t ɹ a ɪ p ɒ d
 tripodes	t ɹ ɪ p ə d iː z
 tripoli	t ɹ ɪ p ə l i
 tripolitan	t ɹ ɪ p ɒ l ɪ t ə n
+tripolitania	t ɹ ɪ p ə l ɪ t e ɪ n i ə
 tripos	t ɹ a ɪ p ɒ s
 tripped	t ɹ ɪ p t
 tripping	t ɹ ɪ p ɪ ŋ
@@ -65290,12 +66027,13 @@ trophæal	t ɹ ə ʊ f iː ə l
 tropic	t ɹ ɒ p ɪ k
 tropical	t ɹ ɒ p ɪ k ə l
 tropical	t ɹ ə ʊ p ɪ k ə l
-tropical	t ʃ ɹ ɒ p ɪ k ə l
+tropical	t͡ʃ ɹ ɒ p ɪ k ə l
 tropicalize	t ɹ ɒ p ɪ k ə l a ɪ z
 tropicamide	t ɹ ə ʊ p ɪ k ə m ʌ ɪ d
 tropicbird	t ɹ ɒ p ɪ k b ɜ ɹ d
 tropism	t ɹ ə ʊ p ɪ z ə m
 tropologize	t ɹ ə p ɒ l ə d͡ʒ a ɪ z
+tropomorphic	t ɹ o ʊ p ə m ɔ ɹ f ɪ k
 tropomyosin	t ɹ ə ʊ p ə m ʌ ɪ ə s ɪ n
 tropomyosin	t ɹ ə ʊ p ə ʊ m ʌ ɪ ə s ɪ n
 troppo	t ɹ ɒ p ə ʊ
@@ -65398,7 +66136,6 @@ truths	t ɹ uː ð z
 truths	t ɹ uː θ s
 truthy	t ɹ uː θ i
 try	t ɹ a ɪ
-try	t͡ʃ ɹ a ɪ
 tryhard	t ɹ a ɪ h ɑː d
 trying	t ɹ a ɪ ɪ ŋ
 tryke	t ɹ a ɪ k
@@ -65459,6 +66196,8 @@ tsuridashi	t s uː ɹ i d ɑː ʃ i
 tsuriotoshi	t s uː ɹ i o ʊ t o ʊ ʃ i
 tsuris	t s uː ɹ ɪ s
 tsuris	t s ʊ ɹ ɪ s
+tsushima	s uː ʃ iː m ə
+tsushima	t s uː ʃ iː m ə
 tsutaezori	t s uː t ɑː e ɪ z ɔː ɹ i
 tsutsugamushi	t s u t s u ɡ æ m uː ʃ iː
 tsuyuharai	t s uː j uː h ɑː ɹ a ɪ
@@ -65507,6 +66246,7 @@ tufty	t ʌ f t i
 tug	t ʌ ɡ
 tugboat	t ʌ ɡ b ə ʊ t
 tugged	t ʌ ɡ d
+tuggeranong	t ʌ ɡ ɹ ə n ɒ ŋ
 tugging	t ʌ ɡ ɪ ŋ
 tugs	t ʌ ɡ z
 tui	t uː i
@@ -65584,7 +66324,9 @@ tunicle	t j uː n ɪ k ə l
 tuning	t j uː n ɪ ŋ
 tunis	t j uː n ɪ s
 tunisia	t j uː n ɪ z i ə
+tunisian	t j uː n ɪ z i ə n
 tunnel	t ʌ n ə l
+tunny	t ʌ n i
 tunxi	t ʊ n ʃ iː
 tuoba	t w o ʊ b ɑː
 tup	t ʌ p
@@ -65615,6 +66357,7 @@ turbulence	t ɜː b j ə l ə n s
 turbulent	t ɜː b j ə l ə n t
 turd	t ɜː d
 turdetani	t ʊ ə ɹ d ɛ t ɑ n i
+turdetanian	t ɜː ɹ d ɪ t e ɪ n i ə n
 turdmuffin	t ɜː ɹ d m ʌ f ɪ n
 turducken	t ɜː d ʌ k ə n
 tureen	t ə ɹ iː n
@@ -65643,7 +66386,6 @@ turmeric	t j uː m ə ɹ ɪ k
 turmeric	t ɜː m ə ɹ ɪ k
 turmeric	t ʃ uː m ə ɹ ɪ k
 turmoil	t ɜː m ɔ ɪ l
-turn	t ɜː n
 turnaround	t ɜː ɹ n ə ɹ a ʊ n d
 turncoat	t əː n k ə ʊ t
 turned	t ɜː n d
@@ -65669,6 +66411,7 @@ turreted	t ʌ ɹ ɪ t ɪ d
 turribant	t ɜː ɹ ɪ b ə n t
 turribant	t ʌ ɹ ɪ b ə n t
 turriff	t ɜ ɹ ɪ f
+turritella	t ʌ ɹ ɪ t ɛ l ə
 turron	t ə ɹ ɒ n
 turtle	t ɜː t l̩
 tuscaloosa	t ʌ s k ə l uː s ə
@@ -65782,6 +66525,7 @@ twincest	t w ɪ n s ɛ s t
 twine	t w a ɪ n
 twinge	t w ɪ n d͡ʒ
 twink	t w ɪ ŋ k
+twinkhon	t w ɪ ŋ k h ʌ n
 twinkle	t w ɪ ŋ k ə l
 twinkling	t w ɪ ŋ k l ɪ ŋ
 twins	t w ɪ n z
@@ -65825,6 +66569,7 @@ tyebble	t͡ʃ ɛ b ə l
 tyek	t j ɛ k
 tying	t a ɪ ɪ ŋ
 tyke	t a ɪ k
+tykhana	t a ɪ k ɑː n ə
 tympan	t ɪ m p ə n
 tympanic	t ɪ m p æ n ɪ k
 tympanites	t ɪ m p ə n a ɪ t iː z
@@ -65983,6 +66728,7 @@ ult	ʌ l t
 ulterior	ʌ l t ɪ ə ɹ ɪ ə
 ultimate	ʌ l t ɪ m ɪ t
 ultimately	ʌ l t ɪ m ə t l i
+ultimately	ʌ l t ɪ m ɪ t l ɪ
 ultimation	ʌ l t ɪ m e ɪ ʃ ə n
 ultimatum	ʌ l t ɪ m e ɪ t ə m
 ultimo	ʌ l t ɪ m ə ʊ
@@ -66042,6 +66788,7 @@ umlaut	ʊ m l a ʊ t
 umlaut	ʌ m l a ʊ t
 umlaute	ʊ m l a ʊ t ə
 ummah	ʊ m ə
+umno	ʌ m n o ʊ
 ump	ʌ m p
 umpire	ʌ m p a ɪ ə ɹ
 umpteen	ʌ m p t iː n
@@ -66178,6 +66925,7 @@ unclutch	ʌ n k l ʌ t͡ʃ
 uncoif	ʌ n k w ɑː f
 uncoif	ʌ n k ɔ ɪ f
 uncoil	ʌ n k ɔ ɪ ə l
+uncollectible	ʌ n k ə l ɛ k t ɪ b l̩
 uncomfortable	ʌ n k ʌ m f t ə b ə l
 uncomfortable	ʌ n k ʌ m f ə t ə b ə l
 uncommon	ʌ n k ɒ m ə n
@@ -66210,8 +66958,7 @@ uncropped	ʌ n k ɹ ɒ p t
 unction	ʌ ŋ k ʃ ə n
 unctional	ʌ ŋ k t͡ʃ n ə l
 unctional	ʌ ŋ k t͡ʃ ə n ə l
-unctuous	ʌ n k t j u ə s
-unctuous	ʌ n k t͡ʃ u ə s
+unctuous	ʌ ŋ k t͡ʃ ʊ ə s
 unctuousness	ʌ ŋ k t͡ʃ u ə s n ə s
 und	ʌ n d
 undashingly	ʌ n d a ʃ ɪ ŋ l i
@@ -66235,6 +66982,9 @@ underbuilder	ʌ n d ə ɹ b ɪ l d ə ɹ
 undercarriage	ʌ n d ə k æ ɹ ɪ d͡ʒ
 undercover	ʌ n d ə ɹ k ʌ v ə ɹ
 undercurrent	ʌ n d ə k ʌ ɹ ə n t
+underestimate	ʌ n d ɚ ɛ s t ɪ m e ɪ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ə t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ɪ t
 underfeeling	ʌ n d ə f iː l ɪ ŋ
 underfire	ʌ n d ə f a ɪ ə
 underfired	ʌ n d ə f a ɪ ə d
@@ -66283,6 +67033,7 @@ undertime	ʌ n d ə ɹ t a ɪ̯ m
 undertime	ʌ n d ɚ t a ɪ̯ m
 undertone	ʌ n d ə ɹ t ə ʊ n
 undertook	ʌ n d ə ɹ t ʊ k
+underutilize	ʌ n d ə j uː t ɪ l a ɪ z
 undervalue	ʌ n d ə ɹ v æ l j u
 underverse	ʌ n d ə ɹ v ɜː ɹ s
 underwater	ʌ n d ə ɹ w ɔː t ə
@@ -66346,6 +67097,7 @@ unencumbered	ʌ n ɪ n k ʌ m b ə d
 unenfranchised	ʌ n ɪ n f ɹ a n t ʃ ʌ ɪ z d
 unenthusiastic	ʌ n ɛ n θ j uː z i æ s t ɪ k
 unequal	ʌ n iː k w ə l
+unequivocal	ʌ n ɪ k w ɪ v ə k ə l
 unergative	ʌ n ɜː ɡ ə t ɪ v
 unergatives	ʌ n ɜː ɹ ɡ ə t ɪ v z
 unerring	ʌ n ɜː ɹ ɪ ŋ
@@ -66450,6 +67202,7 @@ unimportant	ʌ n ɪ m p ɔː t ə n t
 uninitiated	ʌ n ɪ n ɪ ʃ i e ɪ t ɪ d
 uninspired	ʌ n ɪ n s p a ɪ ə d
 uninspiring	ʌ n ɪ n s p a ɪ ə ɹ ɪ ŋ
+unintelligible	ʌ n ɪ n t ɛ l ɪ d͡ʒ ɪ b ə l
 unintended	ʌ n ɪ n t ɛ n d ɪ d
 unintentional	ʌ n ɪ n t ɛ n ʃ ə n ə l
 uninvite	ʌ n ɪ n v a ɪ t
@@ -66466,6 +67219,8 @@ unique	j uː n iː k
 unique	j ə n iː k
 uniquity	j u n ɪ k w ɪ t i
 unisex	j uː n ɪ s ɛ k s
+unison	j u n ɪ s ə n
+unison	j u n ɪ z ə n
 unit	j uː n ɪ t
 unitary	j uː n ɪ t ə ɹ i
 united	j uː n a ɪ t ɪ d
@@ -66487,6 +67242,7 @@ univocal	j uː n ɪ v ə k ə l
 univocal	j uː n ɪ v ə ʊ k ə l
 univocity	j uː n ɪ v ɒ s ɪ t i
 unix	j uː n ɪ k s
+unjam	ʌ n d͡ʒ æ m
 unjust	ʌ n d͡ʒ ʌ s t
 unjustly	ʌ n d͡ʒ ʌ s t l i
 unked	ʌ n k ɛ d
@@ -66504,6 +67260,8 @@ unlaid	ʌ n l e ɪ d
 unlead	ʌ n l ɛ d
 unleaded	ʌ n l ɛ d ə d
 unlearn	ʌ n l əː n
+unlearned	ʌ n l ɜː n d
+unlearned	ʌ n l ɜː n ɪ d
 unleash	ʌ n l i ʃ
 unless	ə n l ɛ s
 unless	ɪ n l ɛ s
@@ -66560,6 +67318,7 @@ unnoticed	ʌ n n ə ʊ t ɪ s t
 unnun	ʌ n n ʌ n
 unoared	ʌ n ɔː ɹ d
 unobtainium	ʌ n ɒ b t e ɪ n ɪ ə m
+unobtrusive	ʌ n ə b t ɹ uː s ɪ v
 unobtrusively	ʌ n ə b t ɹ uː s ɪ v l i
 unorthodox	ʌ n ɔː θ ə d ɒ k s
 unoverridden	ʌ n o ʊ v ɚ ɹ ɪ d ə n
@@ -66605,6 +67364,7 @@ unreasonably	ʌ n ɹ iː z ə n ə b l i
 unrecognizable	ʌ n ɹ ɛ k ə ɡ n a ɪ z ə b ə l
 unrecuring	ʌ n ɹ ɪ k j ʊ ə ɹ ɪ ŋ
 unredressable	ʌ n ɹ ɪ d ɹ ɛ s ə b ə l
+unreliable	ʌ n ɹ ɪ l a ɪ ə b l̩
 unreluctant	ʌ n ɹ ɪ l ʌ k t ə n t
 unremitting	ʌ n ɹ ɪ m ɪ t ɪ ŋ
 unrequited	ʌ n ɹ ə k w a ɪ t ɪ d
@@ -66732,13 +67492,15 @@ unwittingly	ʌ n w ɪ t ɪ ŋ l i
 unwonted	ʌ n w ɒ n t ɪ d
 unwontedly	ʊ n w o ʊ n t ɪ d l i
 unworthy	ʌ n w ɝ ð i
-unwound	ʌ n w ɑ ʊ n d
+unwound	ʌ n w a ʊ̯ n d
+unwound	ʌ n w uː n d
 unwrap	ʌ n ɹ æ p
 unwroken	ʌ n ɹ ə ʊ k ə n
 unyoke	ʌ n j ə ʊ k
 uotsuri	uː o ʊ t s ʊ ə ɹ i
 up	ʌ p
 upanayana	uː p ə n ɑː j ə n ə
+upazila	uː p ɒ d͡ʒ ɪ l ə
 upbar	ʌ p b ɑː ɹ
 upbind	ʌ p b a ɪ n d
 upbraid	ʌ p b ɹ e ɪ d
@@ -66970,6 +67732,7 @@ uterus	j uː t ə ɹ ə s
 uther	j uː θ ə ɹ
 uther	uː θ ə ɹ
 utica	j uː t ɪ k ə
+util	j uː t ɪ l
 utile	j uː t a ɪ l
 utilitarian	j uː t ɪ l ɪ t ɛː ɹ i ə n
 utilitarianist	j u t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
@@ -66977,6 +67740,7 @@ utilitarianist	j ʊ t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianly	j u t ɪ l ɪ t e ɪ ɹ i ə n l i
 utility	j uː t ɪ l ɪ t i
 utility	j ə t ɪ l ɪ t i
+utilize	j uː t ɪ l a ɪ z
 utmost	ʌ t m ə ʊ̯ s t
 utonian	j uː t o ʊ n i ə n
 utopia	j uː t ə ʊ p i ə
@@ -67104,6 +67868,7 @@ valency	v e ɪ l ə n s i
 valent	v e ɪ l ə n t
 valentine	v a l ə n t a ɪ n
 valentine	v æ l ə n t a ɪ n
+valeria	v ə l ɪ ə ɹ i ə
 valerian	v ə l ɪ ə ɹ ɪ ə n
 valet	v æ l e ɪ
 valet	v æ l ɪ t
@@ -67117,6 +67882,7 @@ valid	v æ l ɪ d
 validate	v æ l ɪ d e ɪ t
 validation	v æ l ə d e ɪ ʃ ə n
 validify	v ə l ɪ d ɪ f a ɪ
+valinemia	v e ɪ l ɪ n iː m i ə
 valise	v ə l iː z
 valium	v æ l i ə m
 valkyrie	v æ l k ɚ i
@@ -67127,8 +67893,10 @@ vallejo	v ə l e ɪ ə ʊ
 valletta	v ə l ɛ t ə
 valley	v æ l i
 valleys	v æ l i z
+vallum	v æ l ə m
 valnemulin	v æ l n ɛ m j ʊ l ɪ n
 valour	v æ l ə
+valparaíso	v ɑ l p ɑ ɹ a ɪ iː s o ʊ
 valproate	v æ l p ɹ ə ʊ e ɪ t
 valse	v ɑ l s
 valuable	v æ l j u ə b l̩
@@ -67178,6 +67946,7 @@ vapor	v e ɪ p ə
 vaporous	v e ɪ p ə ɹ ə s
 vaporous	v e ɪ p ɹ ə s
 vaporware	v e ɪ p ə w ɛ ə ɹ
+vaporwave	v e ɪ p ə w e ɪ v
 vapory	v e ɪ p ə ɹ i
 vapourware	v e ɪ p ə w ɛ ə ɹ
 vapulate	v æ p j ʊ l e ɪ t
@@ -67273,6 +68042,7 @@ vecrīga	v ɛ t s ɹ iː ɡ a
 vectis	v ɛ k t ɪ s
 vectisian	v ɛ k t iː z i ə n
 vector	v ɛ k t ə
+vectorize	v ɛ k t ə ɹ a ɪ z
 veda	v e ɪ d ə
 vedette	v ə d ɛ t
 vedge	v ɛ d͡ʒ
@@ -67379,6 +68149,7 @@ venezuela	v ɛ n ɛ z w e ɪ l ə
 venezuela	v ɛ n ɪ z w e ɪ l ə
 vengeance	v ɛ n d͡ʒ ə n s
 vengeful	v e n ʒ f ə l
+vengence	v iː n iː n s
 venial	v iː n i ə l
 venice	v ɛ n ɪ s
 venicia	v ə n iː ʃ ə
@@ -67466,6 +68237,7 @@ verlan	v ɛ ə ɹ l ɑː n
 vermeer	v ə m ɛ ə
 vermeer	v ə m ɪ ə
 vermeil	v ɜː m e ɪ l
+vermetid	v ɜː ɹ m ə t ɪ d
 vermiculate	v ə m ɪ k j ə l e ɪ t
 vermiculate	v ə m ɪ k j ʊ l e ɪ t
 vermiculate	v ə m ɪ k j ʊ l ə t
@@ -67529,6 +68301,7 @@ vertiginous	v ɜː ɹ t ɪ d͡ʒ ɪ n ə s
 vertigo	v ɜː t ɪ ɡ ə ʊ
 verts	v ɜː ɹ t s
 vertu	v əː t uː
+vervaeke	v ɜː v e ɪ k i
 vervaeke	v ɜː v iː k i
 vervain	v ɜː v e ɪ n
 verve	v ɜː v
@@ -67541,6 +68314,8 @@ vesical	v iː s ɪ k ə l
 vesical	v ɛ s ɪ k ə l
 vesicle	v iː s ɪ k ə l
 vesicle	v ɛ s ɪ k ə l
+vesicobullous	v ɛ s ɪ k o ʊ b ʊ l ə s
+vesicocele	v ɛ s ɪ k o ʊ s i l
 vespasian	v ɛ s p e ɪ z i ə n
 vespasian	v ɛ s p e ɪ ʒ i ə n
 vesper	v ɛ s p ə
@@ -67834,6 +68609,7 @@ vinylon	v a ɪ n ɪ l ɒ n
 viognier	v iː ɒ n j e ɪ
 viol	v a ɪ ə l
 viola	v a ɪ ə l ə
+viola	v a ɪ ə ʊ l ə
 viola	v i ə ʊ l ə
 viola	v iː ə l ə
 violate	v a ɪ ə l e ɪ t
@@ -67896,6 +68672,7 @@ virtualize	v ɜː ɹ t j u ə l a ɪ z
 virtualize	v ɜː ɹ t͡ʃ u ə l a ɪ z
 virtue	v ɜː t͡ʃ uː
 virtues	v əː t͡ʃ uː s
+virtuosity	v ɜː ɹ t j u ɒ s ɪ t i
 virtuoso	v ɜ t ʃ u ə ʊ s ə ʊ
 virtuous	v ɜː t͡ʃ ʊ ə s
 virulence	v ɪ ɹ j ə l ə n s
@@ -67927,6 +68704,7 @@ visibility	v ɪ z ə b ɪ l ə t i
 visibility	v ɪ z ə b ɪ l ɪ t i
 visibility	v ɪ z ɪ b ɪ l ɪ t i
 visible	v ɪ z ə b ə l
+visibly	v ɪ z ə b l i
 visibly	v ɪ z ɪ b l i
 vision	v ɪ ʒ ə n
 visionary	v ɪ ʒ n̩ ə ɹ i
@@ -67970,6 +68748,7 @@ vitrify	v ɪ t ɹ ɪ f a ɪ
 vitrine	v ə t ɹ iː n
 vitrine	v ɪ t ɹ iː n
 vitriolic	v ɪ t ɹ ɪ ɒ l ɪ k
+vitrophyre	v ɪ t ɹ ə f a ɪ ə ɹ
 vituperate	v ɪ t j uː p ə ɹ e ɪ t
 vituperate	v ɪ t j uː p ə ɹ ə t
 vituperation	v a ɪ t j uː p ə ɹ e ɪ ʃ ə n
@@ -68347,6 +69126,7 @@ wallow	w ɒ l ə ʊ
 wallowish	w ɒ l ə ʊ ɪ ʃ
 walls	w ɔː l z
 wally	w ɒ l i
+walm	w ɑː m
 walm	w ɔː m
 walmartian	w ɔː l m ɑː ɹ ʃ ə n
 walnut	w ɔː l n ʌ t
@@ -68420,6 +69200,7 @@ wannabe	w ɒ n ə b i
 wans	w æ n s
 wanstead	w ɒ n s t ɛ d
 want	w ɒ n t
+wanted	w ɒ n t ɪ d
 wanting	w ɒ n t ɪ ŋ
 wantok	w ɒ n t ɒ k
 wantokism	w ɑ n t ɒ k ɪ z ə m
@@ -68754,6 +69535,7 @@ weighty	w e ɪ t i
 weimar	v a ɪ m ɑː
 weimaraner	v a ɪ m ə ɹ ɑː n ə ɹ
 weimarization	v a ɪ m ɑː ɹ a ɪ z e ɪ ʃ ə n
+weiqi	w e ɪ t ʃ iː
 weir	w ɪ ə
 weird	w iː ə ɹ d
 weird	w ɪ ə ɹ d
@@ -68836,6 +69618,8 @@ weretiger	w ɛ ə t a ɪ ɡ ə
 weretiger	w ɪ ə t a ɪ ɡ ə
 werewolf	w ɛː w ʊ l f
 werewolf	w ɪ ə w ʊ l f
+wergeld	w ɛ ə ɹ ɡ ɛ l d
+wergeld	w ɜː ɹ ɡ ɛ l d
 wert	w ɜː t
 wes	w ɛ s
 wes	w ɛ z
@@ -68917,9 +69701,11 @@ what	w ɒ t
 what	ʍ ɒ t
 what'd	w ʌ d
 what'd	w ʌ t ə d
+what'd	w ʌ t ɪ d
 what'll	w ɒ t ə l
 what's	w ɒ t s
 whataboutery	w ɒ t ə b a ʊ t ə ɹ i
+whataboutism	w ə t ə b a ʊ t ɪ z ə m
 whatcha	w ɒ t ʃ j ə
 whatcha	w ɒ t ʃ ə
 whatchamacallit	w ɒ t ʃ ə m ə k ɔː l ɪ t
@@ -69112,6 +69898,8 @@ whiteboard	w a ɪ t b ɔː d
 whitechapel	w ʌ ɪ t t͡ʃ æ p ə l
 whitechurch	w a ɪ t t͡ʃ ɜː ɹ t͡ʃ
 whitechurch	ʍ a ɪ t t͡ʃ ɜː ɹ t͡ʃ
+whitehall	w a ɪ t h ɔː l
+whitehall	ʍ a ɪ t h ɔː l
 whitelash	h w a ɪ t l æ ʃ
 whitely	w ʌ ɪ t l i
 whiten	h w a ɪ t n̩
@@ -69299,9 +70087,9 @@ wiktionary	w ɪ k ʃ ə n ə ɹ i
 wiktionary	w ɪ k ʃ ə n ɹ ɪ
 wilco	w ɪ l k ə ʊ
 wild	w a ɪ l d
-wild	w a ɪ ə l d
 wildcat	w a ɪ l d k æ t
 wilde	w a ɪ l d
+wilden	w a ɪ l d ə n
 wilder	w a ɪ l d ə ɹ
 wilder	w ɪ l d ə ɹ
 wilderness	w ɪ l d ə n ə s
@@ -69442,6 +70230,7 @@ winne	w ɪ n
 winner	w ɪ n ə
 winnie	w ɪ n i
 winning	w ɪ n ɪ ŋ
+winningest	w ɪ n ɪ ŋ ɪ s t
 winnings	w ɪ n ɪ ŋ z
 winnipeg	w ɪ n ə p ɛ ɡ
 winnipegger	w ɪ n ə p ɛ ɡ ə ɹ
@@ -69520,6 +70309,7 @@ with't	w ɪ θ t
 withal	w ɪ ð ɔː l
 withdraught	w ɪ ð d ɹ ɑː f t
 withdraw	w ɪ ð d ɹ ɔː
+withdraw	w ɪ θ d ɹ ɔː
 withdrawal	w ɪ ð d ɹ ɔː ə l
 withdrawal	w ɪ θ d ɹ ɔː ə l
 withdrawn	w ɪ ð d ɹ ɔː n
@@ -69542,8 +70332,9 @@ withheld	w ɪ ð h ɛ l d
 withheld	w ɪ θ h ɛ l d
 withhold	w ɪ ð h ə ʊ l d
 withhold	w ɪ θ h ə ʊ l d
-withholding	w ɪ ð h ə ʊ l d i ŋ
-withholding	w ɪ θ h ə ʊ l d i ŋ
+withholding	w ɪ ð h ə ʊ l d ɪ ŋ
+withholding	w ɪ θ h ə ʊ l d ɪ ŋ
+withiel	w ɪ ð j ə l
 withies	w ɪ ð i z
 withies	w ɪ θ i z
 within	w ɪ ð ɪ n
@@ -69646,9 +70437,7 @@ wombat	w ɒ m b æ t
 wombgate	w uː m ɡ e ɪ t
 wombman	w uː m m ə n
 wombmate	w uː m m e ɪ t
-women	w ɪ m ə n
 women	w ɪ m ɪ n
-women	w ʊ m ə n
 women's	w ɪ m ɪ n z
 won	w ɒ n
 won	w ʌ n
@@ -69737,20 +70526,22 @@ wordbook	w ɜː d b ʊ k
 wordform	w ɜː d f ɔː m
 wordforms	w ɜː d f ɔː m z
 words	w ɜː d z
-wordsmith	w ɜː ɹ d s m ɪ θ
+wordsmith	w ɜː d s m ɪ θ
+wordsmithing	w ɜː d s m ɪ θ ɪ ŋ
 wordster	w ɜː d s t ə
 wordsters	w ɜː d s t ə z
 wore	w ɔː
-work	w ɔ ɪ̯ k
-work	w ɜ ɹ k
+work	w ɜ ɪ̯ k
 work	w ɜː k
 work	w ɜː ɹ k
+work	w ɝ k
 workaday	w ɜː ɹ k ə d e ɪ
 workaround	w ɜː k ə ɹ a ʊ n d
 worked	w ɜː k t
 worker	w ɜː k ə
 workers	w ɜː k ə z
 workflow	w ɜː k f l ə ʊ
+workforce	w ɜː k f ɔː s
 workgroup	w əː k ɡ ɹ uː p
 working	w ɜː k ɪ ŋ
 workington	w ɜː ɹ k ɪ ŋ t ə n
@@ -69802,6 +70593,7 @@ worsley	w ɜː ɹ z l i
 worst	w ɜː s t
 worsted	w əː s t ɪ d
 worsted	w ʊ s t ɪ d
+wort	w ɔː t
 wort	w ɜː t
 wortcunning	w ɜː t k ʌ n ɪ ŋ
 worth	w ɜː θ
@@ -69812,6 +70604,8 @@ worthwhile	w ɜː ɹ θ ʍ a ɪ l
 worthwhileness	w ɜː ɹ θ w a ɪ l n ə s
 worthwhileness	w ɜː ɹ θ ʍ a ɪ l n ə s
 worthy	w ɜː ð i
+worts	w ɔː t s
+worts	w ɜː t s
 worty	w ɜː t i
 wot	w ɒ t
 wotcher	w ɒ t͡ʃ ə
@@ -69896,6 +70690,10 @@ wrinkled	ɹ ɪ ŋ k l̩ d
 wrinkledness	ɹ ɪ ŋ k ə l d n ə s
 wrinkliness	ɹ ɪ ŋ k ə l i n ə s
 wrinkly	ɹ ɪ ŋ k ə l i
+wriothesley	r a ɪ z l i
+wriothesley	r a ɪ ə θ s l i
+wriothesley	r ɒ t s l i
+wriothesley	r ɛ z l i
 wrist	ɹ ɪ s t
 wristband	ɹ ɪ s t b æ n d
 wristlet	ɹ ɪ s t l ə t
@@ -69953,6 +70751,8 @@ wug	w ʌ ɡ
 wuhan	uː h ɑː n
 wuhan	w uː h ɑː n
 wuhu	w uː h uː
+wujiang	w u d͡ʒ j æ ŋ
+wujiang	w u d͡ʒ j ɑ ŋ
 wujiaqu	w uː d͡ʒ i ɑː t͡ʃ uː
 wulumuqi	w uː l uː m uː t͡ʃ iː
 wumao	w uː m a ʊ
@@ -70102,6 +70902,7 @@ xeromorphic	z ɪ ə ɹ ə m ɔ ɹ f ɪ k
 xerophagy	z ɪ ə ɹ ɒ f ə d ʒ i
 xerophyte	z ɪ ə ɹ ə ʊ f a ɪ t
 xerox	z ɛ ɹ ɒ k s
+xertz	z ɝ t s
 xerxes	z ɜː k s iː z
 xhosa	k ɔː s ə
 xhosa	k ə ʊ s ə
@@ -70150,6 +70951,7 @@ xizang	ʃ iː z ɑː ŋ
 xmas	k ɹ ɪ s m ə s
 xmas	ɛ k s m ə s
 xoanon	z ə ʊ ə n ɒ n
+xography	ɛ k s ɒ ɡ ɹ ə f i
 xolo	ʃ ə ʊ l ə ʊ
 xor	k s o ɹ
 xor	k s z o ɹ
@@ -70323,6 +71125,7 @@ yaws	j ɔː z
 yay	j e ɪ
 yayan	j ɑː j ɑː n
 yayo	j e ɪ o ʊ
+yclad	ɪ k l æ d
 yclept	ɪ k l iː p ɪ d
 yclept	ɪ k l ɛ p t
 ye	j e ɪ
@@ -70371,6 +71174,7 @@ yem	j ɛ m
 yemen	j ɛ m ə n
 yen	j ɛ n
 yeo	j ə ʊ
+yeoh	j ə ʊ
 yeoman	j ə ʊ m ə n
 yeomen	j ə ʊ m ə n
 yeomen	j ə ʊ m ɛ n
@@ -70391,6 +71195,7 @@ yern	j əː n
 yes	j ɛ s
 yes'm	j ɛ s ə m
 yeses	j ɛ s ɪ z
+yesn't	j ɛ s ə n t
 yesses	j ɛ s ɪ z
 yessir	j ɛ s ɜː ɹ
 yestaday	j ɛ s t ə d e ɪ
@@ -70515,7 +71320,6 @@ youngest	j ʌ ŋ ɡ ə s t
 youngin	j ʌ ŋ ɪ n
 youngling	j ʌ ŋ l ɪ ŋ
 youngster	j ʌ ŋ s t ə
-youngun	j ʌ ŋ ə n
 your	j ɔː
 your	j ə
 your	j ʊ ə
@@ -70612,6 +71416,7 @@ zachary	z æ k ə ɹ i
 zack	z a k
 zack	z æ k
 zacks	z æ k s
+zaddy	z æ d i
 zadruga	z æ d ɹ uː ɡ ə
 zaffre	z æ f ə ɹ
 zaftig	z æ f t ɪ ɡ
@@ -70634,10 +71439,12 @@ zambuk	z æ m b uː k
 zambuk	z æ m b ʌ k
 zamburak	z ʌ m b ʊ ɹ ʌ k
 zamindar	z ə m iː n d ɑː
+zamzummim	z a m z ʌ m m ɪ m
 zander	z æ n d ə ɹ
 zangi	z æ ŋ ɡ iː
 zangid	z æ ŋ ɡ ɪ d
 zante	z a n t ɪ
+zantedeschia	z æ n t ɪ d ɛ s k i ə
 zany	z e ɪ n i
 zanzibar	z æ n z ɪ b ɑː ɹ
 zap	z æ p
@@ -70696,6 +71503,7 @@ zelina	z ɛ l iː n ə
 zellige	z ɛ l iː d͡ʒ
 zelophehad	z ɪ l ɒ f ɪ h æ d
 zelus	z iː l ə s
+zemlyanka	z ɛ m l i ɑ ŋ k ə
 zemstva	z ɛ m s t v a
 zemstvo	z ɛ m s t v ə ʊ
 zenana	z ə n ɑː n ə
@@ -70859,6 +71667,8 @@ zomedy	z ɒ m ə d i
 zonal	z ə ʊ n ə l
 zone	z ə ʊ n
 zongdu	d z ʊ ŋ d uː
+zongzi	t s ʊ ŋ t s ɪ
+zongzi	z ʊ ŋ z ɪ
 zonie	z ə ʊ n i
 zonk	z ɒ ŋ k
 zony	z ə ʊ n i
@@ -70951,6 +71761,8 @@ zun	z ʊ n
 zunyi	d z uː n j iː
 zuojhen	d z w o ʊ d͡ʒ ʌ n
 zuoyun	d z w o ʊ j uː n
+zuppa	t s uː p ə
+zuppa	z uː p ə
 zurich	z j ʊ ə ɹ ɪ k
 zuricher	z j ʊ ə ɹ ɪ k ə
 zwingli	s w ɪ ŋ ɡ l i
@@ -70997,7 +71809,9 @@ zzyzx	z a ɪ z ɪ k s
 éclat	e ɪ k l ɑː
 écorché	e k ɔː ʃ e ɪ
 écu	e ɪ k uː
+élan	e ɪ l æ n
 élan	e ɪ l ɑː n
+émigré	ɛ m ɪ ɡ ɹ e ɪ
 étatisme	e ɪ t ɑː t iː z m
 étatisme	ɛ t ɑ t ɪ z m
 étatisme	ɛ t ɑː t ɪ z ə m

--- a/data/scrape/tsv/eng_latn_uk_narrow.tsv
+++ b/data/scrape/tsv/eng_latn_uk_narrow.tsv
@@ -37,11 +37,10 @@ albicant	a l b ɪ k n̩ t
 album	a ɫ b̚ m̩
 alder	ɔː l d ə
 alders	ɔː l d ə z
-alexander	a l ɨ ɡ z ɑː n d ə
 algorithm	æ ɫ ɡ ə ɹ ɪ ð m̩
 alienation	e ɪ l i ə n e ɪ ʃ ə n
 alignment	ə ɫ a ɪ n m ə n t
-all	ɔ ɫ
+all	ɔː ɫ
 allergies	æ l ə d͡ʒ i z
 allergies	æ l ɚ d͡ʒ i z
 allergy	æ l ə d ʒ i
@@ -57,10 +56,11 @@ amazing	ə m e ɪ̯ z ɪ ŋ
 amphibious	æ m f ɪ b i ə s
 an	ɛ ə n
 analects	æ n ə l ɛ k t s
-andrew	eᵊ n d͡ʒ ɹ ʊ̈ u
-andrew	æ n d͡ʒ ɹ ʊ̈ u
+andrew	eᵊ n d̠ ɹ̠ ˔ʷ ʊ̈ u
+andrew	æ n d̠ ɹ̠ʷ ˔ ʊ̈ u
 angsts	e ɪ ŋ k s t s
 anthropomorphic	æ̃ n̪ θ ɹ̠ ə p ə m ɔ ɹ̠ f ɪ̈ k
+aphorism	æ f ə ɹ ɪ z m̩
 apple	æ p ɫ̩
 appled	æ p ɫ̩ d
 arbitration	ɑː b ə t̠͡ɹ̠ e ɪ ʃ n̩
@@ -74,7 +74,6 @@ article	ɑː tʰ ɪ kʰ ə ɫ
 atend	ə tʰ ɛ n d
 atlanta	æ t l æ n ə
 atlanta	æ t l æ ɾ̃ ə
-attack	ə tʰ æ k
 attend	ə tʰ ɛ n d
 attic	æ ɾ ɪ k
 attraction	ə t ɹ æ k ʃ ɪ̈ n
@@ -91,11 +90,6 @@ aunt	ɑː n t
 aunt	ɒː n t
 aunt	ɛ ə n t
 availability	ə v e ɪ l ə b ɪ l ɪ t ɪ
-aw	o ə
-aw	ɒ̃ː
-aw	ɔ ə
-aw	ɔ̃ː
-aw	ʊ ə
 awara	æ w ɑː ɹ ʌ
 awara	ɒ w ʌ ɹ ʌ
 ayuh	ˀe ɪ ʌˀ
@@ -119,6 +113,7 @@ bale	b e ə̯ ɫ
 bale	b e ɪ̯ ə ɫ
 balt	b ɑ l t
 balt	b ɔː l t
+banana	b ə n ɑː n ɐ
 bank	b e ɪ ŋ k
 barn	b a ɾ n
 barn	b aː n
@@ -147,7 +142,7 @@ baulk	b ɔː ɫ k
 bautzen	b a ʊ t s ə n
 bawl	b ɔː ɫ
 beadle	b iː d ə ɫ
-beagle	b iː ɡ ə ɫ
+beagle	b̥ iː ɡ ə ɫ
 beared	b ɛ ɚ̯ d
 beared	b ɛː d
 beatle	b iː t ə ɫ
@@ -179,6 +174,7 @@ blurple	b l əː p l̩
 bockety	b ɑ k ə t iː
 bold	b ɒ ʊ ɫ d
 boldly	b ɒ ʊ l d l i
+bolt	b ɔ ʊ ɫ t
 bookcase	b ʊ ʔ k̚ k e ɪ s
 boot	b uː t
 botanist	b ɒ t n̩ ɪ s t
@@ -245,6 +241,9 @@ caught	kʰ ɔ ə̯ t
 caught	kʰ ɔː t
 caught	kʰ ʊ ə̯ t
 caught	k̠ʰ oː t
+causal	kʰ oː z̥ ə l
+causality	kʰ oː z̥ æ l ɪ t ɪ
+causation	kʰ oː z̥ e ɪ ʃ ə n
 cause	kʰ oː z̥
 cauterize	kʰ ɑ ɾ ə ɹ a ɪ z
 cauterize	kʰ ɔ ɾ ə ɹ a ɪ z
@@ -257,6 +256,7 @@ chalcanthite	~ θ ɒ͡ɪ t̚
 chance	t͡ʃ ɑː n s
 chance	t͡ʃʰ a n s
 chance	t͡ʃʰ e ə n s
+chance	t͡ʃʰ eː n s
 chance	t͡ʃʰ æ n s
 chance	t͡ʃʰ æ n s ~ t͡ʃʰ a n s
 chance	t͡ʃʰ ɐː n s
@@ -270,6 +270,8 @@ chatted	t͡ʃ æ ɾ ɨ d
 chattel	t͡ʃ æ ɾ ɫ̩
 cheated	t͡ʃ i ɾ ɨ d
 check	t͡ʃ ɛ k̚
+child	t͡ʃ a ɪ̯ ɫ d
+child	t͡ʃ a ɪ̯ ɫ̩ d
 children	t ʃ ɪ l ɹ ə n
 china	t͡ʃʰ a ɪ̯ n ə
 chlordiazepoxide	k l ɔː r d a ɪ ə z e p o k s a ɪ d
@@ -281,6 +283,7 @@ circle	s ɜː k ə ɫ
 circle	s ɝ k ə ɫ
 cital	s a ɪ t l̩
 cital	s ʌ ɪ t l̩
+city	s ɪ tʰ iː
 city	s ɪ ɾ i
 clamming	k l a m ɘ n
 clay	k l̥ e ɪ
@@ -338,6 +341,7 @@ coventry	kʰ ɒ v ə n t ʃ ɹ i
 craytur	k ɹ eː t̪ ə ɹ
 creation	k ɹ iːʲ e ɪ ʃ ɘ n
 creep	kʰ ɹ iː p
+crew	k ɹ u ʊ̯
 crisscross	k ɹ ɪ s k ɹ ɒ s
 crisscross	k ɹ ɪ s k ɹ ɔ s
 cryptography	k ɹ̥ ɪ p tʰ ɒ ɡ ɹ ə f iː
@@ -345,6 +349,7 @@ cuba	k j uː b ə
 cuban	k j u b ə n
 cuban	k j uː b ə n
 cuban	k j ʉː b ə n
+cuddleologist	k ʌ d ə l ɒ l ə d͡ʒ ɪ s t
 culprit	kʰ ʌ ɫ p ɹ̥ ɪ t
 cunt	kʰ ʌ̃ n t
 curve	kʰ ɜː v
@@ -379,6 +384,7 @@ dealkylated	d iː æ ɫ k ɪ l e ɪ t ə d
 dealkylating	d iː æ ɫ k ɪ l e ɪ t ɪ ŋ ɡ
 dealkylation	d iː æ ɫ k ɪ l e ɪ ʃ ə n
 dealkylative	d iː æ ɫ k ɪ l ə t ɪ v
+dean	d iː n
 dean	d ĩː n
 debatable	d ɪ b e ɪ t ə b ə ɫ
 debateful	d ɪ b e ɪ t f ə ɫ
@@ -529,14 +535,16 @@ disrespectful	d ɪ s ɹ ɪ s p ɛ k t f ə ɫ
 dissemble	d ɪ s ɛ m b ə ɫ
 divinyl	d a ɪ v a ɪ n ɪ ɫ
 divisible	d ɪ v ɪ z ɪ b ə ɫ
-dna	d i ɛ n e ɪ
 dniester	d n ɪ e s t ə
 dniester	n iː s t ə
 dojo	d ə ʊ̯ d͡ʒ ə ʊ̯
+dollywood	d ɑ ɫ i w ʊ d
+dollywood	d ɒ ɫ i w ʊ d
 done	d ɐ n
 done	d ʊ n
 dope	d ə ʊ p
 dower	d a ʊ ə ɹ
+drag	d͡ɹ̝ ˗ʷ æˑ ɡ
 dragging	d͡ʒ ɹ æ ɡ ɪ ŋ
 drain	d͡ʒ ɹ e ɪ n
 dream	d̠͡ɹ̠ ˔ʷ ɪ i̯ m
@@ -552,6 +560,9 @@ drown	d̠͡ɹ̠ ˔ʷ a ʊ n
 drug	d̠͡ɹ̠ ˔ʷ ʌ ɡ
 drugs	d ɹ ʌ ɡ z
 drugs	d͡ʒ ɹ ʌ ɡ z
+dry	d̠͡ɹ̠ ˔ a ɪ̯
+dry	d̠͡ɹ̠ ˔ʷ a ɪ̯
+dry	d͡ʒ ɹ a ɪ̯
 drying	d͡ʒ ɹ a ɪ ɪ ŋ
 dunn	d ɐ n
 eaten	iː ʔ n̩
@@ -589,6 +600,7 @@ exchange	ɛ k s t͡ʃ e ɪ n d͡ʒ
 exchange	ɛ k s t͡ʃʰ e ɪ n d͡ʒ
 exosome	ɛ k s o ʊ̯ s o ʊ̯ m
 exosome	ɛ k s ə ʊ̯ s ə ʊ̯ m
+fanaticism	f ə n æ ɾ ɪ s ɪ z m̩
 farrand	f æ ɹ ə n d
 farrand	f æ ɹ ə n t
 fatal	f e ɪ ɾ ɫ̩
@@ -602,6 +614,7 @@ fence	f ɛ n s
 fence	f ɛ n t s
 fencer	f ɛ n s ɚ
 feudal	f j uː d ɫ̩
+feudalism	f j u d ə l ɪ z m̩
 few	f j ʉː
 few	f j ʉ͡u
 fiddy	f ɪ ɾ i
@@ -684,8 +697,6 @@ gold	ɡ ɒ ʊ ɫ d
 gold	ɡ ɔ ʊ ɫ d
 golden	ɡ ɒ ʊ̯ ɫ d n̩
 gonna	ɡ o ʊ ɪ n ə
-goose	ɡ ʉ s
-goose	ɡ ʉː s
 gotta	ɡ ɒ ʔ ə
 gowk	ɡ æ ʊ̯ˀ k
 gramophone	ɡ ɹ æ m ə f o ʊ n
@@ -760,6 +771,9 @@ humanist	h ç uː m ə n ɪ s t
 humanist	ç uː m ə n ɪ s t
 humongous	ç u̟ː m ɐ ŋ ɡ ə s
 humongous	ç u̟ː m ʊ ŋ ɡ ə s
+humph	h ə ɱ f
+humph	h ɱ̩ f
+humph	ɱ̊ ɱ̩ f
 humvee	h ʌ m β iː
 humvee	h ʌ ɱ v iː
 hydra	h a ɪ̯ d ɹ ə
@@ -779,7 +793,8 @@ i	a ɪ̯
 i	aː
 i	ɑ e̯
 iced	a ɪ̯ s t
-important	ɪ m p ɔː tʰ ə n t
+important	ɪ m pʰ ɔː t ə n t̚
+important	ɪ m pʰ ɔː ʔ n̩ ʔ
 inamorata	ɪ n æ m ɒ ɹ ɑː t ə
 incalculable	ɪ n kʰ æ ɫ k j ə l ə b l̩
 incidental	ɪ n s ɪ d ɛ n tʰ ə l
@@ -794,10 +809,13 @@ input	ɪ m p ʊ t
 input	ɪ n p ʊ t
 insolvency	ɪ n s ɒ l v n̩ s i
 installation	ɪ n s t ə l e ɪ ʃ ə n
+intangible	ɪ n t æ n d͡ʒ ɪ b l̩
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ə ɾ i
+intelligibility	ɪ n t ɛ l ə d͡ʒ ə b ɪ l ɪ ɾ i
 intentional	ɪ n tʰ ɛ n ʃ n̩ ɫ̩
-interloper	ɪ n t ə l ə ʊ̯ p ə
 international	ɪ n t ə n æ ʃ ə n ə ɫ
 investigate	ɪ n v ɛ s t ɪ ɡ e ɪ̯ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə ɾ i
 ipa	a ɪ pʰ iː e ɪ
 ireland	a ɪ ɚ l ə n d
 ireland	ä ɪ ɚ ɫ ɪ̈ n d
@@ -852,9 +870,6 @@ lambrusco	l æ m b ɹ ʊ s k ə ʊ
 lander	l æ n d ə
 language	l e ɪ ŋ ɡ w ɪ d͡ʒ
 languages	l e ɪ ŋ ɡ w ɪ d͡ʒ ɪ z
-largely	l aː d͡ʒ l i
-largely	l ɑ ɹ d͡ʒ l i
-largely	l ɑː d͡ʒ l i
 lastborn	l æ s t b ɔ ɚ̯ n
 lastborn	l ɑː s t b ɔː n
 laundry	l ɑ n d ɹ i
@@ -882,7 +897,6 @@ lunch	l ʌ̃ n t͡ʃ
 lycra	l a ɪ k ɹ ə
 madder	m a d ə ɹ
 madhhab	m æ ð h æ b
-mail	m e ɪ̯ ɫ
 mailed	m e ɪ ɫ d
 maintenance	m ẽ ɪ̃ n ʔ ə n ə n s
 make	m e ɪ kʲ
@@ -924,7 +938,7 @@ mikey	m ɐ ɪ kʰ iː
 mile	m a ɪ̯ ɫ
 milkshake	m ɪ ɫ k ʃ e ɪ k
 mill	m ɪ ɫ
-million	m ɪ l j ɪ n
+million	m ɪ ʎ ə n
 mister	m ɪ s t ə ɹ
 mmm	m̩ː
 molasses	m ə l æ s ɪ z
@@ -933,6 +947,7 @@ moneyball	m ɐ n i b ɔː l
 montagnard	m ɒ n t ə n j ɑː d
 montagnard	m ɒ̃ⁿ t ə n j ɑː d
 month	m ɐ n̪ θ
+morning	m oː n ɪ ŋ
 mother	m ɐ ð ə ɹ
 motlopi	m ə ʊ t̚ l ə ʊ p i
 mount	m a ʊ n t
@@ -976,8 +991,9 @@ nonalphanumeric	n ɒ n æ l f ə n j uː m ɛ ɹ ɪ k
 nonna	n ɔ nː ɐ
 nonna	n ɔ nː ə
 nope	n o ʊ p̚
-not	n ɑ t
+not	n ɑ ʔ t
 not	n ɒ t
+not	n ɒ ʔ t
 nothing	n ʌ ʔ n̩
 novel	n ɒ v l̩
 numeration	n j uː m ə ɹ e ɪ ʃ ə n
@@ -1078,6 +1094,7 @@ pet	pʰ ɛ ʔ t
 petting	pʰ ɛ ɾ ɪ ŋ
 pff	p͡ɸː
 pff	ʙ̥͡ɸː
+pfft	p͡ɸː t
 phew	ɸ j u̥ ˥˩
 philadelphia	f ɪ ɫ ə d ɜ ɫ f i ə
 phlebolith	f l ɛ b ə l ɪ θ
@@ -1091,14 +1108,13 @@ pill	pʰ ɪ ɫ
 pin	pʰ ɪ n
 pit	pʰ ɪ ʔ t
 pittance	pʰ ɪ ʔ n̩ s
-pizza	pʰ i t͡s ə
+pizza	pʰ i t s ə
 place	p l̥ e ɪ s
 plack	pʰ l̥ a k
 plack	pʰ l̥ æ k
 plague	pʰ l̥ e ɪ ɡ
 plain	p l̥ e ɪ n
 plan	pʰ l̥ æ n
-plane	pʰ l̥ e ɪ n
 plant	pʰ l̥ ɑː n t
 plate	pʰ l̥ e ɪ t
 play	p l̥ e ɪ
@@ -1109,6 +1125,8 @@ poilu	p w ɑː l uː
 polar	pʰ ə ʊ̯ l ə ɹ
 pole	pʰ ɒ ʊ ɫ
 police	pʰ ə̆ l iˑ s
+polo	p ɒ ʊ ɫ ə ʊ
+polo	p ə ʊ l ə ʊ
 poof	p uː ɸ
 poomplex	p ʊ m p l ɛ k͡s
 possessor	pʰ ə z ɛ s ə ɹ
@@ -1190,8 +1208,6 @@ revelry	ɹ ɛ v ə ɫ ɹ i
 reëvoke	ɹ iː ʔ i v ə ʊ k
 rhotic	ɹ ə ʊ̯ tʰ ɪ k
 rhythm	ɹ ɪ ð m̩
-ridden	ɹ ɪ d n̩
-ridden	ɹ ɪ d̚ n̩
 rider	ɹ̠ a ɪ d ə
 right	ɹ a ɪ t
 rocks	ɹʷ ɑ k s
@@ -1220,7 +1236,6 @@ scale	s k e ɪ̯ ə ɫ
 scallion	s k æ l j n̩
 scallion	s k æ l ɪ ə n
 scape	s k e ɪ p
-scared	s k ɛ ə d
 schemes	s k iː m z̥
 scold	s k ɒ ʊ ɫ d
 screech	s k ɹ i t͡ʃ
@@ -1228,6 +1243,7 @@ screech	s k ɹ iː t͡ʃ
 screen	s k ɹ̥ʷ ɪ i̯ n
 scuttle	s k ʌ t ə ɫ
 scuttle	s k ʌ t ɫ̩
+selfish	s ɛ ɫ f ɪ ʃ
 senpai	s ɛ m p a ɪ̯
 senpai	s ɛ n p a ɪ̯
 sensible	s ɛ n s ɪ b l̩
@@ -1256,16 +1272,15 @@ snares	s n ɛː z
 snash	s n a ʃ
 snow	s n ə ʊ̯
 societal	s ə s a ɪ ə t l̩
-soil	s ɔ ɪ̯ ɫ
+soil	s ɔ ɪ̯ ɫ̩
 sold	s ɒ ʊ ɫ d
 sole	s ɒ ʊ ɫ
 solvent	s ɒ l v ə n t
 some	s ɐ m
-something	s ɐ m θ ɪ ŋ
-something	s ʌ m p θ ɪ ŋ
+something	s ɐ m̥ p θ ɪ ŋ
 something	s ʌ m ʔ m̩
-something	s ʌ m θ ɪ ŋ
-something	s ʌ n̪ θ ɪ ŋ
+something	s ʌ m̥ p θ ɪ ŋ
+something	s ʌ n̪̥ θ ɪ ŋ
 something	s ʌ ɾ̃ ɪ ŋ
 something	s ʌˑ ɪ ŋ
 something	s ʌ̃ː
@@ -1277,6 +1292,7 @@ soul	s ɒ ʊ ɫ
 squamation	s k w e ɪ m e ɪ ʃ n̩
 squander	s k w ɒ n d ə
 squee	s k w iː
+stability	s t ə b ɪ l ɪ ɾ i
 staff	s t a f
 staff	s t e ə f
 staff	s t äː f
@@ -1290,13 +1306,9 @@ steel	s t iː ɫ
 steven	s t e ɪ̯ v n̩
 steven	s t iː v n̩
 steven	s t ɛ v n̩
+still	s t ɪ ɫ
 stope	s t o ʊ p
 streets	ʃ t͡ʃ ɹ i t͡s
-strength	s t̠͡ɹ̠ æ ŋ k θ
-strength	s t̠͡ɹ̠ ɛ n̪ θ
-strength	s t̠͡ɹ̠ ɛ ŋ k θ
-strength	s t̠͡ɹ̠ ɪ ŋ k θ
-strength	ʃ t͡ʃ ɹ e ɪ ŋ k θ
 strident	s t ɹ a ɪ dˀ n t
 stripboard	s t ɹ ɪʰ b ɔ ə d
 stripboard	s t ɹ ɪʰ b ɔː d
@@ -1327,6 +1339,7 @@ syntagms	s ɪ n t æ m z
 t'	t̚
 t'	ʔ
 t'	ː
+ta	tʰ ɑː
 tab	tʰ æ b̥
 tackle	tʰ æ k ɫ̩
 tagore	tʰ ə ɡ ɔː
@@ -1343,6 +1356,7 @@ teared	t ɛ ɚ̯ d
 teared	t ɛː d
 teared	t ɪː d
 tech	tʰ ɛ k
+technological	t ɛ k n ə l ɒ d͡ʒ ɪ k l̩
 tej	t ɛ d͡ʒ
 telangana	t̪ ɛ l ə ŋ ɡ ɑː n ə
 tell	tʰ ɛ l
@@ -1375,10 +1389,8 @@ titty	tʰ ɪ ɾ i
 to	tʰ u̟ː
 told	tʰ ɒ ʊ ɫ d
 told	tʰ ɔ ʊ ɫ d
-tomato	tʰ ə̥ m e ɪ ɾ o ʊ
-tomato	tʰ ə̥ m e ɪ ɾ ə
-tomato	tʰ ə̥ m ɐː tʰ ɐ ʉ
-tomato	tʰ ə̥ m ɑː tʰ ə ʊ
+tomato	tʰ ə̥ m ɐː tʰ ɐ ʉ̯
+tomato	tʰ ə̥ m ɑː tʰ ə ʉ̯
 too	tʰ u̟ː
 top	tʰ ɒˀ p
 towards	tʰ ə̥ w ɔː d z
@@ -1411,6 +1423,10 @@ true	t̠ ɹ̠̊ ˔ʷ u̠ː
 trust	t ɹ ɐ s t
 trust	t ɹ ʌ s t
 truthfully	t ɹ uː θ f ɫ̩ i
+try	t ɹ̝̊ a ɪ̯
+try	t̠͡ɹ̠̊ ˔ a ɪ̯
+try	t̠͡ɹ̠̊ ˔ʷ a ɪ̯
+try	t͡ʃ ɹ a ɪ̯
 tucker	tʰ ʌ k ə
 tumult	t ʌ m ʌ l t̰̚
 tut	ǀ
@@ -1457,7 +1473,7 @@ ugh	ʌ᷈
 unacceptable	ɐ n æ k s ɛ p tʰ ə b ɫ̩
 unacceptable	ɐ n ə k s ɛ p tʰ ə b ɫ̩
 under	ɐ n d ə ɹ
-underutilize	ɐ n d ə j uː t ɨ l a ɪ z
+underutilize	ɐ n d ə j uː t ɪ l a ɪ z
 unfair	ɐ n f ɛ ə ɹ
 unfair	ɐ n f ɛː ɹ
 unilateral	j ʉː n ə ɫ æ ɾ ɚ ɻ ɫ̩
@@ -1493,7 +1509,6 @@ waistband	w e ɪ s t b æ n d
 waiting	w e ɪ̯ ɾ ɪ ŋ
 wale	w e ɪ ɫ
 wales	w e ɪ ɫ z
-wanted	w ɒ n tʰ ɪ d
 wasn't	w ɒ n ʔ
 wasn't	w ɒ z n̩ ʔ
 wealth	w ɛ l̪ θ
@@ -1503,6 +1518,7 @@ welp	w ɛ l p̚
 westside	w ɛ s s a ɪ d
 westside	w ɛ s t s a ɪ d
 what	w ɒ ʔ t
+whataboutism	w ə ɾ ə b a ʊ ɾ ɪ z m̩
 wheugh	ɸ ɪ̥ u̯ h
 whew	ɸ ĭ̥ ŭ̥
 whew	ʍ ĭ̥ ŭ̥
@@ -1518,7 +1534,8 @@ wholly	h ɒ ʊ ɫ l ɪ
 wholly	h ə ʊ l ɪ
 width	w ɪ d̪ θ
 wieldy	w ɪ ə l d ɪ
-wild	w a ɪ ɫ d
+wild	w a ɪ̯ ɫ d
+wild	w a ɪ̯ ɫ̩ d
 wilde	w a ɪ ə̯ ɫ d
 will	w ɪ ɫ
 winter	w ɪ n tʰ ɚ

--- a/data/scrape/tsv/eng_latn_us_broad.tsv
+++ b/data/scrape/tsv/eng_latn_us_broad.tsv
@@ -510,7 +510,7 @@ abidjan	æ b ɪ d͡ʒ ɑ n
 abience	æ b i n̩ s
 abience	æ b i n̩ t s
 abient	æ b i n̩ t
-abier	ə b ɪ ə ɹ
+abier	ə b ɪ ɚ
 abies	e ɪ b i i z
 abies	æ b i i z
 abietate	æ b i ə t e ɪ t
@@ -1534,6 +1534,7 @@ accentuate	ə k s e n t͡ʃ u e ɪ t
 accentuation	æ k s ɛ n t͡ʃ ə w e ɪ ʃ ə n
 accentuation	ɪ k s ɛ n t͡ʃ ə w e ɪ ʃ ə n
 accept	ə k s ɛ p t
+accept	ɪ k s ɛ p t
 acceptability	æ k s ɛ p t ə b ɪ l ə t i
 acceptable	æ k s ɛ p t ə b ə l
 acceptable	ə k s ɛ p t ə b ə l
@@ -1543,6 +1544,8 @@ acceptance	ə k s ɛ p t ə n s
 acceptant	æ k s ɛ p t ə n t
 acceptation	æ k s ɛ p t e ɪ ʃ ə n
 accepted	æ k s ɛ p t ɪ d
+accepted	ə k s ɛ p t ɪ d
+accepted	ɪ k s ɛ p t ɪ d
 accepter	æ k s ɛ p t ɚ
 accepting	ə k s ɛ p t ɪ ŋ
 accepting	ɪ k s ɛ p t ɪ ŋ
@@ -1739,7 +1742,7 @@ acebutolol	æ s ə b j u t ə l ɔ l
 aced	e ɪ s t
 acedia	ə s iː d ɪ ə
 acela	ə s ɛ l ə
-aceldama	ə k e l d ə m ə
+aceldama	ə k ɛ l d ə m ə
 aceldama	ə s ɛ l d ə m ə
 acephalan	e ɪ s ɛ f ə l ə n
 acephalocyst	ɑ s ɛ f ə l o ʊ s ɪ s t
@@ -1778,7 +1781,7 @@ acetaminophen	ə s i t ə m ɪ n ə f ə n
 acetarious	ɑ s ɪ t ɛ ɚ i ə s
 acetary	ə s iː t ə ɹ i
 acetate	æ s ɪ t e ɪ̯ t
-acetator	æ s ɪ t e ɪ t ə ɹ
+acetator	æ s ɪ t e ɪ t ɚ
 acetazolamide	æ s ə t ə z o ʊ l ə m a ɪ d
 acetazolamide	æ s ə t ə z o ʊ l ə m ɪ d
 acetazolamide	æ s ə t ə z ɑ l ə m a ɪ d
@@ -1819,7 +1822,7 @@ ache	e ɪ k
 ache	e ɪ t͡ʃ
 achean	ə k i ə n
 ached	e ɪ k t
-achelous	æ k ɨ l o ʊ ə s
+achelous	æ k ɪ l o ʊ ə s
 acheron	æ k ə ɹ ɔ n
 acheron	æ k ə ɹ ə n
 aches	e ɪ k s
@@ -1831,7 +1834,7 @@ achieved	ə t͡ʃ iː v d
 achievement	ə t͡ʃ iː v m ə n t
 achievement	ə t͡ʃ iː v m ɪ n t
 achievements	ə t͡ʃ iː v m ə n t s
-achiever	ə t͡ʃ iː v ə ɹ
+achiever	ə t͡ʃ iː v ɚ
 achieves	ə t͡ʃ iː v z
 achieving	ə t͡ʃ iː v ɪ ŋ
 achievings	ə t͡ʃ iː v ɪ ŋ z
@@ -1903,7 +1906,7 @@ acquaintant	ə k w e ɪ n t ə n t
 acquainted	ə k w e ɪ n t ɪ d
 acquest	ə k w ɛ s t
 acquiesce	æ k w i ɛ s
-acquire	ə k w a ɪ ə ɹ
+acquire	ə k w a ɪ ɚ
 acquired	ə k w a ɪ ɹ d
 acquirement	ə k w a ɪ ə ɹ m ə n t
 acquiring	ə k w a ɪ ə ɹ ɪ ŋ
@@ -1917,7 +1920,6 @@ acquittal	ə k w ɪ d ə l
 acquittance	ə k w ɪ t ə n s
 acquitted	ə k w ɪ t ɪ d
 acrasia	ə k ɹ e ɪ z i ə
-acre	e ɪ k ə ɹ
 acre	e ɪ k ɚ
 acres	e ɪ k ɚ z
 acrid	æ k ɹ ɪ d
@@ -1927,7 +1929,7 @@ acrobatic	æ k ɹ ə b æ t ɪ k
 acrocephalic	æ k ɹ o ʊ s ə f æ l ɪ k
 acrocephalic	æ k ɹ ə s ə f æ l ɪ k
 acrocyanosis	æ k ɹ o ʊ s a ɪ ə n o ʊ s ɪ s
-acrogynous	ə k ɹ ɑ d͡ʒ ɨ n ə s
+acrogynous	ə k ɹ ɑ d͡ʒ ɪ n ə s
 acrolect	æ k ɹ ə l ɛ k t
 acrolein	æ k ɹ ə l i n
 acrolein	ə k ɹ o ʊ l i ɪ n
@@ -1942,6 +1944,8 @@ acropoleis	æ k ɹ ɒ p ɒ l ɛ ɪ z
 acropolises	æ k ɹ ɒ p ɒ l ɪ s ɪ z
 across	ə k ɹ ɔ s
 acrostic	ə k ɹ ɔ s t ɪ k
+acroter	æ k ɹ ə t ə ɹ
+acroterium	æ k ɹ ə t ɪ ə ɹ i ə m
 acrylamide	ə k ɹ ɪ l ə m a ɪ d
 acrylate	æ k ɹ ɪ l e ɪ t
 acrylic	ə k ɹ ɪ l ɪ k
@@ -1990,6 +1994,7 @@ actual	æ k ʃ u ə l
 actual	æ k ʃ ə l
 actuality	æ k t͡ʃ u æ l ɪ t i
 actually	æ k t͡ʃ u ə l i
+actually	æ k ʃ u ə l i
 actuate	æ k t͡ʃ u e ɪ t
 acuity	ə k j uː ɪ t i
 acumen	æ k j u m ə n
@@ -2002,6 +2007,7 @@ acushla	ə k ʊ ʃ l ə
 acute	ə k j u t
 acutely	ə k j uː t l i
 acyclic	e ɪ s a ɪ k l ɪ k
+acyclic	e ɪ s ɪ k l ɪ k
 acyl	æ s ɪ l
 acyrologia	ə s ɪ ɹ ə l ɒ d͡ʒ i ə
 acyrology	æ s ɪ ɹ ɒ l ə d͡ʒ i
@@ -2072,7 +2078,7 @@ adduce	ə d j uː s
 adduct	æ d ʌ k t
 adduct	ə d ʌ k t
 adduction	ə d ʌ k ʃ n̩
-adductor	ə d ʌ k t ə ɹ
+adductor	ə d ʌ k t ɚ
 ade	e ɪ d
 adela	æ d ə l ə
 adela	ə d ɛ l ə
@@ -2080,6 +2086,7 @@ adelaide	æ d ə l e ɪ d
 adele	ə d ɛ l
 adeling	æ d ə l ɪ ŋ
 adelings	æ d ə l ɪ ŋ z
+adelopod	ə d ɛ l ə p ɒ d
 adenine	æ d ə n iː n
 adenine	æ d ɪ n ɪ n
 adenines	æ d ɪ n ɪ n z
@@ -2101,9 +2108,9 @@ adermatoglyphia	e ɪ d ɝ m ə t ə ɡ l ɪ f i ə
 adespota	ə d ɛ s p ə t ə
 adhan	ɑː ð ɑː n
 adhan	ə ð ɑː n
-adhere	æ d h i ɹ
-adherence	ə d h ɪ ə ɹ ə n s
-adherent	æ d h ɪ ə ɹ ə n t
+adhere	æ d h ɪ ɹ
+adherence	ə d h ɪ ɹ ə n s
+adherent	æ d h ɪ ɹ ə n t
 adhesive	æ d h i s ɪ v
 adhibit	ə d h ɪ b ɪ t
 adhibition	æ d h ɪ b ɪ ʃ ə n
@@ -2126,12 +2133,13 @@ adieux	ə d j u z
 adios	ɑ d i o ʊ s
 adios	ɑ d i ɔ s
 adipate	æ d ɪ p e ɪ t
-adipocere	æ d ə p o ʊ s i ə ɹ
-adipocere	æ d ɪ p o ʊ s i ə ɹ
+adipocere	æ d ə p o ʊ s i ɚ
+adipocere	æ d ɪ p o ʊ s i ɚ
 adipocytokine	æ d ɪ p ə ʊ s a ɪ t ə ʊ k a ɪ n
 adipose	æ d ɪ p o ʊ s
 adirondack	æ d ɪ ɹ ɑ n d æ k
 adiru	æ d ə ɹ u
+adit	a d ɪ t
 adit	æ d ɪ t
 adits	æ d ɪ t s
 adjacent	ə d͡ʒ e ɪ s ə n t
@@ -2178,7 +2186,7 @@ admin	ə d m ɪ n
 administer	ə d m ɪ n ɪ s t ɚ
 administrate	ə d m ɪ n ɪ s t ɹ e ɪ t
 administration	ə d m ɪ n ə s t ɹ e ɪ ʃ ə n
-administrative	ə d m ɪ n ə s t ɹ e ɪ ɾ ɪ v
+administrative	ə d m ɪ n ə s t ɹ e ɪ t ɪ v
 administrator	ə d m ɪ n ɪ s t ɹ e ɪ t ɚ
 administratorship	æ d m ɪ n ə s t ɹ e ɪ t ɚ ʃ ɪ p
 administratrix	æ d m ɪ n ɪ s t ɹ e ɪ t ɹ ɪ k s
@@ -2205,8 +2213,8 @@ admits	ə d m ɪ t s
 admittance	ə d m ɪ t n̩ s
 admitted	ə d m ɪ t ɪ d
 admitting	ə d m ɪ t ɪ ŋ
-admixture	æ d m ɪ k s t͡ʃ ə ɹ
-admixture	ə d m ɪ k s t͡ʃ ə ɹ
+admixture	æ d m ɪ k s t͡ʃ ɚ
+admixture	ə d m ɪ k s t͡ʃ ɚ
 admonish	æ d m ɑ n ɪ ʃ
 admonition	æ d m ə n ɪ ʃ ə n
 ado	ə d uː
@@ -2325,7 +2333,7 @@ advert	ə d v ɜː ɹ t
 advertise	æ d v ɚ t a ɪ z
 advertisement	æ d v ɚ t a ɪ z m ə n t
 advertisement	ə d v ɝ t ɪ z m ə n t
-advertiser	æ d v ə ɹ t a ɪ z ə ɹ
+advertiser	æ d v ɚ t a ɪ z ɚ
 advertising	æ d v ɚ t a ɪ z ɪ ŋ
 advertorial	æ d v ɚ t ɔ ɹ i ə l
 advesperate	æ d v ɛ s p ə ɹ e ɪ t
@@ -2425,7 +2433,9 @@ aesthete	ɛ s θ iː t
 aesthetic	e ɪ s θ ɛ t ɪ k
 aesthetic	ə s θ e t ɪ k
 aesthetic	ɛ s θ ɛ t ɪ k
+aesthetician	ɛ s θ ɪ t ɪ ʃ ə n
 aestivation	iː s t ɪ v e ɪ ʃ ə n
+aether	e ɪ θ ɚ
 aether	i θ ɚ
 aetiology	i t i ɑ l ə d͡ʒ i
 aetites	i t a ɪ d i z
@@ -2435,19 +2445,20 @@ aeviternity	i v ə t ɝ n ə t i
 aevum	i v ə m
 af	e ɪ̯ ɛ f
 af	æ f
+afab	e ɪ f æ b
 aface	ə f e ɪ s
 afam	a f a m
 afanc	æ v æ ŋ k
 afanc	ɑ v ɑ ŋ k
 afar	ʌ f a ɹ
-afare	ə f ɛ ə ɹ
+afare	ə f ɛ ɚ
 afeared	ə f ɪ ə ɹ d
 afelimomab	æ f ɛ l ɪ m ə m æ b
 affable	æ f ə b ə l
 affably	æ f ə b l i
 affabrous	æ f ə b ɹ ə s
 affabrous	ə f æ b ɹ ə s
-affair	ə f ɛ ə ɹ
+affair	ə f ɛ ɚ
 affair	ə f ɛ ɹ
 affairs	ə f ɛ ɹ z
 affamish	ə f æ m ɪ ʃ
@@ -2516,7 +2527,6 @@ afghani	æ f ɡ ɑː n i
 afghanistan	æ f ɡ æ n ɪ s t æ n
 afghanistan	æ f ɡ æ n ɪ s t ɑː n
 afghanistan	æ f ɡ ɑː n ɪ s t ɑː n
-afgod	æ f ɡ ɒ d
 aficionado	ɑ f i s j ɔ n ɑ ð ɔ
 aficionado	ɑ f i θ j ɔ n ɑ ð ɔ
 aficionado	ə f i s i ə n ɑ d o ʊ
@@ -2526,9 +2536,9 @@ aficionado	ə f ɪ s j ə n ɑ d o ʊ
 aficionado	ə f ɪ ʃ i ə n ɑ d o ʊ
 aficionado	ə f ɪ ʃ j ə n ɑ d o ʊ
 afield	ə f iː l d
-afire	ə f a ɪ ə ɹ
+afire	ə f a ɪ ɚ
 aflame	ə f l e ɪ m
-aflare	ə f l ɛ ə ɹ
+aflare	ə f l ɛ ɚ
 aflash	ə f l æ ʃ
 aflat	ə f l æ t
 aflaunt	ə f l ɔː n t
@@ -2537,7 +2547,7 @@ aflight	ə f l a ɪ t
 afloat	ə f l o ʊ t
 aflop	ə f l ɒ p
 aflow	ə f l o ʊ
-aflower	ə f l a ʊ ə ɹ
+aflower	ə f l a ʊ ɚ
 aflush	ə f l ʌ ʃ
 aflutter	ə f l ʌ t ɚ
 afoam	ə f o ʊ m
@@ -2563,7 +2573,7 @@ africana	æ f ɹ ɪ k ɑ n ə
 africo	æ f ɹ ɪ k ə ʊ
 africom	æ f ɹ ɪ k ɑ m
 afrikaans	ɑː f ɹ ɪ k ɑː n z
-afrikaner	æ f ɹ ɪ k ɑː n ə ɹ
+afrikaner	æ f ɹ ɪ k ɑː n ɚ
 afro	æ f ɹ o ʊ
 afroed	æ f ɹ o ʊ d
 afros	æ f ɹ o ʊ z
@@ -2598,7 +2608,7 @@ agape	æ ɡ ə p i
 agape	ə ɡ e ɪ p
 agape	ə ɡ ɑː p e ɪ
 agar	e ɪ ɡ ɑ ɹ
-agar	æ ɡ ə ɹ
+agar	æ ɡ ɚ
 agar	ɑ ɡ ɑ ɹ
 agaric	æ ɡ ə ɹ ɪ k
 agaric	ə ɡ æ ɹ ɪ k
@@ -2609,7 +2619,7 @@ agassi	æ ɡ ə s i
 agate	æ ɡ ə t
 agate	ə ɡ æ t
 agateophobia	ə ɡ e ɪ t i ə ʊ f ə ʊ b i ə
-agateware	æ ɡ ə t w ɛ ə ɹ
+agateware	æ ɡ ə t w ɛ ɚ
 agatha	æ ɡ ə θ ə
 agave	ə ɡ e ɪ v iː
 agave	ə ɡ ɑː v e ɪ
@@ -2652,6 +2662,7 @@ aggrace	ə ɡ ɹ e ɪ s
 aggrandize	ə ɡ ɹ æ n d a ɪ̯ z
 aggravate	æ ɡ ɹ ə v e ɪ̯ t
 aggravated	æ ɡ ɹ ə v e ɪ̯ t ɪ d
+aggravation	æ ɡ ɹ ə v e ɪ ʃ ə n
 aggregate	æ ɡ ɹ ɪ ɡ e ɪ t
 aggregate	æ ɡ ɹ ɪ ɡ ə t
 aggregation	æ ɡ ɹ ə ɡ e ɪ ʃ ə n
@@ -2673,7 +2684,7 @@ agility	ə d͡ʒ ɪ l ɪ t i
 agin	ə ɡ ɪ n
 aging	e ɪ d͡ʒ ɪ ŋ
 agings	e ɪ d͡ʒ ɪ ŋ z
-aginner	ə ɡ ɪ n ə ɹ
+aginner	ə ɡ ɪ n ɚ
 agio	æ d͡ʒ i o ʊ
 agio	æ d͡ʒ o ʊ
 agio	ɑː d͡ʒ o ʊ
@@ -2687,13 +2698,13 @@ agitolalia	æ d͡ʒ ɪ t o ʊ l e ɪ l i ə
 agitophasia	æ d͡ʒ ɪ t o ʊ f e ɪ ʒ ə
 agitprop	æ d͡ʒ ə t p ɹ ɑ p
 agitpropping	æ d͡ʒ ə t p ɹ ɑ p ɪ ŋ
-aglare	ə ɡ l ɛ ə ɹ
+aglare	ə ɡ l ɛ ɚ
 agleam	ə ɡ l iː m
 agley	ə ɡ l e ɪ
 agley	ə ɡ l iː
-aglimmer	ə ɡ l ɪ m ə ɹ
+aglimmer	ə ɡ l ɪ m ɚ
 aglint	ə ɡ l ɪ n t
-aglitter	ə ɡ l ɪ t ə ɹ
+aglitter	ə ɡ l ɪ t ɚ
 aglow	ə ɡ l o ʊ
 agnate	æ ɡ n e ɪ t
 agnath	æ ɡ n ə θ
@@ -2735,6 +2746,7 @@ agrarian	ə ɡ ɹ ɛ ə ɹ i ə n
 agree	ə ɡ ɹ i
 agree	ə ɡ ɹ iː
 agreeable	ə ɡ ɹ iː ə b l
+agreeably	ə ɡ ɹ iː ə b l i
 agreed	ə ɡ ɹ i d
 agreed	ə ɡ ɹ iː d
 agreement	ə ɡ ɹ iː m ə n t
@@ -2856,12 +2868,12 @@ airling	ɛ ə ɹ l ɪ ŋ
 airmail	ɛ ə m e ɪ l
 airmails	ɛ ə m e ɪ l z
 airman	ɛ ɹ m ə n
-airplane	ɛ ə ɹ p l e ɪ̯ n
+airplane	ɛ ɚ p l e ɪ̯ n
 airport	ɛ ɹ p ɔ ɹ t
 airports	ɛ ɹ p o ɹ t s
 airports	ɛ ɹ p ɔ ɹ t s
 airprox	ɛ ə ɹ p ɹ ɒ k s
-airs	ɛ ɹ z
+airs	ɛ ə ɹ z
 airy	ɛ ə ɹ i
 aisha	a ɪ iː ʃ ə
 aisle	a ɪ̯ l
@@ -2922,6 +2934,7 @@ akroposthion	æ k ɹ ə ʊ p ɒ s θ ɪ ə n
 aks	æ k s
 aks	ɑː k s
 aktau	ɑ k t a ʊ
+akwesasne	æ k w ə s æ s n e ɪ
 al	æ l
 al	ɑː l
 ala	e ɪ l ə
@@ -2985,7 +2998,7 @@ album	æ l b ə m
 albumen	æ l b j uː m ə n
 albumen	æ l b j ʊ m ə n
 albumin	æ l b j uː m ə n
-albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ə ɹ
+albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ɚ
 albuminous	æ l b j uː m ɪ n ə s
 albuquerque	æ l b ə k ɝ k i
 albury	ɔː l b ə ɹ i
@@ -2997,7 +3010,8 @@ alcatraz	æ l k ə t ɹ æ z
 alcazar	æ l k ɑ z ɚ
 alcazar	æ l k ə z ɑ ɹ
 alcedine	æ l s ə d ʌ ɪ n
-alcester	ɒ l s t ə ɹ
+alces	æ l s iː z
+alcester	ɒ l s t ɚ
 alchemist	æ l k ə m ɪ s t
 alchemistic	æ l k ə m ɪ s t ə k
 alchemistical	æ l k ə m ɪ s t ɪ k ə l
@@ -3021,8 +3035,8 @@ alcove	æ l k ə ʊ v
 alcyone	æ l s a ɪ ə n i
 aldcliffe	ɔː k l ɪ f
 aldcliffe	ɔː l d k l ɪ f
-aldehyde	æ l d ɨ h a ɪ d
-aldehydes	æ l d ɨ h a ɪ d z
+aldehyde	æ l d ɪ h a ɪ d
+aldehydes	æ l d ɪ h a ɪ d z
 alderliefest	ɔː l d ə ɹ l iː f ɪ s t
 aldermanic	ɔː l d ə ɹ m æ n ɪ k
 aldermaston	ɔː l d ə m ɑː s t ə n
@@ -3064,10 +3078,12 @@ aleutian	ə l uː ʃ ə n
 alevin	æ l ə v ə n
 alewife	e ɪ l w a ɪ f
 alex	æ l ɪ k s
-alexander	æ l ɨ ɡ z æ n d ɚ
-alexanders	æ l ɨ ɡ z æ n d ɚ z
-alexandra	æ l ɨ ɡ z æ n d ɹ ə
-alexandra	æ l ɨ ɡ z ɑ n d ɹ ə
+alexander	æ l ɪ ɡ z æ n d ə ɹ
+alexander	æ l ɪ ɡ z æ n d ɚ
+alexanders	æ l i ɡ z æ n d ɚ z
+alexanders	æ l ɪ ɡ z æ n d ɚ z
+alexandra	æ l ɪ ɡ z æ n d ɹ ə
+alexandra	æ l ɪ ɡ z ɑ n d ɹ ə
 alexandria	æ l ə k z æ n d ɹ i ə
 alexandria	æ l ə ɡ z æ n d ɹ i ə
 alexandrian	æ l ɛ k s z æ n d ɹ i ə n
@@ -3078,7 +3094,7 @@ alexipharmac	ə l ɛ k s ə f ɑ ɹ m æ k
 alexipharmic	ə l ɛ k s ə f ɑ ɹ m ɪ k
 alexithymia	e ɪ l ɛ k s ə θ a ɪ m i ə
 alexithymic	ə l ɛ k s ɪ θ a ɪ m ɪ k
-alexondra	æ l ɨ ɡ z ɑ n d ɹ ə
+alexondra	æ l ɪ ɡ z ɑ n d ɹ ə
 alf	æ l f
 alfacalcidol	æ l f ə k æ l s ɪ d ɔ l
 alfalfa	æ l f æ l f ə
@@ -3234,7 +3250,7 @@ allocate	æ l ə k e ɪ t
 allocated	æ l ə k e ɪ t ɪ d
 allocation	æ l ə k e ɪ ʃ ə n
 allocentric	æ l o ʊ s ɛ n t ɹ ɪ k
-allocher	æ l ə k ɛ ə ɹ
+allocher	æ l ə k ɛ ɚ
 allochthon	ə l ɒ k θ ɒ n
 allochthon	ə l ɒ k θ ə n
 allodial	ə l ə ʊ d i ə l
@@ -3341,7 +3357,6 @@ aloin	æ l o ʊ ɪ n
 alone	ə l o ʊ n
 along	ə l ɑ ŋ
 along	ə l ɔ ŋ
-alongside	ə l ɑ ŋ s a ɪ d
 alongside	ə l ɔ ŋ s a ɪ d
 alongsides	ə l ɑ ŋ s a ɪ d z
 alongsides	ə l ɔ ŋ s a ɪ d z
@@ -3381,13 +3396,13 @@ alright	ɔː l ɹ a ɪ t
 alsace	æ l s e ɪ s
 alsace	æ l s æ s
 alsatian	æ l s e ɪ ʃ ə n
+also	ɑ l s o ʊ
 also	ɔ l s o ʊ
-alstroemeria	æ l s t ɹ ɨ m iː ɹ i ə
+alstroemeria	æ l s t ɹ i m iː ɹ ɪ ə
+alt	ɑ l t
 alt	ɔ l t
-alt	ɔː l t
 alta	ɑː l t ə
 altaic	æ l t e ɪ ɪ k
-altar	ɑ l t ɚ
 altar	ɔ l t ɚ
 alteplase	æ l t ə p l e ɪ s
 alter	ɔ l t ɚ
@@ -3414,6 +3429,7 @@ altman	ɔː l t m ə n
 alto	æ l t o ʊ
 altogether	ɑ l t ə ɡ ɛ ð ɚ
 altogether	ɔ l t u ɡ ɛ ð ɚ
+altogether	ɔ l t ə ɡ ɛ ð ɚ
 alton	ɒ l t ə n
 alton	ɔː l t ə n
 altricial	ə l t ɹ ɪ ʃ ə l
@@ -3453,7 +3469,7 @@ alvinolagnia	æ l v ɪ n ə l a ɡ n i ə
 alvinophilia	æ l v a ɪ n ə f ɪ l i ə
 alvinophilia	æ l v ɪ n ə f i l j ə
 alvocidib	æ l v ɒ s ɪ d ɪ b
-always	ɑ ɫ w e ɪ z
+always	ɑ l w e ɪ z
 always	ɔ l w e ɪ z
 always	ɔ l w i z
 always	ɔ l w ə z
@@ -3462,7 +3478,9 @@ alytarch	æ l ə t ɑ ɹ k
 alytus	ə l iː t ə s
 ama	ɑː m ə
 ama	ʔ ɐ m a
+amab	e ɪ m æ b
 amacrine	æ m ə k ɹ ɪ n
+amadeus	æ m ə d e ɪ ə s
 amadou	æ m ə d uː
 amah	ɑː m ə
 amahs	ɑː m ə z
@@ -3505,12 +3523,11 @@ amatory	æ m ə t ɔ ɚ̯ i
 amatory	æ m ə t ɔː ɹ i
 amatory	ɑ m ə t ə ɹ i
 amaurosis	æ m ɔ ɹ o ʊ s ə s
+amaze	ə m e ɪ z
 amazed	ə m e ɪ z d
 amazement	ə m e ɪ z m ə n t
 amazes	ə m e ɪ z ɪ z
-amazigh	ʔ a m aː z iː ʁ
-amazigh	ʔ æ m æː z iː ʁ
-amazigh	ʔ ɑ m ɑː z iː ʁ
+amazigh	æ m ə z ɪ ɡ
 amazing	ə m e ɪ z ɪ ŋ
 amazingly	ə m e ɪ z ɪ ŋ l i
 amazon	æ m ə z ɑ n
@@ -3554,6 +3571,7 @@ ambles	æ m b ə l z
 amblyopia	æ m b l ɪ ə ʊ p ɪ ə
 amblyopic	æ m b l iː o ʊ p ɪ k
 amblyopic	æ m b l iː ɒ p ɪ k
+ambrisentan	æ m b ɹ ɪ s ɛ n t æ n
 ambrose	æ m b ɹ o ʊ z
 ambrose	æ m b ɹ ə ʊ z
 ambrosia	æ m b ɹ o ʊ ʒ ə
@@ -3623,7 +3641,7 @@ amharic	æ m h æ ɹ ɪ k
 amiability	e ɪ m i ʌ b ɪ l ə t i
 amiable	e ɪ m i ə b ə l
 amiable	æ m i ə b ə l
-amicable	æ m ɨ k ə b ə l
+amicable	æ m ɪ k ə b ə l
 amici	æ m ɪ k i
 amici	ə m i k i
 amicide	æ m ɪ s a ɪ d
@@ -3666,6 +3684,7 @@ amissing	ə m ɪ s ɪ ŋ
 amit	ə m ɪ t
 amite	e ɪ m ɛ t
 amity	æ m ɪ t i
+amlwch	a m l ʊ χ
 amma	ʌ m ə
 amman	ɑː m ɑː n
 ammer	æ m ɚ
@@ -3687,9 +3706,7 @@ amoc	e ɪ m ɑ k
 amoeba	ə m iː b ə
 amoebal	ə m iː b ə l
 amoebic	ə m iː b ɪ k
-amogus	a m o g u s
 amogus	ə m o ʊ ɡ ə s
-amogus	ə m o ʊ ɡ ɪ s
 amok	ə m ɒ k
 amok	ə m ʌ k
 amole	ə m o ʊ l e ɪ
@@ -3701,7 +3718,7 @@ amongst	ə m ʌ ŋ s t
 amoral	e ɪ m ɔ ɹ ə l
 amorally	e ɪ m ɔ ɹ ə l i
 amorally	æ m ɔ ɹ ə l i
-amorce	ə m ɔ ɹ s
+amorce	ə m o ɹ s
 amoret	æ m ə ɹ ɪ t
 amorevolous	æ m ə ɹ ɛ v ə l ə s
 amorous	æ m ə ɹ ə s
@@ -3734,6 +3751,7 @@ ampersat	æ m p ɚ s æ t
 ampersat	æ m p ɚ z æ t
 amphetamine	æ m f ɛ t ə m iː n
 amphetamine	æ m f ɛ t ə m ɪ n
+amphibial	æ m f ɪ b i ə l
 amphibian	æ m f ɪ b ɪ ə n
 amphibole	æ m f ɪ b o ʊ l
 amphibolite	æ m f ɪ b ə l a ɪ t
@@ -3743,7 +3761,7 @@ amphid	æ m f ɪ d
 amphigory	æ m f ɪ ɡ ɔ ɹ i
 amphipathic	æ m f ə p æ θ ɪ k
 amphipod	a m f ɪ p ɑ d
-amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ə ɹ
+amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ɚ
 amphisbaena	æ m f ɪ s b iː n ə
 amphisbæna	æ m f ɪ s b iː n ə
 amphitheatre	æ m f ə θ i j ə t ɚ
@@ -3758,7 +3776,7 @@ amping	æ m p ɪ ŋ
 ample	æ m p ə l
 amplificate	æ m p l ɪ f ɪ k e ɪ̯ t
 amplification	æ m p l ɪ f ɪ k e ɪ ʃ ə n
-amplifier	æ m p l ə f a ɪ ə ɹ
+amplifier	æ m p l ə f a ɪ ɚ
 amplifier	æ m p l ə f a ɪ ɹ
 amplifiers	æ m p l ə f a ɪ ə ɹ z
 amplifiers	æ m p l ə f a ɪ ɹ z
@@ -3790,7 +3808,7 @@ amusement	ə m j u z m ə n t
 amuses	ə m j uː z ɪ z
 amusing	ə m j uː z ɪ ŋ
 amusingly	ə m j u z ɪ ŋ l i
-amutter	ə m ʌ t ə ɹ
+amutter	ə m ʌ t ɚ
 amy	e ɪ m i
 amygdala	ə m ɪ ɡ d ə l ə
 amygdalae	ə m ɪ ɡ d ə l a ɪ
@@ -3819,7 +3837,7 @@ anacoluthon	æ n ə k ə l uː θ ɒ n
 anaconda	æ n ə k ɒ n d ə
 anacreon	ə n æ k ɹ i ə n
 anacreontic	ə n æ k ɹ i ɑ n t ɪ k
-anacrogynous	æ n ə k ɹ ɑ d͡ʒ ɨ n ə s
+anacrogynous	æ n ə k ɹ ɑ d͡ʒ ɪ n ə s
 anacronym	ə n æ k ɹ ə n ɪ m
 anadrome	æ n ə d ɹ o ʊ m
 anadromes	æ n ə d ɹ o ʊ m z
@@ -3827,10 +3845,12 @@ anadromous	ə n æ d ɹ ə m ə s
 anaerobe	æ n ə ɹ o ʊ b
 anaerobic	æ n ə ɹ o ʊ b i k
 anaerophyte	ə n e ɪ ə ɹ ə ʊ f a ɪ t
+anagoge	æ n ə ɡ o ʊ d͡ʒ i
+anagoge	æ n ə ɡ ɑ d͡ʒ i
 anagogy	æ n ə ɡ o ʊ d͡ʒ i
 anagogy	æ n ə ɡ ɒ d͡ʒ i
 anagram	æ n ə ɡ ɹ æ m
-anagrammer	æ n ə ɡ ɹ æ m ə ɹ
+anagrammer	æ n ə ɡ ɹ æ m ɚ
 anagrams	æ n ə ɡ ɹ æ m s
 anagrind	æ n ə ɡ ɹ ɪ n d
 anaheim	æ n ə h a ɪ m
@@ -3856,7 +3876,6 @@ analogous	ə n æ l ə ɡ ə s
 analogously	ə n æ l ə ɡ ə s l i
 analogy	ə n æ l ə d͡ʒ i
 analphabet	æ n æ l f ə b ɛ t
-analyse	æ n ə l a ɪ z
 analyses	æ n ə l a ɪ z ə z
 analyses	æ n ə l a ɪ z ɪ z
 analyses	ə n æ l ə s iː z
@@ -3869,6 +3888,7 @@ analytic	æ n ə l ɪ t ɪ k
 analytical	æ n ə l ɪ t ə k ə l
 analytically	æ n ə l ɪ t ɪ k ə l l i
 analytics	æ n ə l ɪ t ɪ k s
+analyze	æ n ə l a ɪ z
 analyzed	æ n ə l a ɪ z d
 anamnesis	æ n æ m n iː s ɪ s
 anamorphic	æ n ə m ɔ ɹ f ɪ k
@@ -3923,6 +3943,7 @@ anatase	æ n ə t e ɪ z
 anataxis	æ n ə t æ k s ə s
 anathema	ə n æ θ ə m ə
 anathematize	ə n æ θ ə m ə t a ɪ z
+anatidae	ə n æ t ɪ d iː
 anatole	æ n ə t o ʊ l
 anatoli	æ n ə t o ʊ l i
 anatoli	æ n ə t ɑ l i
@@ -3974,7 +3995,7 @@ andorra	æ n d o ɹ ə
 andorran	æ n d ɔː ɹ ə n
 andouille	æ n d u i
 andouilles	ɑ n d uː ɪ z
-andover	æ n d o ʊ v ə ɹ
+andover	æ n d o ʊ v ɚ
 andre	ɑː n d ɹ e ɪ
 andre	ɑː n d ɹ ə
 andre	ɑː n d ɹ ɪ
@@ -4083,11 +4104,12 @@ angulus	æ ŋ ɡ j ə l ə s
 angust	æ ŋ ɡ ʌ s t
 anhedonia	æ n h i d o ʊ n i ə
 anhedonic	æ n h i d ɑ n ɪ k
+anhedonic	æ n h ɪ d ɑ n ɪ k
 anhelation	æ n h ə l e ɪ ʃ ə n
 anhele	ə n h iː l
 anhele	ə n iː l
 anhui	ɑː n h w e ɪ
-anhur	ɑː n h ʊ ə ɹ
+anhur	ɑː n h ʊ ɚ
 anhypostasia	æ n h a ɪ p ə s t e ɪ ʒ i ə
 anhypostasis	æ n h a ɪ p ə s t e ɪ s ɪ s
 ani	e ɪ n a ɪ
@@ -4107,8 +4129,6 @@ animalcule	æ n ə m æ l k j u l
 animals	æ n ɪ m ə l z
 animate	æ n ə m e ɪ t
 animate	æ n ə m ə t
-animate	æ n ɪ m e ɪ t
-animate	æ n ɪ m ə t
 animated	æ n ɪ m e ɪ t ɪ d
 animatedly	æ n ɪ m e ɪ t ɪ d l i
 animatic	æ n ɪ m æ t ɪ k
@@ -4134,6 +4154,7 @@ anisocytosis	ə n a ɪ s ə ʊ s a ɪ t ə ʊ s ɪ s
 anisogamy	æ n a ɪ s ɒ ɡ ə m i
 anisomorphic	æ n a ɪ s o ʊ m ɔː ɹ f ɪ k
 anisopoikilocytosis	ə n a ɪ s o ʊ p ɔ ɪ k ə l o ʊ s a ɪ t o ʊ s ɪ s
+anisotropous	æ n a ɪ s ɒ t ɹ ə p ə s
 anita	ə n iː t ə
 aniṭ	ʌ n ɪ t
 ankang	ɑː n k ɑ ŋ
@@ -4157,7 +4178,7 @@ annal	æ n ə l
 annalist	æ n ə l ɪ s t
 annals	æ n ə l z
 annan	æ n ə n
-annapolis	ə n æ p ə l ɨ s
+annapolis	ə n æ p ə l ɪ s
 anne	æ n
 anneal	ə n iː l
 annette	ə n ɛ t
@@ -4176,7 +4197,7 @@ annish	æ n ɪ ʃ
 anniversary	æ n ə v ɝ s ə ɹ i
 anniversary	æ n ɪ v ɝ s ə ɹ i
 annotate	a n ə t e ɪ t
-announce	ə n a ʊ n s
+announce	ə n a ʊ n t s
 announcement	ə n a ʊ n s m ɛ n t
 announcer	ə n a ʊ n s ɚ
 annoy	ə n ɔ ɪ
@@ -4238,11 +4259,12 @@ ans	æ n z
 ansa	æ n s ə
 ansai	ɑː n s a ɪ
 anselm	æ n s ɛ l m
+anser	æ n s ə r
 ansi	æ n s iː
 answer	æ n s ɚ
 answerable	æ n s ə ɹ ə b l
 answered	æ n s ɚ d
-answerer	æ n s ə ɹ ə ɹ
+answerer	æ n s ə ɹ ɚ
 answering	æ n s ɚ ɪ ŋ
 answers	æ n s ɚ z
 ant	æ n t
@@ -4263,6 +4285,7 @@ ante	æ n t i
 anteater	æ n t i t ɚ
 antebellum	æ n t i b ɛ l ə m
 antecedaneous	æ n t ɪ s ɪ d e ɪ n i ə s
+antecedence	æ n t ɛ s ɪ d ə n s
 antecedent	æ n t ɪ s iː d ə n t
 antechamber	æ n t i t͡ʃ e ɪ m b ɚ
 antediluvian	a n t ə d ɪ l uː v ɪ j ɪ n
@@ -4316,7 +4339,7 @@ anthroposophic	æ n θ ɹ ə p ə s ɑ f ɪ k
 anthroposophical	æ n θ ɹ ə p ə s ɑ f ɪ k ə l
 anthroposophist	æ n θ ɹ ə p ɑ s ə f ɪ s t
 anthroposophy	æ n θ ɹ ə p ɑ s ə f i
-anthroposphere	a n θ ɹ ɒ p ə s f ɪ ə ɹ
+anthroposphere	a n θ ɹ ɒ p ə s f ɪ ɚ
 anthypophora	æ n θ ə p ə f ɔ ɹ ə
 antialiasing	æ n t i e ɪ l i ə s ɪ ŋ
 antialiasing	æ n t ɑ ɪ̯ e ɪ l i ə s ɪ ŋ
@@ -4434,7 +4457,7 @@ antiviral	æ n t i v a ɪ ɹ ə l
 antler	æ n t l ɚ
 antler	æ n ʔ l ɚ
 antler	æ n ʔ ɫ ɚ
-antmire	a n t m a ɪ ə ɹ
+antmire	a n t m a ɪ ɚ
 antonia	æ n t ə ʊ n i ə
 antonia	æ n t ə ʊ n j ə
 antonio	æ n t o ʊ n i o ʊ
@@ -4453,6 +4476,7 @@ antumbra	æ n t ʌ m b ɹ ə
 antwacky	æ n t w æ k i
 antwerp	æ n t w ɝ p
 anubandha	ə n ʊ b ʌ n d ə
+anura	ə n j ʊ ə r ə
 anuran	ə n j ʊ ɹ ə n
 anus	e ɪ n ə s
 anvil	æ n v ə l
@@ -4462,7 +4486,7 @@ anxin	ɑː n ʃ iː n
 anxiolytic	æ ŋ k s i ə l ɪ t ɪ k
 anxious	e ɪ ŋ k ʃ ə s
 anxious	æ ŋ k ʃ ə s
-anxiouser	æ ŋ k ʃ ə s ə ɹ
+anxiouser	æ ŋ k ʃ ə s ɚ
 anxiously	æ ŋ k ʃ ə s l i
 any	ɛ n i
 any	ɪ n i
@@ -4523,7 +4547,7 @@ apeirotheism	ə p e ɪ̯ ɹ ɵ θ iː ɪ z ə m
 apeirotheism	ə p iː ɹ ɵ θ iː ɪ z ə m
 apennine	æ p ə n a ɪ n
 apennines	æ p ə n a ɪ n z
-aper	e ɪ p ə ɹ
+aper	e ɪ p ɚ
 apert	ə p ɜː ɹ t
 aperture	æ p ɚ t j ʊ ɹ
 aperture	æ p ɚ t ʊ ɹ
@@ -4541,6 +4565,18 @@ aphantasia	e ɪ f æ n t e ɪ ʒ ə
 aphasia	ə f e ɪ z ɪ ə
 aphasia	ə f e ɪ ʒ ə
 aphasic	ə f e ɪ z ə k
+aphelia	æ p h i l i ə
+aphelia	æ p h i l j ə
+aphelia	ə f i l i ə
+aphelia	ə f i l j ə
+aphelion	æ p h i l i ə
+aphelion	æ p h i l i ə n
+aphelion	æ p h i l j ə
+aphelion	æ p h i l j ə n
+aphelion	ə f i l i ə
+aphelion	ə f i l i ə n
+aphelion	ə f i l j ə
+aphelion	ə f i l j ə n
 apheresis	æ f ə ɹ i s ɪ s
 apheresis	ə f ɛ ɹ ə s ɪ s
 apheses	æ f ə s iː z
@@ -4549,7 +4585,7 @@ aphetic	ə f ɛ t ɪ k
 aphetism	æ f ə t ɪ z ə m
 aphetize	æ f ə t a ɪ z
 aphid	e ɪ f ɪ d
-aphorism	æ f ə ɹ ɪ z m̩
+aphorism	æ f ə ɹ ɪ z ə m
 aphoristic	æ f ə ɹ ɪ s t ɪ k
 aphotic	e ɪ f o ʊ t ɪ k
 aphrodisiac	æ f ɹ o ʊ d i z i æ k
@@ -4595,6 +4631,7 @@ apodictic	æ p ə d ɪ k t ɪ k
 apodioxis	æ p ə ʊ d a ɪ ɒ k s ɪ s
 apodixis	æ p ə ʊ d a ɪ k s ɪ s
 apodixis	æ p ə ʊ d ɪ k s ɪ s
+apodosis	ə p ɒ d ə s ɪ s
 apogamy	ə p ɒ ɡ ə m ɪ
 apogeal	æ p o ʊ d͡ʒ iː ə l
 apogeal	æ p ə d͡ʒ iː ə l
@@ -4636,7 +4673,7 @@ apostatical	æ p ə s t æ t ɪ k ə l
 apostle	ə p ɑ s l̩
 apostolic	æ p ə s t ɑː l ɪ k
 apostolos	ə p ɒ s t ə l ɪ s
-apostrophe	ə p ɑː s t ɹ ə f i
+apostrophe	ə p ɑ s t ɹ ə f i
 apostrophed	ə p ɒ s t ɹ ə f iː d
 apothecary	ə p ɑ θ ə k ɛ ə ɹ i
 apothegm	æ p ə θ ɛ m
@@ -4660,10 +4697,10 @@ apparel	ə p æ ɹ ə l
 apparel	ə p ɛ ɹ ə l
 apparent	ə p æ ɹ ə n t
 apparent	ə p ɛ ɚ ə n t
-apparently	ə p æ ɹ ɨ n t l i
+apparently	ə p æ ɹ ə n t l iː
 apparition	æ p ɚ ɪ ʃ n̩
 apparition	æ p ɚ ɪ ʃ ə n
-apparitor	ə p æ ɹ i t ə ɹ
+apparitor	ə p æ ɹ i t ɚ
 appeal	ə p i l
 appealed	ə p iː l d
 appealing	ə p i l ɪ ŋ
@@ -4764,7 +4801,7 @@ appropry	ə p ɹ o ʊ p ɹ i
 approval	ə p ɹ u v ə l
 approve	ə p ɹ uː v
 approved	ə p ɹ uː v d
-approver	ə p ɹ uː v ə ɹ
+approver	ə p ɹ uː v ɚ
 approves	ə p ɹ uː v z
 approving	ə p ɹ uː v ɪ ŋ
 approximal	ə p ɹ ɒ k s ɪ m ə l
@@ -4785,11 +4822,12 @@ aprepitant	ə p ɹ ɛ p ɪ t ə n t
 apricate	æ p ɹ i k e ɪ t
 aprication	æ p ɹ i k e ɪ ʃ ə n
 apricitabine	æ p ɹ ɪ s a ɪ t ə b i n
-apricot	e ɪ p ɹ ɪ k ɒ t
-apricot	æ p ɹ ɪ k ɒ t
+apricot	e ɪ p ɹ ɪ k ɑ t
+apricot	æ p ɹ ɪ k ɑ t
 april	e ɪ p ɹ ə l
 aprils	e ɪ p ɹ ə l z
 aprium	e ɪ p ɹ i ə m
+aprocitentan	æ p ɹ ə s ɪ t ɛ n t æ n
 apron	e ɪ p ɹ ə n
 aprons	e ɪ p ɹ ə n z
 apronym	æ p ɹ ə n ɪ m
@@ -4855,7 +4893,7 @@ aquila	ɑː k w ə l ə
 aquiline	æ k w ɪ l a ɪ n
 aquinas	ə k w a ɪ n ə s
 aquitaine	æ k w ɪ t e ɪ n
-aquiver	ə k w ɪ v ə ɹ
+aquiver	ə k w ɪ v ɚ
 ar	ɑ ɹ
 ara	e ɪ ɹ ə
 ara	ɛ ɹ ə
@@ -4887,7 +4925,7 @@ arachnophobia	æ ɹ æ k n ə f ə ʊ b ɪ ə
 aragon	ɛ ɹ ə ɡ ɑ n
 aragonese	æ r ə ɡ ɒ n iː z
 arak	ə ɹ æ k
-arak	ɛ ɹ ɨ k
+arak	ɛ ɹ ɪ k
 aral	ɛ ɹ ə l
 aralia	ə ɹ e ɪ l i ə
 aralia	ə ɹ e ɪ l j ə
@@ -4898,7 +4936,7 @@ aran	æ ɹ ə n
 arancino	ɑ ɹ ə n t͡ʃ i n o ʊ
 arango	ə ɹ æ ŋ ɡ ə ʊ
 arans	æ ɹ ə n z
-arapaho	ə ɹ æ p ə h o ʊ
+arapaho	ə ɹ e ɪ p ə h o ʊ
 arapaima	ɑː ɹ ə p a ɪ m ə
 araphostic	æ ɹ ə f ɑ s t ɪ k
 ararat	æ ɹ ə ɹ æ t
@@ -4916,7 +4954,7 @@ arbor	ɑ ɹ b ɚ
 arboreal	ɑ ɹ b ɔ ɹ i ə l
 arborescent	ɑː ɹ b ə ɹ ɛ s ə n t
 arboretum	ɑː ɹ b ə ɹ iː t ə m
-arboriculture	ɑː ɹ b ɔː ɹ ɨ k ʌ l t͡ʃ ɚ
+arboriculture	ɑː ɹ b ɔː ɹ ɪ k ʌ l t͡ʃ ɚ
 arborio	ɑ ɹ b ɔ ɹ i o ʊ
 arborolatry	ɑ ɹ b ɚ ɑ l ə t ɹ i
 arborvitae	ɑ ɹ b ɚ v a ɪ t ə
@@ -5002,12 +5040,12 @@ archivist	ɑː ɹ k ə v ɪ s t
 archivist	ɑː ɹ k ɪ v ɪ s t
 archking	ɑ ɹ t͡ʃ k ɪ ŋ
 archleader	ɑ ɹ t͡ʃ l i d ɚ
-archleader	ɑ ɹ t͡ʃ l iː d ə ɹ
+archleader	ɑ ɹ t͡ʃ l iː d ɚ
 archmage	ɑː r t͡ʃ m e ɪ d͡ʒ
 archology	ɑː k ɒ l ə d͡ʒ ɪ
 archon	ɑː ɹ k ə n
 archpaladin	ɑ ɹ t͡ʃ p æ l ə d ɪ n
-archpractitioner	ɑ ɹ t͡ʃ p ɹ æ k t ɪ ʃ ə n ə ɹ
+archpractitioner	ɑ ɹ t͡ʃ p ɹ æ k t ɪ ʃ ə n ɚ
 archy	ɑ ɹ k i
 archy	ɑ ɹ t͡ʃ i
 arcing	ɑ ɹ k ɪ ŋ
@@ -5026,7 +5064,7 @@ arcturus	ɑ ɹ k t j ʊ ə ɹ ə s
 arcweld	ɑ ɹ k w ɛ l d
 ard	ɑ ɹ d
 ardent	ɑ ɹ d ə n t
-ardor	ɑː ɹ d ə ɹ
+ardor	ɑː ɹ d ɚ
 arduous	ɑː ɹ d͡ʒ u ə s
 are	ɑ ɹ
 are	ɚ
@@ -5051,18 +5089,18 @@ areopagitic	ɛ ə ɹ i ə ʊ p ə d͡ʒ ɪ t ɪ k
 areopagus	æ r i ɒ p ə ɡ ə s
 ares	e ə ɹ iː z
 arete	æ ɹ ɪ t iː
-arethusa	æ ɹ ɨ θ j uː z ə
+arethusa	æ ɹ ɪ θ j uː z ə
 arew	ə ɹ ə ʊ
 argal	ɑː ɹ ɡ ə l
 argaman	ɑː ɹ ɡ ə m ə n
 argan	ɑː ɹ ɡ ə n
 argent	ɑ ɹ d͡ʒ ə n t
 argentina	ɑ ɹ d͡ʒ ə n t i n ə
-argentinan	ɑ ɹ d͡ʒ ɨ n t iː n ə n
+argentinan	ɑ ɹ d͡ʒ ɪ n t iː n ə n
 argentine	ɑː ɹ d͡ʒ ə n t a ɪ n
 argentine	ɑː ɹ d͡ʒ ə n t iː n
-argentinian	ɑ ɹ d͡ʒ ə n t i n i ə n
-argentinian	ɑ ɹ d͡ʒ ə n t iː n i ə n
+argentinian	ɑ ɹ d͡ʒ ə n t i n ɪ ə n
+argentinian	ɑ ɹ d͡ʒ ə n t iː n ɪ ə n
 argentry	ɑː ɹ d͡ʒ ə n t ɹ i
 argh	ɑ ɹ ɡ
 argh	ɑ ɹː
@@ -5125,6 +5163,7 @@ aristocrat	ə ɹ ɪ s t ə k ɹ æ t
 aristocratic	æ ɹ ɪ s t ə k ɹ æ t ɪ k
 aristolochic	ə ɹ ɪ s t ə l o ʊ k ɪ k
 aristophanes	ɛ ɹ ɪ s t ɑ f ə n i z
+aristotelian	æ ɹ ɪ s t ə t iː l i ə n
 aristotle	æ ɹ ɪ s t ɑ t ə l
 aristotle	ɛ ɹ ɪ s t ɑ t ə l
 arithmetic	æ ɹ ɪ θ m ɛ t ɪ k
@@ -5162,12 +5201,12 @@ armature	ɑ ɹ m ə t͡ʃ ʊ ɚ
 armchair	ɑ ɹ m t͡ʃ ɛ ɚ
 armed	ɑ ɹ m d
 armenia	ɑ ɹ m i n i ə
-armenian	ɑː ɹ m iː n i ə n
+armenian	ɑ ɹ m i n i ə n
 armet	ɑ ɹ m ɛ t
 armful	ɑ ɹ m f ʊ l
 armhole	ɑ ɹ m h o ʊ l
 armies	ɑ ɹ m i z
-armiger	ɑː ɹ m ɪ d͡ʒ ə ɹ
+armiger	ɑː ɹ m ɪ d͡ʒ ɚ
 armigerous	ɑ ɹ m ɪ d͡ʒ ɚ ə s
 armill	ɑ ɹ m ə l
 armill	ɑ ɹ m ɪ l
@@ -5206,11 +5245,11 @@ arpa	ɑ ɹ p ə
 arpanet	ɑ ɹ p ə n ɛ t
 arpeggio	ɑ ɹ p ɛ d͡ʒ i o ʊ
 arpitan	ɑ ɹ p ɪ t ə n
-arquebus	ɑ ɹ k w ɨ b ə s
-arquebus	ɑ ɹ k ɨ b ə s
+arquebus	ɑ ɹ k w ɪ b ə s
+arquebus	ɑ ɹ k ɪ b ə s
 arrabbiata	ɑ ɹ ə b i ɑː t ə
 arrack	ə ɹ æ k
-arrack	ɛ ɹ ɨ k
+arrack	ɛ ɹ ɪ k
 arraign	ə ɹ e ɪ n
 arraigned	ə ɹ e ɪ n d
 arraigning	ə ɹ e ɪ n ɪ ŋ
@@ -5256,7 +5295,8 @@ arrogant	æ ɹ ə ɡ ə n t
 arrogate	æ ɹ ə ɡ e ɪ t
 arrondissement	ə ɹ ɒ n d ɪ s m ə n t
 arrove	ə ɹ o ʊ v
-arrowmaker	æ ɹ ə ʊ m e ɪ k ə ɹ
+arrowcide	æ ɹ o ʊ s a ɪ d
+arrowmaker	æ ɹ ə ʊ m e ɪ k ɚ
 arrowroot	ɛ ɹ o ʊ ɹ u t
 arrows	ɛ ɹ o ʊ z
 arroyo	ə ɹ ɔ ɪ o ʊ
@@ -5322,8 +5362,8 @@ articulation	ɑ ɹ t ɪ k j ə l e ɪ ʃ ə n
 articulatory	ɑː ɹ t ɪ k j ə l ə t ɔ ɹ i
 artifact	ɑ ɹ t ɪ f æ k t
 artifice	ɑː ɹ t ɪ f ɪ s
-artificer	ɑ ɹ t ɪ f ə s ə ɹ
-artificer	ɑ ɹ t ɪ f ɪ s ə ɹ
+artificer	ɑ ɹ t ɪ f ə s ɚ
+artificer	ɑ ɹ t ɪ f ɪ s ɚ
 artificial	ɑː ɹ t ə f ɪ ʃ ə l
 artillery	ɑ ɹ t ɪ l ə ɹ i
 artina	ɑ ɹ t i n ə
@@ -5420,14 +5460,13 @@ ashamed	ə ʃ e ɪ m d
 ashanti	ə ʃ æ n t iː
 ashanti	ə ʃ ɑː n t iː
 ashed	æ ʃ t
-ashen	æ ʃ ɪ n
-asher	æ ʃ ə ɹ
+ashen	æ ʃ ə n
 asher	æ ʃ ɚ
 asherah	ə ʃ i ɹ ə
 ashes	æ ʃ ɪ z
 ashfield	æ ʃ f iː l d
 ashine	ə ʃ a ɪ n
-ashiver	ə ʃ ɪ v ə ɹ
+ashiver	ə ʃ ɪ v ɚ
 ashkelon	æ ʃ k ə l ɒ n
 ashkenazi	ɑː ʃ k ɪ n ɑː z i
 ashkenazi	ɑː ʃ k ɪ n ə z iː
@@ -5469,7 +5508,7 @@ aslant	ə s l ɑː n t
 asleep	ə s l iː p
 aslope	ə s l ə ʊ p
 asmara	æ s m ɑː ɹ ə
-asmear	ə s m ɪ ə ɹ
+asmear	ə s m ɪ ɚ
 asmodeus	æ z m ə d iː ə s
 asmrtist	e ɪ ɛ s ɛ m ɑ ɹ t ɪ s t
 asnarl	ə s n ɑː ɹ l
@@ -5493,11 +5532,11 @@ aspectable	æ s p ɛ k t ə b ə l
 aspects	æ s p ɛ k t s
 aspectual	æ s p ɛ k t j ʊ ə l
 aspen	æ s p ə n
-asper	æ s p ə ɹ
+asper	æ s p ɚ
 asperate	æ s p ə ɹ e ɪ t
 asperate	æ s p ə ɹ ə t
 asperge	ə s p ɜː ɹ d͡ʒ
-asperger	æ s p ɜː ɹ ɡ ə ɹ
+asperger	æ s p ɜː ɹ ɡ ɚ
 aspergilloma	æ s p ə ɹ d͡ʒ ɪ l o ʊ m ə
 aspergilloses	æ s p ə ɹ d͡ʒ ɪ l o ʊ s i s
 aspergillosis	æ s p ə ɹ d͡ʒ ɪ l o ʊ s ɪ s
@@ -5651,13 +5690,13 @@ assyrogenous	æ s ɪ ɹ ɑ d͡ʒ ɪ n ə s
 assythment	ə s a ɪ ð m ə n t
 astana	æ s t ɑː n ə
 astand	ə s t æ n d
-astare	ə s t ɛ ə ɹ
+astare	ə s t ɛ ɚ
 astart	ə s t ɑː ɹ t
 astasia	ə s t e ɪ z i ə
 astasia	ə s t e ɪ ʒ ə
 astatine	æ s t ə t i n
 astay	ə s t e ɪ
-aster	æ s t ə ɹ
+aster	æ s t ɚ
 asterisk	æ s t ə ɹ ɪ k s
 asterisk	æ s t ə ɹ ɪ s k
 asterism	æ s t ə ɹ ɪ z ə m
@@ -5710,7 +5749,7 @@ astrogeometry	æ s t ɹ ə d͡ʒ iː ɑ m ɛ t ɹ i
 astrohistory	æ s t ɹ ə h ɪ s t ə ɹ i
 astrolabe	æ s t ɹ ə l e ɪ b
 astrolinguistics	æ s t ɹ ə l ɪ ŋ ɡ w ɪ s t ɪ k s
-astrologer	ə s t r ɒ l ə d͡ʒ ə ɹ
+astrologer	ə s t r ɒ l ə d͡ʒ ɚ
 astrological	æ s t ɹ ə l ɒ d͡ʒ ɪ k ə l
 astromancy	æ s t ɹ ɵ m æ n s i
 astronaut	æ s t ɹ ə n ɔ t
@@ -5806,8 +5845,8 @@ atherine	æ θ ə ɹ a ɪ n
 atherine	æ θ ə ɹ ɪ n
 athermic	e ɪ θ ɜ ɹ m ɪ k
 athetesis	æ θ ɪ t iː s ɪ s
-athleisure	æ θ l iː ʒ ə ɹ
-athleisure	æ θ l ɛ ʒ ə ɹ
+athleisure	æ θ l iː ʒ ɚ
+athleisure	æ θ l ɛ ʒ ɚ
 athlete	æ θ l i t
 athletics	æ θ l ɛ t ɪ k s
 athos	æ θ ɒ s
@@ -5842,6 +5881,7 @@ atoll	ə t ɑ l
 atoltivimab	æ t ɒ l t ɪ v ɪ m æ b
 atom	æ t ə m
 atomic	ə t ɑː m ɪ k
+atomicity	æ t ə m ɪ s ɪ t i
 atomist	æ t ə m ɪ s t
 atompunk	æ t ə m p ʌ ŋ k
 atoms	a t ə m z
@@ -5872,6 +5912,7 @@ atrium	e ɪ t ɹ i ə m
 atrocious	ə t ɹ o ʊ ʃ ə s
 atrocity	ə t ɹ ɒ s ɪ t i
 atrophy	æ t ɹ ə f i
+atropia	ə t ɹ ə ʊ p i ə
 atropine	æ t ɹ ə p i n
 atropos	æ t ɹ ə p ɒ s
 atrous	e ɪ t ɹ ə s
@@ -5931,7 +5972,7 @@ attesting	ə t ɛ s t ɪ ŋ
 attests	ə t ɛ s t s
 attic	æ t ɪ k
 attinge	ə t ɪ n d͡ʒ
-attire	ə t a ɪ ə ɹ
+attire	ə t a ɪ ɚ
 attitude	æ t ɪ t u d
 attitudinize	æ t ɪ t j uː d ɪ n a ɪ z
 attitudinize	æ t ɪ t uː d ɪ n a ɪ z
@@ -5963,7 +6004,7 @@ atwinkle	ə t w ɪ ŋ k ə l
 atwirl	ə t w ɜː ɹ l
 atwist	ə t w ɪ s t
 atwitch	ə t w ɪ t͡ʃ
-atwitter	ə t w ɪ t ə ɹ
+atwitter	ə t w ɪ t ɚ
 atyrau	ɑ t ɪ ɹ a ʊ
 aubade	o ʊ b ɑ d
 aube	ɔː b
@@ -5974,7 +6015,8 @@ auburn	ɔː b ə ɹ n
 auchinleck	ɔː x ɪ n l ɛ k
 auchtermuchty	ɒ x t ə ɹ m ʌ x t i
 auckland	ɔː k l ə n d
-auction	ɔː k ʃ ə n
+auction	ɑ k ʃ ə n
+auction	ɔ k ʃ ə n
 audacious	ɔ d e ɪ ʃ ə s
 audaciously	ɔ d e ɪ ʃ ə s l i
 audaciousness	ɔ d e ɪ ʃ ə s n ə s
@@ -5991,9 +6033,10 @@ audio	ɔ d i o ʊ
 audiology	ɔː d i ɒ l ə d͡ʒ i
 audiovisual	ɑ d i o ʊ v ɪ ʒ u ə l
 audiovisual	ɔ d i o ʊ v ɪ ʒ u ə l
+audit	ɑ d ɪ t
 audit	ɔ d ɪ t
 audition	ɔː d ɪ ʃ ə n
-auditor	ɔː d ɪ t ə ɹ
+auditor	ɔː d ɪ t ɚ
 auditorium	ɔ d ə t ɔ ɹ i ə m
 auditory	ɑː d ɪ t ɔ ɹ i
 auditory	ɔː d ɪ t ɔ ɹ i
@@ -6087,9 +6130,9 @@ austenesque	ɔ s t ə n ɛ s k
 austenian	ɔ s t i n i ə n
 austenite	ɔ s t ɪ n a ɪ t
 auster	ɒ s t ə
-auster	ɒ s t ə ɹ
+auster	ɒ s t ɚ
 auster	ɔː s t ə
-auster	ɔː s t ə ɹ
+auster	ɔː s t ɚ
 austere	ɔ s t i ɹ
 austerely	ɔ s t i ə ɹ l i
 austerity	ɔ s t ɛ ɹ ɪ t i
@@ -6110,14 +6153,14 @@ australiana	ɔ s t ɹ e ɪ l i ɑ n ə
 australianise	ɒ s t ɹ e ɪ l j ə n a ɪ z
 australianize	ɒ s t ɹ e ɪ l j ə n a ɪ z
 austria	ɔ s t ɹ i ə
-austrian	ɔː s t ɹ i ə n
+austrian	ɔ s t ɹ i ə n
 austrians	ɔː s t ɹ i ə n s
 austronesia	ɒ s t ɹ ə n iː ʒ ə
 austronesian	ɔː s t ɹ o ʊ n iː ʒ ə n
 austronesians	ɔː s t ɹ o ʊ n iː ʒ ə n z
-autarchy	ɔː t ɑː ɹ k i
+autarchy	ɔ t ɑ ɹ k i
+autarky	ɔ t ɑ ɹ k i
 auteur	o ʊ t ɝ
-authentic	ɒ θ ɛ n t ɪ k
 authentic	ɔ θ ɛ n t ɪ k
 authenticate	ɔ θ ɛ n t ɪ k e ɪ t
 authenticity	ɑ θ ə n t ɪ s ɪ t i
@@ -6242,7 +6285,7 @@ avenge	ə v ɛ n d͡ʒ
 avens	æ v ɪ n z
 aventail	æ v ə n t e ɪ l
 aventine	æ v ə n t a ɪ n
-aventre	ə v ɛ n t ə ɹ
+aventre	ə v ɛ n t ɚ
 aventurine	ə v ɛ n t͡ʃ ə ɹ i n
 aventurine	ə v ɛ n t͡ʃ ə ɹ ɪ n
 avenue	æ v ə n j u
@@ -6292,6 +6335,7 @@ avoirdupois	æ v ɚ d ə p ɔ ɪ z
 avolition	e ɪ v ə l ɪ ʃ ə n
 avondale	e ɪ v ə n d e ɪ l
 avonmouth	e ɪ v ə n m ə θ
+avosentan	æ v ə s ɛ n t æ n
 avouch	ə v a ʊ t͡ʃ
 avourneen	ə v ɝ n iː n
 avourneen	ə v ʊ ɹ n iː n
@@ -6325,7 +6369,7 @@ awaze	ɑ w ɑ z e ɪ
 awaze	ɑ w ɑ z i
 awe	ɔ
 aweary	ə w ɪ ə ɹ i
-aweather	ə w ɛ ð ə ɹ
+aweather	ə w ɛ ð ɚ
 awed	ɔː d
 aweigh	ə w e ɪ
 aweless	ɔ l ɪ s
@@ -6351,14 +6395,13 @@ awkwards	ɔ k w ɚ d z
 awl	ɔ l
 awlwort	ɔː l w ɜː ɹ t
 awn	ɔː n
-awner	ɔː n ə ɹ
+awner	ɔː n ɚ
 awning	ɔ n ɪ ŋ
 awnry	ɔː n ɹ i
 awoke	ə w ə ʊ k
 awoken	ə w ə ʊ k ə n
 awol	e ɪ̯ w ɑ l
 awol	e ɪ̯ w ɔ l
-awoman	e ɪ w ʊ m ɘ n
 awoman	e ɪ w ʊ m ə n
 awoman	ɑː w ʊ m ə n
 awook	ə w ʊ k
@@ -6418,7 +6461,7 @@ ayn	a ɪ n
 ayo	e ɪ j o ʊ
 ayoo	e ɪ o ʊ
 ayoo	e ɪ uː
-ayr	ɛ ə ɹ
+ayr	ɛ ɚ
 ayr	ɛ ɹ
 ayrab	e ɪ ɹ æ b
 ayrshire	ɛ ɚ ʃ ɪ ɚ
@@ -6445,14 +6488,14 @@ azinomycin	æ z i n o ʊ m a ɪ s ɪ n
 azinomycin	æ z ɪ n o ʊ m a ɪ s ɪ n
 aziridine	ə z ɪ ɹ ɪ d iː n
 azithromycin	ə z ɪ θ ɹ o ʊ m a ɪ s n̩
-aznavour	ɑː z n ə v ʊ ə ɹ
+aznavour	ɑː z n ə v ʊ ɚ
 azole	æ z o ʊ l
 azole	ə z o ʊ l
 azores	e ɪ z ɔː ɹ z
 azote	æ z ə ʊ t
 azotemia	æ z o ʊ t i m i ə
 azoth	æ z ɔ θ
-azotometer	e ɪ z ə ʊ t ɒ m ɪ t ə ɹ
+azotometer	e ɪ z ə ʊ t ɒ m ɪ t ɚ
 azov	e ɪ z ɑ v
 azov	e ɪ z ɔ f
 azov	æ z ɔ f
@@ -6498,7 +6541,7 @@ babblery	b æ b ə l ɹ i
 babby	b æ b i
 babe	b e ɪ b
 babel	b æ b l̩
-babergh	b e ɪ b ə ɹ
+babergh	b e ɪ b ɚ
 babes	b e ɪ b z
 babiche	b æ b iː ʃ
 babiche	b ə b iː ʃ
@@ -6551,7 +6594,7 @@ backcountry	b æ k k ʌ n t r i
 backdam	b æ k d æ m
 backdrop	b æ k d ɹ ɒ p
 backed	b æ k t
-backer	b æ k ə ɹ
+backer	b æ k ɚ
 backfield	b æ k f i l d
 backfisch	b æ k f ɪ ʃ
 backflip	b æ k f l ɪ p
@@ -6580,7 +6623,7 @@ backseaters	b æ k s i t ɚ z
 backside	b æ k s a ɪ d
 backslang	b æ k s l æ ŋ
 backslash	b æ k s l æ ʃ
-backslider	b æ k s l a ɪ d ə ɹ
+backslider	b æ k s l a ɪ d ɚ
 backspace	b æ k s p e ɪ s
 backspin	b æ k s p ɪ n
 backstab	b æ k s t æ b
@@ -6629,7 +6672,6 @@ badass	b æ d æ s
 badassery	b æ d æ s ə ɹ i
 baddams	b æ d ə m z
 baddeck	b ə d ɛ k
-badder	b æ d ə ɹ
 baddie	b æ d i
 bade	b e ɪ d
 bade	b æ d
@@ -6640,6 +6682,7 @@ badenoch	b æ d ə n ɒ x
 badge	b æ d͡ʒ
 badger	b æ d ʒ ɚ
 badger	b æ d͡ʒ ɚ
+badigeon	b ə d ɪ d ʒ ə n
 badinage	b ɑ d ɪ n ɑ ʒ
 badine	b ə d iː n
 badinerie	b æ d ɪ n ɹ i
@@ -6652,7 +6695,7 @@ badness	b æ d n ə s
 badong	b ə d ɔ ŋ
 badonkadonk	b ə d ɔ ŋ k ə d ɔ ŋ k
 bae	b e ɪ
-baenomere	b iː n ə m ɪ ə ɹ
+baenomere	b iː n ə m ɪ ɚ
 baenopod	b iː n ə p ɒ d
 baetyl	b iː t a ɪ ɫ
 baff	b æ f
@@ -6713,7 +6756,7 @@ baihe	b a ɪ h ə
 baiji	b a ɪ d͡ʒ i
 baijiu	b a ɪ d͡ʒ uː
 baikal	b a ɪ k ɑː l
-baikonur	b a ɪ k ə n ɪ ə ɹ
+baikonur	b a ɪ k ə n ɪ ɚ
 bail	b e ɪ̯ l
 baile	b a ɪ l i
 baile	b e ɪ l
@@ -6776,7 +6819,8 @@ balaclava	b ɑː l ə k l ɑː v ə
 balalaika	b æ l ə l a ɪ k ə
 balance	b æ l ə n s
 balanced	b æ l ə n s t
-balancer	b æ l ə n s ə ɹ
+balancer	b æ l ə n s ɚ
+balanic	b ə l æ n ɪ k
 balanitis	b æ l ə n a ɪ t ɪ s
 balas	b a l ə s
 balaton	b æ l ə t ɒ n
@@ -6803,6 +6847,7 @@ baled	b e ɪ l d
 baleen	b e ɪ l iː n
 baleen	b ə l iː n
 baleful	b e ɪ l f ə l
+balenciaga	b ə l ɛ n s i ɑː ɡ ə
 bales	b e ɪ l z
 bali	b ɑː l i
 baling	b e ɪ l ɪ ŋ
@@ -6823,7 +6868,7 @@ balladry	b æ l ə d ɹ i
 ballarat	b æ l ə ɹ æ t
 ballast	b æ l ə s t
 ballcock	b ɔː l k ɒ k
-baller	b ɔː l ə ɹ
+baller	b ɔː l ɚ
 ballerina	b æ l ə ɹ iː n ə
 ballerino	b æ l ə ɹ iː n o ʊ
 ballet	b æ l e ɪ
@@ -6840,7 +6885,7 @@ ballistic	b ə l ɪ s t ɪ k
 ballistics	b ə l ɪ s t ɪ k s
 balloon	b ə l u n
 ballooned	b ə l uː n d
-ballooner	b ə l uː n ə ɹ
+ballooner	b ə l uː n ɚ
 ballooning	b ə l uː n ɪ ŋ
 balloonings	b ə l uː n ɪ ŋ z
 balloons	b ə l uː n z
@@ -6866,7 +6911,7 @@ balmily	b ɔ l m ə l i
 balmoral	b æ l m ɒ ɹ ə l
 balmy	b ɑː m i
 baloney	b ə l o ʊ n i
-balquhidder	b æ l k w ɪ d ə ɹ
+balquhidder	b æ l k w ɪ d ɚ
 balrog	b æ l ɹ ɑ ɡ
 balrog	b ɑ l ɹ ɑ ɡ
 balrog	b ɔ l ɹ ɑ ɡ
@@ -6874,7 +6919,7 @@ balsa	b ɑ l s ə
 balsamic	b ɔː l s æ m ɪ k
 balsamous	b ɔː l s ə m ə s
 balsamy	b ɑ l s ə m iː
-balthazar	b æ l θ e ɪ z ə ɹ
+balthazar	b æ l θ e ɪ z ɚ
 balthazar	b æ l θ ə z ɔ ɹ
 baltic	b ɑ l t ɪ k
 baltic	b ɔ l t ɪ k
@@ -6895,15 +6940,16 @@ bamboozle	b æ m b uː z l̩
 bambuterol	b æ m b j uː t ə ɹ ɒ l
 bamf	b æ m f
 bamma	b æ m ə
-bammer	b æ m ə ɹ
+bammer	b æ m ɚ
 bamp	b æ m p
 bampot	b æ m p ɒ t
 ban	b æ n
+banaba	b ə n ɑː b ə
 banal	b e ɪ n ə l
 banal	b ə n æ l
 banal	b ə n ɑː l
-banality	b e ɪ n æ l ɨ t i
-banality	b ə n æ l ɨ t i
+banality	b e ɪ n æ l ɪ t i
+banality	b ə n æ l ɪ t i
 banana	b ə n æ n ə
 bananas	b ə n æ n ə z
 banausic	b ə n ɔ z ɪ k
@@ -6923,8 +6969,9 @@ bandings	b æ n d ɪ ŋ z
 bandit	b æ n d ɪ t
 bandmate	b æ n d m e ɪ t
 bandolero	b æ n d ə l e ə ɹ ə ʊ
-bandolier	b æ n d ə l ɪ ə ɹ
+bandolier	b æ n d ə l ɪ ɚ
 bandolierwise	b æ n d ə l ɪ ə ɹ w a ɪ z
+bandra	b æ n d ɹ ə
 bands	b æ n d z
 bandung	b ɑ n d ʊ ŋ
 bandura	b æ n d u ɹ ə
@@ -6940,14 +6987,14 @@ bangable	b æ ŋ ɡ ə b ə ɫ
 bangalore	b æ ŋ ɡ ə l o ɹ
 bangarang	b æ ŋ ə ɹ æ ŋ
 bangel	b e ɪ n d͡ʒ ə l
-banger	b æ ŋ ə ɹ
+banger	b æ ŋ ɚ
 banging	b æ ŋ ɪ ŋ
 bangiophyte	b æ n d͡ʒ ɪ ɔ f a ɪ t
 bangkok	b æ ŋ k ɒ k
 bangladesh	b æ ŋ ɡ l ə d ɛ ʃ
 bangladesh	b ɑː ŋ ɡ l ə d ɛ ʃ
 bangle	b æ ŋ ɡ ə l
-bangor	b æ ŋ ɡ ə ɹ
+bangor	b æ ŋ ɡ ɚ
 bangui	b ɑː ŋ ɡ i
 bangui	b ɑː ŋ ɡ iː
 baning	b e ɪ n ɪ ŋ
@@ -6957,7 +7004,7 @@ banishes	b æ n ɪ ʃ ɪ z
 banishing	b æ n ɪ ʃ ɪ ŋ
 banishings	b æ n ɪ ʃ ɪ ŋ z
 banishment	b æ n ɪ ʃ m ə n t
-banister	b æ n ɪ s t ə ɹ
+banister	b æ n ɪ s t ɚ
 banjax	b æ n d͡ʒ æ k s
 banjo	b æ n d͡ʒ o ʊ
 banjouke	b æ n d͡ʒ ə ʊ j uː k
@@ -7106,6 +7153,7 @@ bargello	b ɑ ɹ d͡ʒ ɛ l o ʊ
 bargello	b ɑ ɹ ʒ ɛ l o ʊ
 bari	b æ ɹ i
 baria	b ɛ ə ɹ i ə
+bariatric	b æ ɹ i æ t ɹ ɪ k
 bariatrician	b ɛ ɹ i ə t ɹ ɪ ʃ ə n
 barin	b ɑ ɹ ɪ n
 baring	b ɛ ɹ ɪ ŋ
@@ -7120,7 +7168,7 @@ bark	b ɑ ɹ k
 barken	b ɑː ɹ k ə n
 barker	b ɑ ɹ k ɚ
 barker	b ɑː r k ə r
-barker	b ɑː ɹ k ə ɹ
+barker	b ɑː ɹ k ɚ
 barking	b ɑ ɹ k ɪ ŋ
 barkley	b ɑ ɹ k l i
 barksian	b ɑ ɹ k s i ə n
@@ -7153,17 +7201,16 @@ barramundi	b æ ɹ ə m ʌ n d i
 barranca	b ə ɹ æ ŋ k ə
 barrasso	b ə ɹ æ s o ʊ
 barrasso	b ə ɹ ɑ s o ʊ
-barrator	b æ ɹ ə t ə ɹ
+barrator	b æ ɹ ə t ɚ
 barrators	b æ ɹ ə t ə ɹ z
 barratry	b æ ɹ ə t ɹ i
 barrel	b æ ɹ ə l
-barrel	b ɛ ɚ ɹ ə l
+barrel	b ɛ ɚ ə l
 barrett	b æ ɹ ɪ t
 barrette	b ə ɹ ɛ t
-barrier	b æ ɹ i ə ɹ
-barrier	b ɛ ɹ i ə ɹ
+barrier	b æ ɹ i ɚ
+barrier	b ɛ ɹ i ɚ
 barrow	b æ ɹ o ʊ
-barry	b æ ɹ i
 barry	b ɑ ɹ i
 barse	b ɑː ɹ s
 barside	b ɑ ɹ s a ɪ d
@@ -7177,9 +7224,8 @@ bartholow	b ɑː ɹ θ ə l ə ʊ
 bartisan	b ɑː t ɪ z æ n
 bartitsu	b ɑː t ɪ t s uː
 bartizan	b ɑː t ɪ z æ n
-baruch	b ɑ r u k
-baruch	b ə r u k
-baruch	b ɛ r ə k
+baruch	b ɑ r u x
+baruch	b ə r u x
 baryon	b æ ɹ i ɒ n
 baryon	b ɛ ə ɹ i ɒ n
 baryta	b ə ɹ a ɪ t ə
@@ -7216,7 +7262,7 @@ bashes	b æ ʃ ɪ z
 bashing	b æ ʃ ɪ ŋ
 bashings	b æ ʃ ɪ ŋ z
 bashir	b ə ʃ i ɹ
-bashkir	b ɑː ʃ k ɪ ə ɹ
+bashkir	b ɑː ʃ k ɪ ɚ
 bashlyk	b æ ʃ l ɪ k
 basic	b e ɪ s ɪ k
 basically	b e ɪ s ɪ k ə l i
@@ -7241,9 +7287,10 @@ basis	b e ɪ s ɪ s
 bask	b æ s k
 baskerville	b æ s k ɚ v ɪ l
 basket	b æ s k ɪ t
-basketball	b æ s k ɪ t b ɔː l
-basler	b æ z l ə ɹ
-basler	b ɑː z l ə ɹ
+basketball	b æ s k ɪ t b ɑ l
+basketball	b æ s k ɪ t b ɔ l
+basler	b æ z l ɚ
+basler	b ɑː z l ɚ
 basophil	b e ɪ s ə f ɪ l
 basque	b æ s k
 basque	b ɑː s k
@@ -7251,13 +7298,14 @@ bass	b e ɪ s
 bass	b æ s
 bassaleg	b æ s æ l ɛ ɡ
 bassein	b ə s e ɪ n
+basseterre	b æ s t ɛ ə ɹ
 bassinet	b æ s ɪ n ɛ t
 bassist	b e ɪ s ɪ s t
 bassline	b e ɪ s l a ɪ n
 basslines	b e ɪ s l a ɪ n z
 bassoon	b ə s u n
 bassooned	b ə s uː n d
-bassooner	b ə s uː n ə ɹ
+bassooner	b ə s uː n ɚ
 bassooning	b ə s uː n ɪ ŋ
 bassoons	b ə s uː n z
 basswood	b æ s w ʊ d
@@ -7380,6 +7428,7 @@ bawson	b ɔː s ə n
 bawtry	b ɔː t ɹ i
 baxter	b æ k s t ɚ
 bay	b e ɪ
+baybayin	b a ɪ b a j i n
 bayed	b e ɪ d
 bayesian	b e ɪ z i ə n
 bayesian	b e ɪ ʒ ə n
@@ -7433,6 +7482,7 @@ beadings	b iː d ɪ ŋ z
 beads	b iː d z
 beadsman	b iː d z m ə n
 beady	b i d i
+beagle	b iː ɡ ə l
 beaked	b iː k t
 beaker	b iː k ɚ
 beaking	b iː k ɪ ŋ
@@ -7509,7 +7559,7 @@ beaus	b o ʊ z
 beaut	b j uː t
 beauties	b j uː t i z
 beautifies	b j u t ə f a ɪ z
-beautiful	b j uː t ɪ f ə l
+beautiful	b j u t ɪ f ə l
 beautifully	b j uː t ɪ f ə l i
 beautify	b j uː t ɪ f a ɪ
 beautility	b j uː t ɪ l ə t i
@@ -7549,6 +7599,7 @@ beckonings	b ɛ k ə n ɪ ŋ z
 beckons	b ɛ k ə n z
 becky	b ɛ k i
 becloud	b ɪ k l a ʊ d
+become	b i k ʌ m
 become	b ə k ʌ m
 become	b ɪ k ʌ m
 becomes	b ə k ʌ m z
@@ -7621,7 +7672,6 @@ beeping	b iː p ɪ ŋ
 beepings	b iː p ɪ ŋ z
 beeps	b iː p s
 beer	b i ɚ
-beer	b ɪ ə ɹ
 beer	b ɪ ɚ
 beer	b ɪ ɹ
 beers	b i ɹ z
@@ -7715,15 +7765,17 @@ behelp	b ɪ h ɛ l p
 behemoth	b iː ə m ə θ
 behemoth	b ə h iː m ə θ
 behest	b i h ɛ s t
+behest	b ɪ h ɛ s t
 behind	b iː h a ɪ n d
 behind	b ə h a ɪ n d
 behind	b ɪ h a ɪ n d
 behl	b e ɪ l
 behold	b ɪ h o ʊ l d
-beholden	b ɨ h o ʊ l d ə n
+beholden	b ɪ h o ʊ l d ə n
 beholder	b ɪ h o ʊ l d ɚ
-behoove	b ɨ h uː v
+behoove	b ɪ h uː v
 behove	b i h o ʊ v
+behoven	b i h o ʊ v ə n
 beibei	b e ɪ b e ɪ
 beida	b e ɪ d a
 beige	b e ɪ d͡ʒ
@@ -7731,6 +7783,7 @@ beige	b e ɪ ʒ
 beigey	b e ɪ ʒ i
 beignet	b ɛ n j e ɪ
 beijing	b e ɪ d͡ʒ ɪ ŋ
+beijinger	b e ɪ d ʒ ɪ ŋ ə ɹ
 bein	b iː n
 being	b i ŋ
 being	b i ɪ ŋ
@@ -7788,7 +7841,7 @@ belief	b ɪ l iː f
 believe	b ɪ l i v
 believer	b ɪ l i v ɚ
 belinda	b ə l ɪ n d ə
-belittle	b ɨ l ɪ t ə l
+belittle	b ɪ l ɪ t ə l
 belive	b ə l a ɪ v
 beliven	b ə l ɪ v ə n
 belize	b e ɪ l iː z
@@ -7841,7 +7894,7 @@ beloved	b ɪ l ʌ v d
 beloved	b ɪ l ʌ v ɪ d
 below	b ɪ l o ʊ
 belphegor	b ɛ l f ə ɡ ɔ ɹ
-belswagger	b ɛ l s w æ ɡ ə ɹ
+belswagger	b ɛ l s w æ ɡ ɚ
 belt	b ɛ l t
 belted	b ɛ l t ɪ d
 belter	b ɛ l t ɚ
@@ -7856,7 +7909,7 @@ bema	b iː m ə
 bemean	b ɪ m iː n
 bemidji	b ə m ɪ d͡ʒ i
 bemingle	b ɪ m ɪ ŋ ɡ ə l
-bemire	b ə m a ɪ ə ɹ
+bemire	b ə m a ɪ ɚ
 bemoan	b ɪ m o ʊ n
 bemol	b iː m ɒ l
 bemuse	b ə m j uː z
@@ -7868,7 +7921,7 @@ benatoprazole	b ɛ n ə t ɒ p ɹ ə z o ʊ l
 benbecula	b ɛ n b ɛ k j ʊ l ə
 bench	b ɛ n t͡ʃ
 benched	b ɛ n t͡ʃ t
-bencher	b ɛ n t͡ʃ ə ɹ
+bencher	b ɛ n t͡ʃ ɚ
 benches	b ɛ n t͡ʃ ɪ z
 benching	b ɛ n t͡ʃ ɪ ŋ
 benchings	b ɛ n t͡ʃ ɪ ŋ z
@@ -7889,7 +7942,7 @@ beneficence	b ə n ɛ f ɪ s ə n s
 beneficent	b ə n ɛ f ə s ə n t
 beneficial	b ɛ n ə f ɪ ʃ ə l
 beneficiary	b ɛ n ə f ɪ ʃ i ɚ i
-beneficiary	b ɛ n ɨ f ɪ ʃ ɚ i
+beneficiary	b ɛ n ɪ f ɪ ʃ ɚ i
 beneficient	b ɛ n ə f ɪ ʃ ə n t
 benefit	b ɛ n ə f ɪ t
 benegro	b ɪ n iː ɡ ɹ ə ʊ
@@ -7936,7 +7989,7 @@ benzathine	b ɛ n z ə θ i n
 benzatropine	b ɛ n z æ t ɹ ə p i n
 benzene	b ɛ n z iː n
 benzocaine	b ɛ n z ə k e ɪ n
-benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɨ p iː n
+benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɪ p iː n
 benzonatate	b ɛ n z o ʊ n ə t e ɪ t
 benzopyrazine	b ɛ n z ə ʊ p a ɪ ɹ ə z iː n
 benzoyl	b ɛ n z ə ʊ a ɪ l
@@ -7978,7 +8031,7 @@ bere	b ɪ ə
 bereave	b ɪ ɹ iː v
 bereaved	b ɪ r iː v d
 bereft	b ə ɹ ɛ f t
-berengar	b ɛ ɹ ɪ ŋ ɡ ə ɹ
+berengar	b ɛ ɹ ɪ ŋ ɡ ɚ
 berenice	b ɛ r ə n a ɪ s i
 berenice	b ɛ r ə n iː s
 berenice	b ɛ r ə n iː s i
@@ -8017,6 +8070,7 @@ berserker	b ɚ s ɚ k ɚ
 berserker	b ɚ z ɚ k ɚ
 bert	b ɝ t
 berth	b ɝ θ
+bertha	b ɜː ɹ θ ə
 bertha	b ɝ θ ə
 berwick	b ɝ w ɪ k
 beryl	b ɛ ɹ ə l
@@ -8076,7 +8130,7 @@ bestiary	b ɛ s t i ɛ r i
 bestie	b ɛ s t i
 besting	b ɛ s t ɪ ŋ
 bestir	b i s t ɝ
-bestir	b ɘ s t ɝ
+bestir	b ə s t ɝ
 bestir	b ɪ s t ɝ
 bestow	b ɪ s t o ʊ
 bestowal	b ɪ s t o ʊ ə l
@@ -8092,8 +8146,8 @@ betamethasone	b e ɪ t ə m ɛ θ ə s o ʊ n
 betaxolol	b ə t æ k s ə l ɔ l
 betcha	b ɛ t͡ʃ ə
 betcho	b ɛ t͡ʃ o ʊ
-betear	b ɪ t ɛ ə ɹ
-betear	b ɪ t ɪ ə ɹ
+betear	b ɪ t ɛ ɚ
+betear	b ɪ t ɪ ɚ
 betel	b i tᵊ l
 betelgeuse	b i d l d ʒ u s
 betelgeuse	b i d l d ʒ u z
@@ -8158,11 +8212,11 @@ bevor	b i v ɚ
 bevvy	b ɛ v i
 bevy	b ɛ v i
 bewail	b ɪ w e ɪ l
-beware	b i w ɛ ə ɹ
-beware	b ə w ɛ ə ɹ
-beware	b ɪ w ɛ ə ɹ
-bewater	b ɪ w ɔː t ə ɹ
-bewelter	b ɪ w ɛ l t ə ɹ
+beware	b i w ɛ ɚ
+beware	b ə w ɛ ɚ
+beware	b ɪ w ɛ ɚ
+bewater	b ɪ w ɔː t ɚ
+bewelter	b ɪ w ɛ l t ɚ
 bewhape	b ɪ w e ɪ p
 bewhape	b ɪ ʍ e ɪ p
 bewhore	b ɪ h ɔː ɹ
@@ -8212,7 +8266,7 @@ bhaji	b ɑː d͡ʒ i
 bhang	b a ŋ
 bhang	b æ ŋ
 bhangra	b ɑː ŋ ɡ ɹ ə
-bheer	b ɪ ə ɹ
+bheer	b ɪ ɚ
 bhikkhu	b ɪ k uː
 bhojpuri	b o ʊ d͡ʒ p ʊ ə r i
 bhopal	b ə ʊ p ɑː l
@@ -8246,6 +8300,7 @@ bibliometrist	b ɪ b l i ɒ m ə t ɹ ɪ s t
 bibliopoly	b ɪ b l i ɑ p ə l i
 bibliotheca	b ɪ b l i ə θ iː k ə
 bibliothecal	b ɪ b l i ə θ iː k ə l
+bibliotheque	b ɪ b l i ə θ iː k
 bibliotic	b ɪ b l i ɒ t ɪ k
 biblist	b ɪ b l ɪ s t
 bibs	b ɪ b z
@@ -8260,9 +8315,9 @@ bicep	b a ɪ s ɛ p
 bicephaly	b a ɪ s ɛ f ə l i
 biceps	b a ɪ s ɛ p s
 bicester	b ɪ s t ɚ
-bichir	b iː ʃ ə ɹ
+bichir	b iː ʃ ɚ
 bichir	b ɪ ʃ iː ɹ
-bichir	b ɪ ʃ ə ɹ
+bichir	b ɪ ʃ ɚ
 bichon	b i ʃ ɔ n
 bicipital	b a ɪ s ɪ p ə t ə l
 bicipital	b a ɪ s ɪ p ɪ t ə l
@@ -8288,7 +8343,7 @@ bide	b a ɪ d
 bided	b a ɪ d ɪ d
 bideford	b ɪ d ɪ f ə r d
 biden	b a ɪ d ə n
-bidencare	b a ɪ d ə n k ɛ ə ɹ
+bidencare	b a ɪ d ə n k ɛ ɚ
 bidenomics	b a ɪ d ə n ɒ m ɪ k s
 bides	b a ɪ d z
 bidet	b ɪ d e ɪ
@@ -8300,7 +8355,8 @@ bids	b ɪ d z
 bieber	b i b ɚ
 biennial	b a ɪ ɛ n i ə l
 biennium	b a ɪ ɛ n i ə m
-bier	b i ɚ
+bier	b ɪ ɚ
+bifarious	b a ɪ f ɛ ə ɹ i ə s
 bifenthrin	b a ɪ f ɛ n θ ɹ ɪ n
 bifeprunox	b ɪ f ɛ p ɹ ə n ɒ k s
 biff	b ɪ f
@@ -8346,7 +8402,7 @@ bikini	b ɪ k iː n i
 bikini	b ɪ k ɪ n i
 bilabial	b a ɪ l e ɪ b i ə l
 bilali	b ɪ l ɑː l i
-bilander	b ɪ l ə n d ə ɹ
+bilander	b ɪ l ə n d ɚ
 bilateral	b a ɪ l æ t ə ɹ ə l
 bilbao	b ɪ l b a ʊ
 bilberry	b ɪ l b ə ɹ ɪ
@@ -8393,7 +8449,6 @@ bimetallic	b a ɪ m ɪ t æ l ɪ k
 bimillennial	b a ɪ m ɪ l ɛ n i ə l
 bimini	b ɪ m ɪ n i
 bimini	b ɪ m ɪ n iː
-bin	b iː n
 bin	b ɪ n
 binal	b a ɪ n ə l
 binarseniate	b a ɪ n ɑː ɹ s iː n i e ɪ t
@@ -8408,7 +8463,11 @@ bine	b a ɪ n
 bines	b a ɪ n z
 bing	b ɪ ŋ
 binge	b ɪ n d͡ʒ
+binged	b ɪ n d͡ʒ d
+binged	b ɪ ŋ d
 binghi	b ɪ ŋ a ɪ
+binging	b ɪ n d͡ʒ ɪ ŋ
+binging	b ɪ ŋ ɪ ŋ
 bingo	b ɪ ŋ ɡ o ʊ
 bingy	b ɪ ŋ i
 binhai	b ɪ n h a ɪ
@@ -8423,8 +8482,9 @@ binner	b ɪ n ɚ
 binning	b ɪ n ɪ ŋ
 binns	b ɪ n z
 binny	b ɪ n i
-binocular	b ɪ n ɒ k j ʊ l ə ɹ
+binocular	b ɪ n ɒ k j ʊ l ɚ
 binomial	b a ɪ n o ʊ m i ə l
+binoxide	b a ɪ n ɒ k s a ɪ d
 bins	b ɪ n z
 bint	b ɪ n t
 bintje	b ɪ n t͡ʃ ə
@@ -8435,6 +8495,7 @@ bioanalytics	b a ɪ o ʊ æ n ə l ɪ t ɪ k s
 biocide	b a ɪ o ʊ s a ɪ d
 biodegradable	b a ɪ o ʊ d ə ɡ ɹ e ɪ d ə b l̩
 biodegradable	b a ɪ ə d ə ɡ ɹ e ɪ d ə b l̩
+biodiversity	b a ɪ o ʊ d ə v ɚ s ə t i
 biodomain	b a ɪ o ʊ d o ʊ m e ɪ n
 biodome	b a ɪ o ʊ d o ʊ m
 biogenesis	b a i o ʊ d͡ʒ ɛ n ə s ɪ s
@@ -8494,7 +8555,7 @@ birefringence	b a ɪ ɹ ɪ f ɹ ɪ n d͡ʒ ə n s
 birkenhead	b ɜː k ə n h ɛ d
 birl	b ɝ l
 birr	b ɝ
-birr	b ɪ ə ɹ
+birr	b ɪ ɚ
 birse	b ɜː ɹ s
 birt	b ɜː ɹ t
 birth	b ɝ ð
@@ -8607,16 +8668,16 @@ bizen	b a ɪ z ə n
 biñan	b ɪ n j a ʊ n
 blab	b l æ b
 blabbed	b l æ b d
-blabber	b l æ b ə ɹ
+blabber	b l æ b ɚ
 blabbing	b l æ b ɪ ŋ
 blabby	b l æ b i
 blabs	b l æ b z
 black	b l æ k
-blackadder	b l æ k æ d ə ɹ
+blackadder	b l æ k æ ɚ
 blackamoor	b l æ k ə m ɔ ɹ
 blackamoor	b l æ k ə m ʊ ɹ
 blackball	b l æ k b ɔː l
-blackberry	b l æ k b e ɹ i
+blackberry	b l æ k b ɛ ɹ i
 blackbird	b l æ k b ɚ d
 blackboard	b l æ k b o ɹ d
 blackboard	b l æ k b ɔ ɹ d
@@ -8659,14 +8720,14 @@ blaeberry	b l e ɪ b ə ɹ i
 blaenrhondda	b l a ɪ n r ɒ n ð ə
 blag	b l æ ɡ
 blaggard	b l æ ɡ ə d
-blagger	b l æ ɡ ə ɹ
+blagger	b l æ ɡ ɚ
 blagoveshchensk	b l ɑ ɡ ə v ɛ ʃ t͡ʃ ɛ n s k
 blah	b l a
 blahaj	b l o ʊ h a ɪ
 blahaj	b l ɑː h ɑː ʒ
 blain	b l e ɪ n
 blaine	b l e ɪ n
-blair	b l ɛ ə ɹ
+blair	b l ɛ ɚ
 blaisdon	b l e ɪ z d ə n
 blake	b l e ɪ k
 blamable	b l e ɪ m ə b ə l
@@ -8686,8 +8747,8 @@ blanchability	b l æ n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l æ n ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n ʃ ə b ɪ l ɪ t i
-blancher	b l æ n t͡ʃ ə ɹ
-blancher	b l ɑː n t͡ʃ ə ɹ
+blancher	b l æ n t͡ʃ ɚ
+blancher	b l ɑː n t͡ʃ ɚ
 blancmange	b l ə m ɑ n d͡ʒ
 blanco	b l æ ŋ k ə ʊ
 bland	b l æ n d
@@ -8700,7 +8761,7 @@ blankie	b l æ ŋ k i
 blankley	b l æ ŋ k l i
 blanquette	b l ɑ ŋ k ɛ t
 blanquette	b l ɑ̃ k ɛ t
-blare	b l ɛ ə ɹ
+blare	b l ɛ ɚ
 blarney	b l ɑ ɹ n i
 blasian	b l e ɪ ʒ ə n
 blaspheme	b l æ s f i m
@@ -8725,12 +8786,12 @@ blazer	b l e ɪ z ɚ
 blazes	b l e ɪ z ɪ z
 blazing	b l e ɪ z ɪ ŋ
 blazon	b l e ɪ z ə n
-blazoner	b l e ɪ z ə n ə ɹ
+blazoner	b l e ɪ z ə n ɚ
 blazoning	b l e ɪ z ə n ɪ ŋ
 blazonry	b l e ɪ z ə n ɹ i
 bleach	b l iː t͡ʃ
 bleached	b l iː t͡ʃ t
-bleacher	b l iː t͡ʃ ə ɹ
+bleacher	b l iː t͡ʃ ɚ
 bleaching	b l iː t͡ʃ ɪ ŋ
 blead	b l iː d
 bleak	b l iː k
@@ -8775,8 +8836,8 @@ blessedness	b l ɛ s ɪ d n ɪ s
 blesses	b l ɛ s ɪ z
 blessing	b l ɛ s ɪ ŋ
 blessings	b l ɛ s ɪ ŋ z
-blessure	b l ɛ s j ʊ ə ɹ
-blessure	b l ɛ ʃ ə ɹ
+blessure	b l ɛ s j ʊ ɚ
+blessure	b l ɛ ʃ ɚ
 blessèd	b l ɛ s ə d
 blest	b l ɛ s t
 blet	b l ɛ t
@@ -8810,7 +8871,7 @@ blindside	b l a ɪ n d s a ɪ d
 bling	b l ɪ ŋ
 blink	b l ɪ ŋ k
 blinkard	b l ɪ ŋ k ə ɹ d
-blinker	b l ɪ ŋ k ə ɹ
+blinker	b l ɪ ŋ k ɚ
 blinks	b l ɪ ŋ k s
 blinky	b l ɪ ŋ k i
 blip	b l ɪ p
@@ -8826,7 +8887,7 @@ blithedale	b l a ɪ θ d e ɪ l
 blitheful	b l a ɪ ð f ʊ l
 blitheful	b l a ɪ θ f ʊ l
 blithely	b l a ɪ ð l i
-blither	b l a ɪ ð ə ɹ
+blither	b l a ɪ ð ɚ
 blither	b l ɪ ð ɚ
 blitz	b l ɪ t s
 blitzed	b l ɪ t s t
@@ -9108,7 +9169,7 @@ boiling	b ɔ ɪ l ɪ ŋ
 boilings	b ɔ ɪ l ɪ ŋ z
 boils	b ɔ ɪ l z
 boinc	b ɔ ɪ ŋ k
-boing	b o ɪ ŋ
+boing	b ɔ ɪ ŋ
 boingy	b ɔ ɪ ŋ ɡ iː
 boink	b ɔ ɪ ŋ k
 boise	b ɔ ɪ s iː
@@ -9181,6 +9242,7 @@ bonanza	b ə n æ n z ə
 bonapartism	b o ʊ n ə p ɑ ɹ t ɪ z ə m
 bonavista	b o ʊ n ə v ɪ s t ə
 bonbright	b ɔ n b ɹ a ɪ t
+bonce	b ɒ n s
 bond	b ɑ n d
 bondage	b ɑ n d ɪ d͡ʒ
 bonds	b ɑ n d z
@@ -9202,7 +9264,7 @@ bonism	b ɑ n ɪ z ə m
 bonjour	b ɑ n ʒ ʊ ɹ
 bonk	b ɑ ŋ k
 bonk	b ɔ ŋ k
-bonkers	b ɒ ŋ k ɚ z
+bonkers	b ɑ ŋ k ɚ z
 bonkler	b ɒ ŋ k l ɚ
 bonnet	b ɑ n ɪ t
 bonnie	b ɒ n i
@@ -9213,6 +9275,7 @@ bonsai	b ɑ n z a ɪ
 bonspiel	b ɑ n s p iː l
 bonus	b o ʊ n ə s
 bony	b o ʊ n i
+bonytail	b o ʊ n i t e ɪ l
 bonza	b ɒ n z ə
 bonze	b ɒ n z
 bonzer	b ɒ n z ə
@@ -9239,6 +9302,7 @@ bookie	b ʊ k i
 booking	b ʊ k ɪ ŋ
 bookings	b ʊ k ɪ ŋ z
 bookish	b ʊ k ɪ ʃ
+bookkeeping	b ʊ k k iː p ɪ ŋ
 booklegging	b ʊ k l ɛ ɡ ɪ ŋ
 booklet	b ʊ k l ə t
 booklist	b ʊ k l ɪ s t
@@ -9296,6 +9360,7 @@ booths	b uː ð z
 booths	b uː θ s
 bootikin	b uː t ɪ k ɪ n
 bootle	b uː t ə l
+bootleggery	b uː t l ɛ ɡ ə ɹ i
 boots	b uː t s
 bootstrap	b uː t s t ɹ æ p
 bootsy	b u t s i
@@ -9356,6 +9421,7 @@ borromean	b ɒ r ə m iː ə n
 borrovian	b ə ɹ o ʊ v i ə n
 borrow	b ɑ ɹ o ʊ
 borrowed	b ɑ ɹ o ʊ d
+borrowed	b ɔ ɹ o ʊ d
 borsch	b ɔ ɹ ʃ
 borscht	b ɔ ɹ ʃ t
 bortezomib	b ɔ ɹ t ɛ z o ʊ m ɪ b
@@ -9366,6 +9432,7 @@ bosanquet	b o ʊ z ə n k ɛ t
 bosanquet	b o ʊ z ə n k ɪ t
 boscage	b ɑ s k ɪ d͡ʒ
 bose	b o ʊ s
+bosentan	b ə ʊ s ɛ n t æ n
 bosh	b ɑ ʃ
 bosk	b ɑ s k
 bosket	b ɒ s k ɪ t
@@ -9383,6 +9450,7 @@ bosque	b ɑ s k
 bosque	b ɑ s k e ɪ
 bosques	b ɒ s k e ɪ z
 boss	b ɔ s
+bossale	b o ʊ s æ l
 bossman	b ɔ s m æ n
 bossy	b ɔ s i
 boston	b ɔ s t ə n
@@ -9412,10 +9480,12 @@ bottler	b ɑ t l̩ ɚ
 bottler	b ɑ t ə l ɚ
 bottles	b ɑ t l̩ z
 bottom	b ɑ t ə m
-bottomless	b a ɾ ə m l ɨ s
+bottomless	b a ɾ ə m l ɪ s
 bottoms	b ɑ t ə m s
 botty	b ɒ t i
 botulism	b ɑ t͡ʃ ə l ɪ z ə m
+botw	b ɑː t w ə
+botw	b ɔː t w ə
 botwood	b ɒ t w ʊ d
 bouche	b uː ʃ
 bouclé	b uː k l e ɪ
@@ -9433,6 +9503,9 @@ bougainvillea	b o ʊ ɡ ə n v ɪ l j ə
 bougainvillea	b u ɡ ə n v ɪ l j ə
 bougar	b u ɡ ɚ
 bouge	b uː d͡ʒ
+bouget	b uː d ʒ ɛ t
+bouget	b uː d ʒ ɪ t
+bouget	b uː ɡ ɛ t
 bough	b a ʊ
 boughs	b a ʊ z
 bought	b ɔ t
@@ -9452,6 +9525,8 @@ boulder	b o ʊ l d ə ɹ
 boule	b uː l
 bouleutic	b o ʊ l j u ɾ ɪ k
 boulevard	b ʊ l ə v ɑ ɹ d
+boulevardier	b ʊ l ə v ɑ ɹ d j e ɪ
+boulevardier	b ʊ l ə v ɑ ɹ d ɪ ɹ
 boulogne	b ə l ɔ ɪ n
 boulogne	b ʊ l ɔ ɪ n
 boulton	b o ʊ l t ə n
@@ -9566,11 +9641,12 @@ boyfriend	b ɔ ɪ f ɹ ɛ n d
 boyhood	b ɔ ɪ h ʊ d
 boyish	b ɔ ɪ ɪ ʃ
 boykin	b ɔ ɪ k ə n
+boymoder	b ɔ ɪ m o ʊ d ɚ
 boys	b ɔ ɪ z
 boysenberry	b ɔ ɪ z n̩ b ɛ ɹ i
 bozal	b o ʊ s æ l
 bozal	b o ʊ z æ l
-bozo	b o ʊ z o ʊ
+bozo	b ə ʊ z ə ʊ
 boötes	b o ʊ o ʊ t iː z
 bra	b ɹ ɑː
 braai	b ɹ a ɪ
@@ -9698,6 +9774,7 @@ branny	b ɹ æ n i
 brans	b ɹ æ n z
 branson	b ɹ æ n s ə n
 brant	b ɹ æ n t
+branta	b r æ n t ə
 brantle	b ɹ æ n t ə l
 brash	b ɹ æ ʃ
 brass	b ɹ æ s
@@ -9765,6 +9842,7 @@ breachings	b ɹ iː t͡ʃ ɪ ŋ z
 bread	b ɹ ɛ d
 breadalbane	b r ə d ɔː l b æ n
 breadbasket	b ɹ ɛ d b æ s k ɪ t
+breadbox	b ɹ ɛ d b ɑ k s
 breadcrumb	b ɹ ɛ d k r ʌ m
 breadfruit	b ɹ e d f ɹ uː t
 breadmaker	b ɹ ɛ d m e ɪ k ɚ
@@ -9810,7 +9888,7 @@ breathe	b ɹ i ð
 breathed	b ɹ iː ð d
 breathed	b ɹ ɛ θ t
 breathes	b ɹ iː ð z
-breathing	b ɹ iː ð ɪ ŋ
+breathing	b ɹ i ð ɪ ŋ
 breathings	b ɹ iː ð ɪ ŋ z
 breathless	b ɹ ɛ θ l ə s
 breaths	b ɹ ɛ θ s
@@ -10223,6 +10301,7 @@ bruv	b ɹ ʌ v
 bruvver	b ɹ ʌ v ɚ
 brux	b ɹ ʌ k s
 bruxism	b ɹ ʌ k s ɪ z ə m
+bruz	b ɹ ʌ z
 bryan	b ɹ a ɪ ə n
 bryanite	b ɹ a ɪ ə n a ɪ t
 bryant	b ɹ a ɪ ə n t
@@ -10260,9 +10339,9 @@ buccal	b ʌ k ə l
 buccally	b ʌ k ə l i
 buccaneer	b ʌ k ə n ɪ ə ɹ
 buccinator	b ʌ k s ə n e ɪ t ɚ
-buccoapical	b ʌ k o ʊ e ɪ p ɨ k l̩
-buccocervical	b ʌ k o ʊ s ɝː v ɨ k l̩
-buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɨ v l̩
+buccoapical	b ʌ k o ʊ e ɪ p ɪ k l̩
+buccocervical	b ʌ k o ʊ s ɝː v ɪ k l̩
+buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɪ v l̩
 buccolabial	b ʌ k o ʊ l e ɪ b i l̩
 buccolingual	b ʌ k o ʊ l ɪ ŋ ɡ w ə l
 buccopalatal	b ʌ k o ʊ p æ l ə t ə l
@@ -10589,6 +10668,7 @@ burr	b ɝ
 burra	b ʌ ɹ ə
 burrampooter	b ʌ r ə m p uː t ə r
 burrata	b ə ɹ ɑ t ə
+burrel	b ʌ ɹ ə l
 burrito	b ə ɹ i t o ʊ
 burro	b ɝ o ʊ
 burro	b ʊ ɹ o ʊ
@@ -10599,7 +10679,7 @@ burrstone	b ɚ s t o ʊ n
 burscough	b ɜː ɹ s k ə
 bursiform	b ɝ s ɪ f ɔ ɹ m
 bursledon	b ɜː ɹ z ə l d ə n
-burst	b ɚ s t
+burst	b ɝ s t
 bursting	b ɝ s t ɪ ŋ
 burt	b ɝ t
 burthen	b ɝ ð n̩
@@ -10659,7 +10739,7 @@ busts	b ʌ s t s
 busty	b ʌ s t i
 busulfan	b j uː s ʌ l f æ n
 busy	b ɪ z i
-busyness	b ɪ z ɪ n ə s
+busyness	b ɪ z ɪ n ɪ s
 but	b ʌ t
 but's	b ʌ t s
 butabarbital	b j u t ə b ɑ ɹ b ɪ t ɔ l
@@ -10817,6 +10897,9 @@ cacahuatepec	k ɑː k ə w ɑː t ɛ p ɛ k
 cacao	k ə k a ʊ̯
 cacao	k ə k e ɪ̯ o ʊ̯
 cacciatore	k ɑ t͡ʃ ə t ɔ ɹ i
+cachaemia	k æ k iː m i ə
+cachaemic	k æ k iː m ɪ k
+cachaemic	k æ k ɛ m ɪ k
 cachalot	k æ ʃ ə l ɑ t
 cachaça	k ə ʃ ɑː s ə
 cache	k e ɪ ʃ
@@ -10842,6 +10925,7 @@ cacoethics	k a k ə ʊ ɛ θ ɪ k s
 cacogamy	k ə k ɒ ɡ ə m i
 cacogenic	k æ k ə d͡ʒ ɛ n ɪ k
 cacology	k ə k ɒ l ə d͡ʒ i
+cacophonic	k ə k ɒ f ə n ɪ k
 cacophonous	k ə k ɑ f ə n ə s
 cacophony	k ə k ɑ f ə n i
 cacti	k æ k t a ɪ
@@ -10918,6 +11002,7 @@ cagey	k e ɪ d͡ʒ i
 cagliari	k æ l j ə ɹ i
 cagliari	k ɑː l j ə ɹ i
 cagot	k ə ɡ o ʊ
+cahier	k a ɪ j e ɪ
 cahokia	k ə h o ʊ k i ə
 cahoot	k ə h uː t
 cahoots	k ə h uː t s
@@ -11018,8 +11103,9 @@ calgary	k æ l ɡ ɹ i
 calgary	k æ l ɡ̩ ɹ i
 cali	k æ l i
 caliban	k æ l ɪ b æ n
+caliber	k æ l ə b ɚ
 caliber	k æ l ɪ b ɚ
-calibrate	k æ l ɪ b ɹ e ɪ t
+calibrate	k æ l ə b ɹ e ɪ t
 calibration	k æ l ɪ b ɹ e ɪ ʃ ə n
 calibre	k æ l ə b ɚ
 caliche	k ə l i t͡ʃ i
@@ -11033,12 +11119,11 @@ caliginous	k ə l ɪ d͡ʒ ə n ə s
 calipash	k æ l ɪ p æ ʃ
 calipee	k æ l ɪ p iː
 caliper	k æ l ɪ p ɚ
-calipers	k æ l ɨ p ɚ z
+calipers	k æ l ɪ p ɚ z
 caliph	k e ɪ l ɪ f
 caliph	k æ l ɪ f
 caliphate	k æ l ɪ f e ɪ t
 calk	k æ l k
-call	k ɑ l
 call	k ɔ l
 call't	k ɔː l t
 callahan	k æ l ə h ə n
@@ -11120,7 +11205,7 @@ cama	k ɑː m ə
 camail	k æ m e ɪ l
 camail	k ə m e ɪ l
 camaldolese	k ə m ɑ l d ə l i z
-camaraderie	k æ m ə ɹ æ d ə ɹ i
+camaraderie	k æ m ə ɹ ɑ d ə ɹ i
 camaraderie	k ɑ m ə ɹ ɑ d ə ɹ i
 camas	k æ m ɪ s
 camas	k ɑː m ə z
@@ -11243,6 +11328,7 @@ candelabrum	k æ n d l̩ ɑ b ɹ ə m
 candelabrum	k æ n d ɪ l e ɪ b ɹ ə m
 candian	k æ n d ɪ ə n
 candid	k æ n d ɪ d
+candidacy	k æ n d ɪ d ə s i
 candidate	k æ n d ɪ d e ɪ t
 candidate	k æ n d ɪ d ɪ t
 candidate	k æ n ɪ d e ɪ t
@@ -11472,6 +11558,7 @@ caracole	k æ ɹ ə k ə ʊ l
 carafe	k ə ɹ æ f
 caragana	k æ ɹ ə ɡ ɑː n ə
 caragana	k ɑː ɹ ə ɡ ɑː n ə
+carambola	k æ ɹ ə m b ə ʊ l ə
 caramel	k æ ɹ ə m ə l
 caramel	k æ ɹ ə m ɛ l
 caramel	k ɑ ɹ m ə l
@@ -11489,7 +11576,9 @@ caravaggesque	k ɑ ɹ ə v ɑ d͡ʒ ɛ s k
 caravaggio	k æ ɹ ə v ɑ d͡ʒ i o ʊ
 caravaggio	k ɑ ɹ ə v ɑ d͡ʒ i o ʊ
 caravan	k æ ɹ ə v æ n
-caravanserai	k ɑ ɹ ə v æ n s ə ɹ a ɪ
+caravansary	k ɛ ɹ ə v æ n s ə ɹ i
+caravanserai	k ɛ ɹ ə v æ n s ə ɹ a ɪ
+caravanserial	k ɛ ɹ ə v æ n s ə ɹ i ə l
 caravel	k æ ɹ ə v ɛ l
 caraway	k ɛ ɹ ə w e ɪ
 carb	k ɑ ɹ b
@@ -11655,7 +11744,7 @@ carnaby	k ɑː ɹ n ə b i
 carnage	k ɑ ɹ n ɪ d͡ʒ
 carnal	k ɑ ɹ n ə l
 carnaroli	k ɑ ɹ n ə ɹ o ʊ l i
-carnatic	k ɑ ɹ n æ t ɨ k
+carnatic	k ɑ ɹ n æ t ɪ k
 carnation	k ɑ ɹ n e ɪ ʃ ə n
 carnaval	k ɑ ɹ n ə v ɑ l
 carnegie	k ɑ ɹ n e ɪ ɡ i
@@ -11720,15 +11809,13 @@ carriage	k æ ɹ ɪ d͡ʒ
 carriage	k ɛ ɹ ɪ d͡ʒ
 carriages	k ɛ ɹ ɪ d͡ʒ ɪ z
 carrickmacross	k æ ɹ ɪ k m ə k ɹ ɒ s
-carrie	k æ r i
+carrie	k æ ɹ i
 carrier	k æ ɹ ɪ ɚ
 carrillo	k ə ɹ ɪ l o ʊ
 carrion	k æ ɹ i ə n
 carrol	k ɛ ɹ ə l
 carroll	k æ ɹ ə l
 carronade	k ɛ ɹ ə n e ɪ d
-carrot	k æ ɹ ə t
-carrot	k ɛ ɹ ə t
 carrow	k æ ɹ ə ʊ
 carrying	k æ ɹ i ɪ ŋ
 carrying	k ɛ ɹ i ɪ ŋ
@@ -11930,6 +12017,7 @@ catatonia	k æ t ə t o ʊ n i ə
 catatonic	k æ t ə t ɑ n ɪ k
 catawampus	k æ t ə w ɑ m p ə s
 catbird	k a t b ɝ d
+catcall	k æ t k ɔ l
 catch	k æ t͡ʃ
 catch	k ɛ t͡ʃ
 catchee	k æ t͡ʃ i
@@ -11948,6 +12036,8 @@ catechol	k æ t ə k ɔ l
 catechu	k æ t ə t͡ʃ uː
 catechu	k æ t ə ʃ uː
 catechumen	k æ t ə k j u m ə n
+catechumenate	k æ t ɪ k j uː m ə n e ɪ t
+catechumenate	k æ t ɪ k j uː m ə n ə t
 categorially	k æ t ə ɡ ɒ ɹ ɪ ə l i
 categorical	k æ t ə ɡ ɔ ɹ ɪ k ə l
 categories	k æ t ə ɡ ɔ ɹ i z
@@ -11958,10 +12048,11 @@ cater	k e ɪ t ə ɹ
 cater	k e ɪ t ɚ
 caterer	k e ɪ t ə ɹ ə ɹ
 catering	k e ɪ t ə ɹ ɪ ŋ
+catering	k e ɪ t ɚ ɪ ŋ
 caterpillar	k æ t ə p ɪ l ɚ
 caterpillar	k æ t ɚ p ɪ l ɚ
 caterwaul	k æ t ɚ w ɔ l
-caterwauling	k æ t ə ɹ w ɑ l ɪ ŋ
+caterwauling	k æ t ɚ w ɔ l ɪ ŋ
 catesby	k e ɪ t s b i
 catfighting	k æ t f a ɪ t ɪ ŋ
 catfucker	k æ t f ʌ k ɚ
@@ -12001,6 +12092,10 @@ catloaf	k æ t l o ʊ f
 catmint	k æ t m ɪ n t
 catnip	k a t n ɪ p
 cato	k e ɪ t o ʊ
+catoblepas	k æ t o ʊ b l iː p ə s
+catoblepas	k æ t o ʊ b l ɛ p ə s
+catoblepas	k æ t o ʊ b l ɪ p ə s
+catoblepas	k ə t ɒ b l ɪ p ə s
 catridge	k æ t ɹ ɪ d͡ʒ
 catron	kʰ æ t r ə n
 cats	k æ t s
@@ -12035,6 +12130,9 @@ caulini	k ɑ l iː n i
 caulini	k ɔ l iː n i
 caulk	k ɔː k
 cauma	k a ʊ m ə
+causal	k ɔ z ə l
+causality	k ɔ z æ l ɪ t ɪ
+causation	k ɔ z e ɪ ʃ ə n
 causative	k ɔ z ə t ɪ v
 causator	k ɔː z e ɪ t ə ɹ
 cause	k ɔ z
@@ -12174,7 +12272,7 @@ celecoxib	s ɛ l ə k ɑ k s ɪ b
 celeriac	s ə l ɛ ə ɹ i æ k
 celeriac	s ə l ɪ ə ɹ i æ k
 celerity	s ɪ l ɛ ɹ ɪ t i
-celery	s ɛ l ə ɹ i
+celery	s ɛ l ɚ i
 celesta	s ə l ɛ s t ə
 celeste	s ə l ɛ s t
 celestial	s ə l ɛ s t i ə l
@@ -12195,7 +12293,6 @@ cells	s ɛ l z
 celluloid	s ɛ l j ə l ɔ ɪ d
 cellulose	s ɛ l j ʊ l ə ʊ z
 celly	s ɛ l i
-celsius	s ɛ l s i ə s
 celt	k ɛ l t
 celt	s ɛ l t
 celta	s ɛ l t ə
@@ -12299,6 +12396,7 @@ cephalopod	s ɛ f a l a p ɑ d
 cephalosporin	k ɛ f ə l ə ʊ s p ɔ ə ɹ ɪ n
 cephalothorax	s ɛ f ə l ə θ ɑ ɹ æ k s
 cephalothorax	s ɛ f ə l ə θ ɔ ɹ æ k s
+cephas	s i f ə s
 cepheus	s iː f i ə s
 cepheus	s iː f j uː s
 cepstrum	k ɛ p s t ɹ ə m
@@ -12339,14 +12437,15 @@ ceremonies	s ɛ ɹ ɪ m o ʊ n i z
 ceremony	s ɛ ɹ ə m o ʊ n i
 cereology	s ɪ ə ɹ ɪ ɑ l ə d͡ʒ i
 cereous	s ɪ ə ɹ i ə s
-cererian	s ɨ ɹ ɪ ə ɹ i ə n
+cererian	s ə ɹ ɪ ə ɹ ɪ ə n
 ceres	s ɪ ə ɹ iː z
-ceresian	s ɨ ɹ iː z i ə n
+ceresian	s ə ɹ iː z i ə n
 cerise	s ə ɹ iː s
 cerise	s ə ɹ iː z
 cerium	s ɪ ə ɹ i ə m
 cernuous	s ɜː ɹ n j u ə s
 cerrial	s ɛ ɹ i ə l
+cerrigceinwen	k ɛ r ɪ ɡ k ɛ i n ʊ ɛ n
 certain	s ɝ t n̩
 certain	s ɝ ʔ n̩
 certainly	s ɝ t n̩ l i
@@ -12367,7 +12466,7 @@ cervantes	s ə v æ n t iː z
 cervantes	s ɛ ə v ɑː n t e ɪ z
 cervelliere	s ɛ ɹ v ə l j ɛ ə ɹ
 cervical	s ɝ v ɪ k l̩
-cervices	s ɝ v ɨ s iː z
+cervices	s ɝ v ɪ s iː z
 cervidae	s ə ɹ v ə d i
 cervix	s ɝ v ɪ k s
 cervus	s ə ɹ v ə s
@@ -12431,7 +12530,7 @@ chainings	t͡ʃ e ɪ n ɪ ŋ z
 chainring	t͡ʃ e ɪ n ɹ ɪ ŋ
 chains	t͡ʃ e ɪ n z
 chainsaw	t͡ʃ e ɪ n s ɔː
-chair	t͡ʃ ɛ ə ɹ
+chair	t͡ʃ ɛ ɚ
 chairman	t ʃ ɛ ɹ m ə n
 chairness	t͡ʃ ɛ ɹ n ə s
 chairs	t͡ʃ ɛ ɹ z
@@ -12445,7 +12544,7 @@ chakra	t͡ʃ ʌ k ɹ ə
 chalaza	k ə l e ɪ z ə
 chalazion	k ə l e ɪ z i ə n
 chalcanthite	k æ l k æ n θ a ɪ t
-chalcedon	k æ l s ɪ d ɑː n
+chalcedon	k æ l s ə d ɑ n
 chalcedony	k æ l s ə d o ʊ n i
 chalcedony	k æ l s ɛ d ə n i
 chalcis	k æ l s ɪ s
@@ -12465,6 +12564,7 @@ challenged	t͡ʃ æ l ə n d͡ʒ d
 challenging	t͡ʃ æ l ə n d͡ʒ ɪ ŋ
 challenging	t͡ʃ æ l ɪ n d͡ʒ ɪ ŋ
 challis	ʃ æ l i
+challoch	t ʃ æ l ə x
 chalmette	ʃ æ l m ɛ t
 chalmette	ʃ ɛ l m ɛ t
 chalumeau	ʃ æ l ʊ m ə ʊ
@@ -12581,7 +12681,7 @@ chaplain	t͡ʃ æ p l ɪ n
 chaplet	t͡ʃ æ p l ə t
 chaplet	t͡ʃ æ p l ɪ t
 chapleted	t͡ʃ æ p l ə t ə d
-chapleted	t͡ʃ æ p l ɨ ɾ ɨ d
+chapleted	t͡ʃ æ p l ɪ ɾ ɨ d
 chaplin	t͡ʃ æ p l ɪ n
 chapman	t͡ʃ æ p m ə n
 chappe	ʃ æ p
@@ -12600,8 +12700,6 @@ char	k ɛ ɹ
 char	t͡ʃ a ɹ
 char	t͡ʃ ɑ ɹ
 charact	k æ ɹ æ k t
-character	k æ ɹ ə k t ɚ
-character	k ɛ ɹ ə k t ɚ
 characteristic	k ɛ ɹ ə k t ə ɹ ɪ s t ɪ k
 characteristics	k ɛ ɹ ə k t ə ɹ ɪ s t ɪ k s
 characterize	k æ ɹ ə k t ə ɹ a ɪ z
@@ -12623,7 +12721,7 @@ chardonnay	ʃ ɑː ɹ d ə n e ɪ
 chare	t͡ʃ ɛ ɹ
 charette	ʃ ə ɹ ɛ t
 charge	t͡ʃ ɑ ɹ d͡ʒ
-charged	t͡ʃ ɑː d͡ʒ d
+charged	t͡ʃ ɑ ɹ d͡ʒ d
 chargeous	t͡ʃ ɑː ɹ d͡ʒ ə s
 charger	t͡ʃ ɑ ɹ d͡ʒ ɚ
 charges	t͡ʃ ɑ ɹ d͡ʒ ɪ z
@@ -12657,7 +12755,6 @@ charms	t͡ʃ ɑ ɹ m z
 charon	k ɛ ə ɹ ɑ n
 charon	k ɛ ə ɹ ə n
 charon	ʃ ɛ ə ɹ ɑ n
-charon	ʃ ɛ ə ɹ ə n
 charonean	k æ r ə n iː ə n
 charonian	k ə r o ʊ n ɪ ə n
 charontean	k ə r ɒ n t ɪ ə n
@@ -13047,7 +13144,6 @@ chilaquiles	t͡ʃ i l ə k i l e ɪ s
 chilblain	t͡ʃ ɪ l b l e ɪ n
 chilcotin	t͡ʃ ɪ l k o ʊ t ɪ n
 child	t͡ʃ a ɪ l d
-child	t͡ʃ a ɪ ə l d
 childbed	t͡ʃ a ɪ l d b ɛ d
 childe	t͡ʃ a ɪ l d
 childer	t͡ʃ ɪ l d ə r
@@ -13088,6 +13184,7 @@ chiltepin	t͡ʃ ɪ l t ɛ p ɪ n
 chilver	t͡ʃ ɪ l v ə ɹ
 chimbley	t͡ʃ ɪ m b l i
 chimed	t͡ʃ a ɪ m d
+chimenea	t ʃ ɪ m ə n e ɪ ə
 chimera	k a ɪ m ɪ ɹ ə
 chimera	k ə m ɪ ɹ ə
 chimerical	k ɪ m ɛ ɹ ɪ k ə l
@@ -13125,6 +13222,8 @@ chinned	t͡ʃ ɪ n d
 chinning	t͡ʃ ɪ n ɪ ŋ
 chinny	t͡ʃ ɪ n i
 chinoiserie	ʃ iː n w ɑː z ə ɹ iː
+chinone	k a ɪ n ə ʊ n
+chinone	k ɪ n ə ʊ n
 chinook	t͡ʃ ɪ n uː k
 chinook	ʃ ɪ n ʊ k
 chinquapin	t͡ʃ ɪ n k ə p ɪ n
@@ -13140,8 +13239,10 @@ chipmunk	t͡ʃ ɪ p m ʌ ŋ k
 chipolata	t͡ʃ ɪ p ə l ɑː t ə
 chipotle	t͡ʃ ɪ p o ʊ t l e ɪ
 chipotle	t͡ʃ ɪ p o ʊ t l i
-chipotle	t͡ʃ ɪ p ɒ t l e ɪ
-chipotle	t͡ʃ ɪ p ɒ t l i
+chipotle	t͡ʃ ɪ p ɑ t l e ɪ
+chipotle	t͡ʃ ɪ p ɑ t l i
+chipotle	t͡ʃ ɪ p ɔ t l e ɪ
+chipotle	t͡ʃ ɪ p ɔ t l i
 chipped	t͡ʃ ɪ p t
 chippendale	t͡ʃ ɪ p n̩ d e ɪ l
 chipper	t͡ʃ ɪ p ɚ
@@ -13161,7 +13262,7 @@ chiromancy	k a ɪ ɹ ə ʊ m æ n s i
 chiron	k a ɪ ɹ ə n
 chiropodist	k ɪ r ɒ p ə d ɪ s t
 chiropterologist	k a ɪ ɹ ɑ p t ə ɹ ɑ l ə d͡ʒ ɪ s t
-chirp	t͡ʃ ɝ p
+chirp	t͡ʃ ɚ p
 chirpy	t͡ʃ ɜː ɹ p i
 chirr	t͡ʃ ɝ
 chirren	t͡ʃ ɪ ɹ ə n
@@ -13174,6 +13275,8 @@ chirurgy	k a ɪ ɹ ɜː ɹ d͡ʒ i
 chirurgy	k ɪ ɹ ɜː ɹ d͡ʒ i
 chisel	t͡ʃ ɪ z ə l
 chiseled	t͡ʃ ɪ z ə l d
+chislic	t͡ʃ ɪ s l ɪ k
+chislic	t͡ʃ ɪ z l ɪ k
 chiswick	t͡ʃ ɪ z ɪ k
 chit	t͡ʃ ɪ t
 chita	t͡ʃ ɪ t ə
@@ -13243,7 +13346,7 @@ chocotini	t͡ʃ ɔ k ə t i n i
 choctaw	t͡ʃ ɒ k t ɔː
 chode	t͡ʃ o ʊ d
 choenix	k iː n ɪ k s
-choi	t ʃʰ ɔ ɪ
+choi	t ʃ ɔ ɪ
 choice	t͡ʃ ɔ ɪ s
 choiceful	t͡ʃ ɔ ɪ s f ə l
 choices	t͡ʃ ɔ ɪ s ɪ z
@@ -13271,7 +13374,7 @@ cholla	t͡ʃ ɔ ɪ ə
 cholo	t͡ʃ o ʊ l o ʊ
 chomo	t͡ʃ o ʊ m o ʊ
 chomophyte	k ə ʊ m ə ʊ f a ɪ t
-chomp	t͡ʃ ɔ m p
+chomp	t͡ʃ ɑ m p
 chomps	t͡ʃ ɔ m p s
 chon	t͡ʃ ɑ n
 chondrite	k ɒ n d ɹ a ɪ t
@@ -13309,6 +13412,7 @@ choregus	k ə ɹ iː ɡ ə s
 choreograph	k ɔ ɹ j ə ɡ ɹ æ f
 choreography	k ɔ ɹ i ɒ ɡ ɹ ə f i
 chori	k ɔ ɹ a ɪ
+choric	k ɔ ɹ ɪ k
 chorion	k ɔ ɹ i ɑ n
 chorister	k ɔ ɹ ɪ s t ə ɹ
 chorizo	t ʃ ə ɹ i s o ʊ
@@ -13404,12 +13508,14 @@ chrysocolla	k ɹ ɪ s ə k ɑ l ə
 chrysolite	k ɹ ɪ s ə l a ɪ t
 chrysostom	k ɹ ɪ s ə s t ə m
 chrysotile	k ɹ ɪ s ə t ɪ l
+chthamaloid	θ æ m ə l ɔ ɪ d
 chthonian	k θ o ʊ n i ə n
 chthonian	θ ʊ n i ə n
 chthonic	θ ɑ n ɪ k
 chthonophagia	θ ɑ n o ʊ f e ɪ d͡ʒ i ə
 chu	t ʃ u
 chub	t͡ʃ ʌ b
+chubasco	t ʃ uː b ɑː s k ə ʊ
 chubby	t͡ʃ ʌ b i
 chubs	t͡ʃ ʌ b z
 chubster	t͡ʃ ʌ b s t ɚ
@@ -13473,6 +13579,7 @@ churl	t͡ʃ ɝ l
 churlish	t͡ʃ ɝː l ɪ ʃ
 churly	t͡ʃ ɜː ɹ l i
 churn	t͡ʃ ɝ n
+churnalism	t ʃ əː n ə l ɪ z ə m
 churrasco	t͡ʃ ʊ ɹ æ s k ə ʊ
 churrasco	t͡ʃ ʊ ɹ ɑː s k ə ʊ
 churro	t͡ʃ ɜ ɹ o ʊ
@@ -13561,8 +13668,10 @@ cinching	s ɪ n t͡ʃ ɪ ŋ
 cinchona	s ɪ ŋ k o ʊ n ə
 cinchophen	s ɪ ŋ k ə f ɛ n
 cinchy	s ɪ n t͡ʃ i
-cincinnati	s ɪ n s ɨ n æ t i
-cincinnati	s ɪ n s ɨ n æ t ə
+cincinnati	s ɪ n s ɪ n æ t i
+cincinnati	s ɪ n s ɪ n æ t ə
+cincinnatus	s ɪ n s ɪ n e ɪ t ə s
+cincinnatus	s ɪ n s ɪ n ɑː t ə s
 cincture	s ɪ ŋ k t͡ʃ ə ɹ
 cinder	s ɪ n d ɚ
 cinderella	s ɪ n d ə ɹ ɛ l ə
@@ -13581,12 +13690,13 @@ cinnabar	s ɪ n ə b ɑː ɹ
 cinnamon	s ɪ m ɪ n
 cinnamon	s ɪ n ə m ə n
 cinnamon	s ɪ n ə m ɪ n
-cinquain	s ɪ n k e n
+cinquain	s æ ŋ k e ɪ n
+cinquain	s ɪ ŋ k e ɪ n
 cinque	s æ ŋ k
 cinque	s ɪ ŋ k
 cinquecentist	t͡ʃ i ŋ k w ə t͡ʃ ɛ n t ɪ s t
-cinquedea	t͡ʃ ɪ ŋ k w ɨ d e ɪ ə
-cinquedea	t͡ʃ ɪ ŋ k w ɨ d i ə
+cinquedea	t͡ʃ ɪ ŋ k w ɪ d e ɪ ə
+cinquedea	t͡ʃ ɪ ŋ k w ɪ d i ə
 cinquefoil	s ɪ ŋ k f ɔ ɪ l
 cinques	s ɪ ŋ k s
 cipher	s a ɪ f ɚ
@@ -13622,7 +13732,7 @@ circuline	s ɜː ɹ k j ʊ l a ɪ n
 circumambulate	s ɝ k ə m æ m b j u l e ɪ t
 circumambulation	s ɝ k ə m æ m b j u l e ɪ ʃ ə n
 circumaural	s ɝ k ʌ m a ɹ ʌ l
-circumbendibus	s ɝ k m̩ b ɛ n d ɨ b ə s
+circumbendibus	s ɝ k m̩ b ɛ n d ɪ b ə s
 circumcellion	s ɜː k ə m s ɛ l ɪ ə n
 circumclusion	s ɜː ɹ k ə m k l uː ʒ ə n
 circumduction	s ɝ k ə m d ʌ k ʃ ə n
@@ -13895,12 +14005,14 @@ clayey	k l e ɪ i
 claying	k l e ɪ ɪ ŋ
 clays	k l e ɪ z
 clayton	k l e ɪ t ə n
+clazosentan	k l e ɪ z ə ʊ s ɛ n t æ n
 clean	k l i n
 cleaned	k l iː n d
 cleaner	k l i n ɚ
 cleaning	k l iː n ɪ ŋ
 cleanings	k l iː n ɪ ŋ z
 cleanliness	k l ɛ n l i n ə s
+cleanliness	k l ɛ n l i n ɪ s
 cleanly	k l iː n l i
 cleanly	k l ɛ n l i
 cleans	k l iː n z
@@ -13941,7 +14053,7 @@ clementine	k l ɛ m ə n t iː n
 clemizole	k l ɛ m ɪ z o ʊ l
 clen	k l ɛ n
 clench	k l ɛ n t͡ʃ
-cleopatra	k l i o ʊ p æ t ɹ ə
+cleopatra	k l iː o ʊ p æ t ɹ ə
 clepe	k l iː p
 clepsydra	k l ɛ p s ɪ d ɹ ə
 clept	k l ɛ p t
@@ -14082,6 +14194,7 @@ cloning	k l o ʊ n ɪ ŋ
 clonus	k l o ʊ n ə s
 cloom	k l uː m
 clooney	k l uː n i
+clopen	k l o ʊ p ə n
 clopenthixol	k l o ʊ p ɛ n θ ɪ k s ɔ l
 clopidogrel	k l o ʊ p ɪ d ə ɡ ɹ ɛ l
 cloque	k l o ʊ k e ɪ
@@ -14095,7 +14208,6 @@ closen	k l o ʊ s ə n
 closeness	k l ə ʊ s n ə s
 closer	k l o ʊ s ɚ
 closer	k l o ʊ z ɚ
-closer	k l ə ʊ z ɚ
 closes	k l o ʊ s ɪ z
 closes	k l o ʊ z ɪ z
 closest	k l o ʊ s ɪ s t
@@ -14202,8 +14314,8 @@ clutter	k l ʌ t ɚ
 clutton	k l ʌ t ə n
 clydach	k l ʌ d ə x
 clyde	k l a ɪ d
-clymene	k l a ɪ m ɨ n i
-clymene	k l ɪ m ɨ n i
+clymene	k l a ɪ m ɪ n i
+clymene	k l ɪ m ɪ n i
 clypei	k l ɪ p ɪ a ɪ
 clypeus	k l ɪ p ɪ ə s
 clyster	k l ɪ s t ɚ
@@ -14344,7 +14456,7 @@ codical	k ə ʊ d ɪ k ə l
 codicil	k ɒ d ɪ s ɪ l
 codicil	k ə ʊ d ɪ s ɪ l
 codies	k ə ʊ d i z
-codification	k ɑ d ɨ f ɪ k e ɪ ʃ ə n
+codification	k ɑ d ɪ f ɪ k e ɪ ʃ ə n
 codlet	k ɒ d l ə t
 codling	k ɒ d l ɪ ŋ
 codomain	k o ʊ d o ʊ m e ɪ n
@@ -14375,6 +14487,7 @@ coevous	k ə ʊ iː v ə s
 coextensive	k o ʊ ɛ k s t ɛ n s ɪ v
 coextinct	k o ʊ ɛ k s t ɪ ŋ k t
 coextinct	k o ʊ ɪ k s t ɪ ŋ k t
+cofeoffee	k o ʊ f ɛ f iː
 coffa	k ɔ f ə
 coffee	k ɔ f i
 coffeetini	k ɔ f i t i n i
@@ -14387,7 +14500,6 @@ coffin	k ɔ f ɪ n
 coffle	k ɑ f l̩
 coffle	k ɔ f l̩
 cofounder	k o ʊ f a ʊ n d ɚ
-cog	k ɑ ɡ
 cog	k ɔ ɡ
 cogent	k o ʊ d͡ʒ n̩ t
 coggery	k ɒ ɡ ə ɹ i
@@ -14515,7 +14627,8 @@ colinet	k ɑ l ɪ n ɛ t
 coll	k ɒ l
 collab	k o ʊ l æ b
 collab	k ə l æ b
-collaborate	k ə l a b ə ɹ e ɪ t
+collaborate	k ə l æ b ə ɹ e ɪ t
+collaborate	k ə l æ b ɹ e ɪ t
 collaboration	k ə l æ b ə ɹ e ɪ ʃ ə n
 collaborative	k ə l a b ə ɹ ə t ɪ v
 collaborator	k ə l æ b ə ɹ e ɪ t ɚ
@@ -14523,7 +14636,7 @@ collage	k o ʊ l ɑ ʒ
 collage	k ə l ɑ ʒ
 collagen	k ɒ l ə d͡ʒ ə n
 collagen	k ɒ l ə d͡ʒ ɪ n
-collagenous	k ə l æ d͡ʒ ɨ n ə s
+collagenous	k ə l æ d͡ʒ ɪ n ə s
 collagic	k ə l æ d͡ʒ ɪ k
 collapse	k ə l æ p s
 collar	k ɑ l ɚ
@@ -14659,7 +14772,7 @@ comber	k o ʊ m ɚ
 comber	k ɑ m b ɚ
 combi	k ɒ m b i
 combination	k ɑ m b ɪ n e ɪ ʃ ə n
-combinational	k a m b ɨ n e ɪ ʃ ɨ n ə l
+combinational	k a m b ɪ n e ɪ ʃ ɪ n ə l
 combinations	k ɑ m b ɪ n e ɪ ʃ ə n z
 combinative	k ɑ m b ɪ n e ɪ t ɪ v
 combinative	k ə m b a ɪ n ə t ɪ v
@@ -14767,6 +14880,7 @@ commentator	k ɑ m ə n t e ɪ t ə ɹ
 commented	k ɑ m ɛ n t ɪ d
 comments	k ɑ m ɛ n t s
 commerce	k ɑ m ɚ s
+commerce	k ə m ɝ s
 commercial	k ə m ɝ ʃ ə l
 comminate	k ɒ m ɪ n e ɪ t
 comminute	k ɑ m ɪ n j uː t
@@ -14812,8 +14926,10 @@ communicating	k ə m j u n ə k e ɪ t ɪ ŋ
 communication	k ə m j uː n ɪ k e ɪ ʃ ə n
 communications	k ə m j uː n ɪ k e ɪ ʃ ə n z
 communion	k ə m j uː n j ə n
-communism	k ɒ m j u n ɪ z m̩
-communist	k ɑː m j ə n ɪ s t
+communism	k ɑ m j u n ɪ z m̩
+communism	k ɑ m j ə n ɪ z m̩
+communist	k ɑ m j u n ɪ s t
+communist	k ɑ m j ə n ɪ s t
 communities	k ə m j uː n ɪ t i z
 community	k ə m j u n ə t i
 commute	k ə m j uː t
@@ -14855,7 +14971,7 @@ compartmentalize	k ə m p ɑ ɹ t m ɛ n t ə l a ɪ z
 compass	k ʌ m p ə s
 compassed	k ʌ m p ə s t
 compassion	k ə m p æ ʃ ə n
-compatibility	k ə m p æ t ɪ b ɪ l ɪ t i
+compatibility	k ə m p æ t ə b ɪ l ə t i
 compatible	k ə m p æ t ə b ə l
 compatriot	k ə m p e ɪ t ɹ i ə t
 compatriot	k ə m p æ t ɹ i ə t
@@ -14915,6 +15031,7 @@ completely	k ə m p l iː t l i
 completes	k ə m p l iː t s
 completing	k ə m p l iː t ɪ ŋ
 completion	k ə m p l iː ʃ ə n
+completist	k ə m p l iː t ɪ s t
 completory	k ə m p l iː t ə ɹ i
 complex	k ɑ m p l ɛ k s
 complex	k ə m p l ɛ k s
@@ -15067,7 +15184,7 @@ conche	k ɒ n t ʃ
 conches	k ɒ n t͡ʃ ə z
 conches	k ɒ ŋ k
 conchifer	k ɒ ŋ k ɪ f ə ɹ
-conchoidal	k ɒ n k ɔ ɪ ɪ d ə l
+conchoidal	k ɑ ŋ k ɔ ɪ d ə l
 conchology	k ɒ ŋ k ɒ l ə d͡ʒ i
 conchs	k ɒ n t͡ʃ
 conchs	k ɒ ŋ k s
@@ -15106,7 +15223,7 @@ concupiscent	k ə n k j uː p ə s ə n t
 concur	k ə n k ɝ
 concurrency	k ə ŋ k ʌ ɹ ə n s i
 concurrent	k ə ŋ k ɝ ɹ ə n t
-concussion	k ə n k ʌ ʃ n
+concussion	k ə n k ʌ ʃ n̩
 concussion	k ə n k ʌ ʃ ə n
 condemn	k ə n d ɛ m
 condemnable	k ə n d ɛ m n ə b ə l
@@ -15214,7 +15331,7 @@ conflate	k ə n f l e ɪ t
 conflation	k ə n f l e ɪ ʃ ə n
 conflict	k ɑ n f l ɪ k t
 conflict	k ə n f l ɪ k t
-conflicted	k ə n f l ɪ k t ɪ d
+conflicted	k ə n f l ɪ t ɪ d
 conflow	k ə n f l o ʊ
 confluence	k ɑ n f l u ə n s
 confluence	k ə n f l u ə n s
@@ -15289,6 +15406,7 @@ congruous	k ɑ ŋ ɡ ɹ u ə s
 conic	k ɑ n ɪ k
 conical	k ɑ n ɪ k ə l
 conifer	k ɒ n ɪ f ə ɹ
+coniferous	k ə n ɪ f ə ɹ ə s
 conivaptan	k ɑ n ə v æ p t ə n
 conject	k ə n d͡ʒ ɛ k t
 conjecture	k ə n d͡ʒ ɛ k t͡ʃ ɚ
@@ -15462,15 +15580,15 @@ constant	k ɑ n s t ə n t
 constantine	k ɑ n s t ə n t iː n
 constantinople	k ɔ n s t æ n t ɪ n ə ʊ p ə l
 constantinopolitan	k ɒ n s t æ n t ɨ n ɵ p ɒ l ɨ t ə n
-constantly	k ɑ n s t ə n t l i
+constantly	k ɑ n s t ə n ʔ l i
 constellation	k ɑ n s t ə l e ɪ ʃ ə n
 constellationally	k ɑ n s t ə l e ɪ ʃ ə n ə l i
 consternation	k ɑ n s t ɚ n e ɪ ʃ ə n
 constipate	k ɒ n s t ɪ p e ɪ t
 constipated	k ɒ n s t ə p e ɪ t ə d
 constipation	k ɒ n s t ɪ p e ɪ ʃ ə n
-constituencies	k ə n s t ɪ t j u ə n s ɨ z
-constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s ɨ z
+constituencies	k ə n s t ɪ t j u ə n s iː z
+constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s iː z
 constituency	k ə n s t ɪ t j u ə n s i
 constituency	k ə n s t ɪ t͡ʃ u ə n s i
 constituent	k ə n s t ɪ t j u ə n t
@@ -15503,7 +15621,7 @@ consubstantiation	k ɔ n s ʌ b s t n̩ ʃ i e ɪ ʃ ə n
 consuetude	k ɒ n s w ɪ t j uː d
 consuetudinal	k ɑ n s w ə t u d ɪ n ə l
 consul	k ɑ n s ə l
-consulate	k ɑ n s ə l ɨ t
+consulate	k ɑ n s ə l ɪ t
 consulate	k ɒ n s ə l ə t
 consult	k ɑ n s ʌ l t
 consult	k ə n s ʌ l t
@@ -15647,6 +15765,7 @@ controller	k ə n t ɹ o ʊ l ɚ
 controllers	k ə n t ɹ o ʊ l ɚ z
 controlling	k ə n t ɹ o ʊ l ɪ ŋ
 controls	k ə n t ɹ o ʊ l z
+controversial	k ɑ n t ɹ ə v ɝ s i ə l
 controversial	k ɑ n t ɹ ə v ɝ s j ə l
 controversial	k ɑ n t ɹ ə v ɝ ʃ ə l
 controversies	k ɑ n t ɹ ə v ɚ s i z
@@ -15763,7 +15882,7 @@ cookie	k ʊ k i
 cookies	k ʊ k i z
 cooking	k ʊ k ɪ ŋ
 cooks	k ʊ k s
-cool	k uː l
+cool	k u l
 coolant	k uː l ə n t
 cooldown	k uː l d a ʊ n
 cooled	k uː l d
@@ -15873,6 +15992,7 @@ cor	k ɔ ɹ
 coral	k ɔ ɚ ɹ ə l
 coranto	k ə ɹ æ n t ə ʊ
 coranto	k ə ɹ ɑː n t ə ʊ
+corb	k ɔː ɹ b
 corbe	k ɔː ɹ b
 corbyn	k ɔ ɹ b ɪ n
 corbynomics	k ɔ ɹ b ɪ n ɑ m ɪ k s
@@ -15952,6 +16072,7 @@ corollary	k ɔ ɹ ə l ɛ ɹ i
 corona	k ə ɹ o ʊ n ə
 coronach	k ɒ ɹ ə n ə k
 coronach	k ɒ ɹ ə n ə x
+coronado	k ɒ ɹ ə n ɑː d ə ʊ
 coronae	k ə ɹ o ʊ n iː
 coronal	k ɑ ɹ ə n ə l
 coronal	k ɔ ɹ ə n ə l
@@ -16013,8 +16134,8 @@ corresponding	k ɔ ɹ ə s p ɑ n d ɪ ŋ
 corridor	k ɔ ɹ ə d ɔ ɹ
 corridor	k ɔ ɹ ə d ɚ
 corrie	k ɒ ɹ i
-corrigendum	k ɔ ɹ ɨ d͡ʒ ɛ n d ə m
-corrigendum	k ɔ ɹ ɨ ɡ ɛ n d ə m
+corrigendum	k ɔ ɹ ɪ d͡ʒ ɛ n d ə m
+corrigendum	k ɔ ɹ ɪ ɡ ɛ n d ə m
 corrival	k ə ɹ a ɪ v ə l
 corroborate	k ə ɹ ɑ b ə ɹ e ɪ̯ t
 corroboree	k ə ɹ ɒ b ə ɹ i
@@ -16198,7 +16319,7 @@ countershed	k a ʊ n t ɚ ʃ ɛ d
 countertime	k a ʊ n t ə ɹ t a ɪ m
 countervailing	k a ʊ n t ə v e ɪ l ɪ ŋ
 counterview	k a ʊ n t ə ɹ v j uː
-countess	k a ʊ n t ɨ s
+countess	k a ʊ n t ɪ s
 counties	k a ʊ n t i z
 counting	k a ʊ n t ɪ ŋ
 countings	k a ʊ n t ɪ ŋ z
@@ -16271,6 +16392,7 @@ couvade	k uː v æ d
 couvade	k uː v ɑː d
 covalent	k o ʊ v e ɪ l ə n t
 cove	k o ʊ v
+cove	k ə ʊ v
 covelo	k o ʊ v ə l o ʊ
 coven	k ʌ v ə n
 covenant	k ʌ v n ə n t
@@ -16279,6 +16401,7 @@ covenstead	k ʌ v n̩ s t ɛ d
 coventry	k ɑ v ə n t ɹ i
 cover	k ʌ v ɚ
 coverack	k ɒ v ə ɹ ə k
+coverall	k ʌ v ɚ ɔ l
 covered	k ʌ v ə ɹ d
 covering	k ʌ v ə ɹ ɪ ŋ
 coverlet	k ʌ v ə ɹ l ɪ t
@@ -16328,6 +16451,7 @@ cowrie	k a ʊ ɹ i
 cows	k a ʊ z
 cowslip	k a ʊ s l ɪ p
 cox	k ɑ k s
+coxa	k ɑ k s ə
 coxie	k ɒ k s i
 coxswain	k ɑ k s ə n
 coy	k ɔ ɪ
@@ -16475,7 +16599,7 @@ craxism	k ɹ æ k s ɪ z ə m
 cray	k ɹ æ ɪ
 crayfish	k ɹ e ɪ f ɪ ʃ
 crayon	k ɹ a ʊ n
-crayon	k ɹ e ɪ ɒ n
+crayon	k ɹ e ɪ ɑ n
 crayon	k ɹ e ɪ ɔ n
 crayon	k ɹ æ n
 craze	k ɹ e ɪ z
@@ -16496,6 +16620,7 @@ creaks	k ɹ iː k s
 creaky	k ɹ iː k i
 cream	k ɹ iː m
 creamed	k ɹ iː m d
+creamer	k ɹ iː m ɚ
 creaming	k ɹ iː m ɪ ŋ
 creamings	k ɹ iː m ɪ ŋ z
 creampie	k ɹ iː m p a ɪ
@@ -16510,6 +16635,7 @@ creasings	k ɹ iː s ɪ ŋ z
 creasy	k ɹ i s i
 create	k ɹ iː e ɪ t
 created	k ɹ i e ɪ t ɪ d
+creatic	k ɹ iː æ t ɪ k
 creatify	k ɹ i e ɪ t ə f a ɪ
 creatine	k ɹ i ə t i n
 creating	k ɹ iː e ɪ t ɪ ŋ
@@ -16521,7 +16647,7 @@ creativeness	k ɹ i e ɪ t ɪ v n ə s
 creativity	k ɹ i e ɪ t ɪ v ə t i
 creativize	k ɹ i e ɪ t ə v a ɪ z
 creator	k ɹ i e ɪ t ɚ
-creature	k ɹ iː t͡ʃ ə ɹ
+creature	k ɹ iː t͡ʃ ɚ
 creatures	k ɹ i t͡ʃ ɚ z
 crebrous	k ɹ iː b ɹ ə s
 crebrous	k ɹ ɛ b ɹ ə s
@@ -16617,8 +16743,7 @@ cretic	k ɹ iː t ɪ k
 cretin	k ɹ iː t ɪ n
 cretin	k ɹ ɛ t ɪ n
 crevasse	k ɹ ə v æ s
-crew	k ɹ u ʊ̯
-crew	k ɹ uː
+crew	k ɹ u
 crewe	k ɹ u ʊ̯
 crewe	k ɹ uː
 crewed	k ɹ uː d
@@ -16740,7 +16865,6 @@ criterion	k ɹ ɪ t ɪ ə ɹ i ə n
 criterium	k ɹ a ɪ t ɪ ə ɹ i ə m
 crith	k ɹ ɪ θ
 critic	k ɹ ɪ t ɪ k
-critical	k ɹ ɪ t ə k ə l
 critical	k ɹ ɪ t ɪ k ə l
 critically	k ɹ ɪ t ɪ k l i
 critically	k ɹ ɪ t ɪ k ə l i
@@ -16820,7 +16944,7 @@ crosswordese	k ɹ ɒ s w ɜː ɹ d iː z
 crotalum	k ɹ ə ʊ t ə l ə m
 crotch	k ɹ ɑ t͡ʃ
 crotchet	k ɹ ɑ t͡ʃ ɪ t
-crotchety	k ɹ ɑ t͡ʃ ɨ t i
+crotchety	k ɹ ɑ t͡ʃ ɪ t i
 croton	k ɹ o ʊ t ə n
 crouch	k ɹ a ʊ t͡ʃ
 crouched	k ɹ a ʊ t͡ʃ t
@@ -16866,9 +16990,11 @@ cruces	k ɹ u s i z
 crucial	k ɹ uː ʃ ə l
 crucially	k ɹ uː ʃ ə l i
 crucian	k ɹ uː ʃ ə n
+cruciate	k r uː ʃ i ə t
 crucible	k ɹ uː s ɪ b ə l
 cruciferous	k ɹ u s ɪ f ə ɹ ə s
-crucifix	k ɹ uː s ɨ f ɪ k s
+crucifices	k ɹ uː s ɨ f ɪ s iː z
+crucifix	k ɹ uː s ɪ f ɪ k s
 crucifixion	k ɹ uː s ɪ f ɪ k ʃ ə n
 crucify	k ɹ uː s ɪ f a ɪ
 cruck	k ɹ ʌ k
@@ -16917,6 +17043,7 @@ crunchings	k ɹ ʌ n t͡ʃ ɪ ŋ z
 crunchy	k ɹ ʌ n t͡ʃ i
 crunk	k ɹ ʌ ŋ k
 crunkmeister	k ɹ ʌ ŋ k m a ɪ s t ɚ
+cruor	k ɹ uː ə ɹ
 crup	k ɹ ʌ p
 crupper	k ɹ ʊ p ɚ
 crupper	k ɹ ʌ p ɚ
@@ -16950,6 +17077,7 @@ crying	k ɹ a ɪ̯ ɪ ŋ
 cryobiotic	k ɹ a ɪ ə ʊ b a ɪ ɒ t ɪ k
 cryogenic	k ɹ a ɪ o ʊ d͡ʒ ɛ n ɪ k
 cryogenic	k ɹ a ɪ ə d͡ʒ ɛ n ɪ k
+cryonicist	k ɹ a ɪ ɒ n ɪ s ɪ s t
 crypsis	k ɹ ɪ p s ɪ s
 crypt	k ɹ ɪ p t
 cryptic	k ɹ ɪ p t ɪ k
@@ -16973,6 +17101,8 @@ crypts	k ɹ ɪ p t s
 crystal	k ɹ ɪ s t ə l
 crystalize	k ɹ ɪ s t ə l a ɪ z
 crystalline	k ɹ ɪ s t ə l a ɪ n
+crystalline	k ɹ ɪ s t ə l iː n
+crystalline	k ɹ ɪ s t ə l ɪ n
 crystallize	k ɹ ɪ s t ə l a ɪ z
 crystals	k ɹ ɪ s t ə l z
 crèche	k ɹ e ɪ ʃ
@@ -17022,10 +17152,12 @@ cud	k ʊ d
 cud	k ʌ d
 cudden	k ʌ d ə n
 cuddle	k ʌ d l̩
+cuddleologist	k ʌ d ə l ɑ l ɒ d͡ʒ ɪ s t
 cuddler	k ʌ d l ɚ
 cuddler	k ʌ d l̩ ɚ
 cuddly	k ʌ d l i
 cuddly	k ʌ d l̩ i
+cuddly	k ʌ d ə l i
 cuddy	k ʌ d i
 cudgel	k ʌ d͡ʒ ə l
 cudraflavone	k uː d ɹ ə f l e ɪ v ə ʊ n
@@ -17354,8 +17486,9 @@ cyanosis	s a ɪ ə n o ʊ s ɪ s
 cyanotype	s a ɪ æ n ə t a ɪ p
 cyanotype	s a ɪ æ n ə ʊ t a ɪ p
 cyattie	k j æ t i
-cybele	s ɪ b ɨ l iː
+cybele	s ɪ b ɪ l iː
 cyber	s a ɪ b ə ɹ
+cyberbole	s a ɪ b ɝ b ə l i
 cybernat	s a ɪ b ɚ n æ t
 cybernetic	s a ɪ b ɚ n ɛ t ɪ k
 cyberocracy	s a ɪ b ə ɹ ɒ k ɹ ə s i
@@ -17747,7 +17880,7 @@ darlin'	d ɑ ɹ l ɪ n
 darling	d ɑ ɹ l ɪ ŋ
 darmstadtium	d ɑː ɹ m ʃ t ɑː t i ə m
 darn	d ɑ ɹ n
-darnedest	d ɑ ɹ n d ɨ s t
+darnedest	d ɑ ɹ n d ɪ s t
 darpa	d ɑː ɹ p ə
 darrein	d æ ɹ e ɪ n
 darrein	d ə ɹ e ɪ n
@@ -17760,8 +17893,9 @@ dartos	d ɑ ɹ t ɑ s
 dartos	d ɑ ɹ t ə s
 darty	d ɑ ɹ t i
 daruma	d ɑː ɹ ʊ m ə
+darusentan	d æ ɹ ə s ɛ n t æ n
 darvel	d ɑː ɹ v ə l
-darwin	d ɑ ɹ w ɨ n
+darwin	d ɑ ɹ w ɪ n
 darwinian	d ɑ ɹ w ɪ n i ə n
 das	d æ s
 das	d ɑː z
@@ -17821,6 +17955,7 @@ dauntless	d ɔː n t l ə s
 dauphin	d o ʊ f æ̃
 dauphin	d ɔ f ə n
 dauphin	d ɔ f ɪ n
+dauphiné	d ə ʊ f ɪ n e ɪ
 dauria	d ɑː ʊ ə r ɪ ə
 dauw	d a ʊ
 davao	d ɑ v a ʊ
@@ -17908,7 +18043,7 @@ deafly	d ɛ f l i
 deafs	d ɛ f s
 deal	d iː l
 dealate	d i e ɪ l e ɪ t
-dealate	d i e ɪ l ɨ t
+dealate	d i e ɪ l ɪ t
 dealated	d i e ɪ l e ɪ t ə d
 dealie	d iː l i
 dealignment	d iː j ə l a ɪ n m ə n t
@@ -17928,6 +18063,8 @@ dearness	d ɪ ə ɹ n ə s
 dearth	d ɝ θ
 dearthy	d ɝ θ i
 dearworth	d ɪ ə ɹ w ɜː ɹ θ
+deas	d e ɪ ə s
+deas	d iː ə s
 deasil	d i s ə l
 deasil	d i z ə l
 deasil	d j ɛ ʃ ə l
@@ -17978,7 +18115,7 @@ debunks	d ɪ b ʌ ŋ k s
 debut	d e ɪ b j uː
 debut	d ə b j uː
 debuted	d e ɪ b j uː d
-debuted	d ɨ b j uː d
+debuted	d ɪ b j uː d
 debuts	d e ɪ b j uː z
 debye	d ə b a ɪ
 decacumination	d iː k ə k j uː m ɪ n e ɪ ʃ ə n
@@ -18002,7 +18139,7 @@ decan	d i k æ n
 decan	d ɛ k ə n
 decanal	d ɛ k ə n æ l
 decanal	d ɛ k ə n ə l
-decanal	d ɨ k e ɪ n ə l
+decanal	d ɪ k e ɪ n ə l
 decangle	d ɛ k æ ŋ ɡ ə l
 decani	d ɪ k e ɪ n a ɪ
 decant	d ə k æ n t
@@ -18055,6 +18192,7 @@ decimal	d ɛ s ɪ m ə l
 decimate	d ɛ s ə m e ɪ t
 decimation	d ɛ s ɪ m e ɪ ʃ ə n
 decime	d ɛ s iː m
+decision	d ɪ s ɪ ʒ ə n
 decitabine	d ɪ s a ɪ t ə b iː n
 deck	d ɛ k
 decked	d ɛ k t
@@ -18114,6 +18252,8 @@ decussate	d ɪ k ʌ s e ɪ t
 decussation	d ɛ k ʌ s e ɪ ʃ ə n
 decussative	d ɪ k ʌ s ə t ɪ v
 dedicant	d ɛ d ɪ k ə n t
+dedicate	d ɛ d ɪ k e ɪ t
+dedicate	d ɛ d ɪ k ɪ t
 dedication	d ɛ d ɪ k e ɪ ʃ ə n
 dedicatory	d ɛ d ə k ə t ɔ ɹ i
 dedolent	d ɛ d ə l ə n t
@@ -18134,6 +18274,7 @@ deep	d iː p
 deepen	d iː p ə n
 deeper	d i p ɚ
 deepest	d iː p ɪ s t
+deepfake	d iː p f e ɪ k
 deeply	d iː p l i
 deer	d ɪ ɹ
 dees	d iː z
@@ -18177,8 +18318,9 @@ defile	d i f a ɪ l
 defile	d ə f a ɪ l
 define	d ɪ f a ɪ n
 defined	d ɪ f a ɪ n d
+definiendum	d ɪ f ɪ n i ɛ n d ə m
+definite	d ɛ f ə n ə t
 definite	d ɛ f ə n ɪ t
-definite	d ɛ f ɪ n ɪ t
 definitely	d ɛ f n ɪ t l i
 definitely	d ɛ f ə n ɪ t l i
 definitely	d ɛ f ɪ n ɪ t l i
@@ -18389,7 +18531,7 @@ demeter	d ə m iː t ə ɹ
 demeter	d ɛ m ɪ t ə ɹ
 demideity	d ɛ m iː d e ɪ ə t i
 demideity	d ɛ m iː d i ə t i
-demigod	d ɛ m ɪ ɡ ɑ d
+demigod	d ɛ m i ɡ ɑ d
 demigrate	d iː m a ɪ ɡ ɹ e ɪ t
 demigrate	d ɛ m ɪ ɡ ɹ e ɪ t
 demilitarize	d ɪ m ɪ l ɪ t ə ɹ a ɪ z
@@ -18445,7 +18587,7 @@ demurral	d ɪ m ɝ ə l
 demurrer	d ɪ m əː ɹ ə ɹ
 den	d ɛ n
 dena'ina	d ə n aː i n ə
-denali	d ɨ n ɑː l i
+denali	d ɪ n ɑː l i
 denar	d e ɪ n ɑː ɹ
 denar	d ɛ n ɑː ɹ
 denary	d iː n ə ɹ i
@@ -18519,10 +18661,11 @@ deontic	d iː ɒ n t ɪ k
 deontology	d iː ɒ n t ɒ l ə d͡ʒ i
 deoxy	d iː ɒ k s i
 deoxycorticosterone	d i ɑ k s ɪ k ɔ ɹ t ɪ k ɑ s t ə ɹ o ʊ n
+deoxyribonucleic	d i ɔ k s i ɹ a ɪ b o ʊ n uː k l ɛ ɪ k
 deoxyribosylthymine	d iː ɒ k s i ɹ a ɪ b ə s ɪ l θ a ɪ m iː n
 depart	d ɪ p ɑ ɹ t
 departed	d ɪ p ɑ ɹ t ɪ d
-department	d ə p ɑ ɹ t m ə n t
+department	d ɪ p ɑ ɹ t m ə n t
 departmental	d iː p ɑː ɹ t m ɛ n t ə l
 departmental	d ɪ p ɑː ɹ t m ɛ n t ə l
 depend	d ɪ p ɛ n d
@@ -18562,7 +18705,7 @@ deport	d ɪ p ɔ ɹ t
 deportment	d ɪ p ɔ ɹ t m ə n t
 depose	d i p o ʊ z
 depose	d ə p o ʊ z
-deposit	d ɨ p ɑ z ɪ t
+deposit	d ɪ p ɑ z ɪ t
 depositary	d ɪ p ɑ z ɪ t ɛ ɹ i
 deposited	d ɪ p ɑ z ɪ t ɪ d
 deposition	d ɛ p ə z ɪ ʃ ə n
@@ -18683,7 +18826,7 @@ dese	d iː z
 desecrate	d ɛ s ə k ɹ e ɪ̯ t
 desecrate	d ɛ s ɪ k ɹ e ɪ̯ t
 desecration	d ɛ s ə k ɹ e ɪ ʃ ə n
-desecration	d ɛ s ɨ k ɹ e ɪ ʃ ə n
+desecration	d ɛ s ɪ k ɹ e ɪ ʃ ə n
 desecration	d ɛ z ə k ɹ e ɪ ʃ ə n
 desegregation	d i s ɛ ɡ ɹ ə ɡ e ɪ̯ ʃ ə n
 deselect	d iː s ə l ɛ k t
@@ -18744,7 +18887,7 @@ desoxycorticosterone	d ɛ z ɑ k s ɪ k ɔ ɹ t ɪ k ɑ s t ə ɹ o ʊ n
 desoxycortone	d ɛ z ɑ k s ɪ k ɔ ɹ t o ʊ n
 despaghettify	d iː s p ə ɡ ɛ t ɪ f a i
 despaghettifying	d iː s p ə ɡ ɛ t ɪ f a ɪ j ɪ ŋ
-despair	d ɪ s p ɛ ə ɹ
+despair	d ɪ s p ɛ ɚ
 despairer	d ɪ s p ɛ ɹ ɚ
 despairing	d ɪ s p ɛ ə ɹ ɪ ŋ
 despairingly	d ɪ s p ɛ ə ɹ ɪ ŋ l i
@@ -18800,7 +18943,7 @@ detailed	d iː t e ɪ l d
 detailed	d ɪ t e ɪ l d
 details	d iː t e ɪ l z
 details	d ɪ t e ɪ l z
-detained	d ɨ t e ɪ n d
+detained	d ɪ t e ɪ n d
 detected	d ɪ t ɛ k t ɪ d
 detection	d ə t ɛ k ʃ ə n
 detective	d ɪ t ɛ k t ɪ v
@@ -18822,7 +18965,7 @@ detest	d ɪ t ɛ s t
 detestable	d ɪ t ɛ s t ə b l̩
 detestate	d ɪ t ɛ s t e ɪ t
 dethick	d ɛ θ ɪ k
-detonate	d ɛ t ə n e ɪ t
+detonate	d ɛ ʔ ə n e ɪ t
 detour	d i t o ɹ
 detour	d iː t ɔː ɹ
 detour	d iː t ʊ ə ɹ
@@ -18848,7 +18991,7 @@ deucalion	d j uː k e ɪ l ɪ ə n
 deuce	d uː s
 deuced	d j uː s t
 deuced	d j uː s ɪ d
-deucedly	d u s ɨ d l i
+deucedly	d u s ɪ d l i
 deuteragonist	d j u t ə ɹ æ ɡ ə n ɪ s t
 deuteragonist	d uː t ə ɹ æ ɡ ə n ɪ s t
 deuterium	d j uː t ɪ ɹ i ə m
@@ -18873,7 +19016,7 @@ developers	d ɪ v ɛ l ə p ɚ z
 developing	d ɪ v ɛ l ə p ɪ ŋ
 development	d ɪ v ɛ l ə p m ə n t
 developmentals	d ɪ v ɛ l ə p m ɛ n t ə l z
-developmentation	d ɨ v ɛ l ə p m ə n t e ɪ ʃ ə n
+developmentation	d ɪ v ɛ l ə p m ə n t e ɪ ʃ ə n
 devi	d e ɪ v i
 deviance	d iː v ɪ ə n s
 deviate	d iː v i e ɪ t
@@ -18956,7 +19099,6 @@ dhyana	d j ɑː n ə
 di	d a ɪ
 diabase	d a ɪ ə b e ɪ s
 diabeetus	d a ɪ ə b iː t ə s
-diabetes	d a ɪ ə b eː t ɪ s
 diabetes	d a ɪ ə b iː t iː z
 diabetes	d a ɪ ə b iː t ɪ s
 diable	d i ɑː b ə l
@@ -19108,7 +19250,7 @@ dicloxacillin	d a ɪ k l ɑ k s ə s ɪ l ɪ n
 dicrotic	d a ɪ k ɹ ɑ t ɪ k
 dicrotophos	d a ɪ k ɹ ə ʊ t ə f ɒ s
 dictamen	d ɪ k t e ɪ m ə n
-dictamina	d ɪ k t æ m ɨ n ə
+dictamina	d ɪ k t æ m ɪ n ə
 dictate	d ɪ k t e ɪ t
 dictated	d ɪ k t e ɪ t ɪ d
 dictation	d ɪ k t e ɪ ʃ ə n
@@ -19122,6 +19264,8 @@ dicycloverine	d a ɪ s a ɪ k l o ʊ v ə ɹ i n
 did	d ɪ d
 didactic	d a ɪ d æ k t ɪ k
 didactic	d ɪ d æ k t ɪ k
+didactician	d a ɪ d ə k t ɪ ʃ ə n
+didactics	d a ɪ d æ k t ɪ k s
 didanosine	d a ɪ d æ n ə s i n
 diddest	d ɪ d ɛ s t
 didelphic	d a ɪ d ɛ l f ɪ k
@@ -19140,6 +19284,7 @@ died	d a ɪ d
 diedre	d ɪ ə d r i
 diegetic	d a ɪ ə d͡ʒ ɛ t ɪ k
 diego	d i e ɪ ɡ o ʊ
+dieguez	d i e ɪ ɡ ɛ z
 diel	d a ɪ ə l
 diel	d i ə l
 dielectric	d a ɪ ə l ɛ k t ɹ ɪ k
@@ -19160,12 +19305,14 @@ diet	d a ɪ ə t
 dietary	d a ɪ ə t ɛ ɹ i
 dietary	d a ɪ ə t ɹ i
 dietetic	d a ɪ ə t ɛ t ɪ k
+dietetician	d a ɪ ə t ɪ t ɪ ʃ ə n
+dietetics	d a ɪ ə t ɛ t ɪ k s
 diethylstilbestrol	d a ɪ ɛ θ ə l s t ɪ l b ɛ s t ɹ ɔ l
 dietitian	d a ɪ ə t ɪ ʃ ə n
 difenoxin	d a ɪ f ə n ɑ k s ɪ n
 diff	d ɪ f
 differ	d ɪ f ɚ
-difference	d ɪ f ɹ ə n s
+difference	d ɪ f ə ɹ ə n s
 differences	d ɪ f ɹ ə n s ɪ z
 different	d ɪ f ə ɹ ə n t
 different	d ɪ f ɹ ə n t
@@ -19199,7 +19346,7 @@ digest	d a ɪ d͡ʒ ə s t
 digest	d a ɪ d͡ʒ ɛ s t
 digest	d ə d͡ʒ ɛ s t
 digestion	d a ɪ d͡ʒ ɛ s t͡ʃ ə n
-digestion	d ɨ d͡ʒ ɛ s t͡ʃ ə n
+digestion	d ɪ d͡ʒ ɛ s t͡ʃ ə n
 digger	d ɪ ɡ ɚ
 diggety	d ɪ ɡ ə t i
 diggs	d ɪ ɡ z
@@ -19320,6 +19467,8 @@ dinette	d a ɪ n ɛ t
 ding	d ɪ ŋ
 dingbat	d ɪ ŋ b æ t
 dinge	d ɪ n d͡ʒ
+dinged	d ɪ n d͡ʒ d
+dinged	d ɪ ŋ d
 dinghy	d ɪ ŋ i
 dingle	d ɪ ŋ ɡ l̩
 dingleberry	d ɪ ŋ ɡ ə ɫ b ɛ ɹ i
@@ -19344,6 +19493,7 @@ dinocarid	d a ɪ n ə k æ ɹ ɪ d
 dinocarid	d a ɪ n ə k ɛ ə ɹ ɪ d
 dinokaryote	d a ɪ n ə ʊ k æ ɹ i ə ʊ t
 dinoprostone	d a ɪ n ə p ɹ ɑ s t o ʊ n
+dinorwig	d ɪ n ɔ r w ɪ ɡ
 dinq	d ɪ ŋ k
 dins	d ɪ n z
 dint	d ɪ n t
@@ -19460,7 +19610,9 @@ disanthropic	d ɪ s æ n θ ɹ ɑ p ɪ k
 disanthropy	d ɪ s æ n θ ɹ ə p i
 disappear	d ɪ s ə p ɪ ɹ
 disappeared	d ɪ s ə p ɪ ɹ d
+disappoint	d ɪ s ə p ɔ ɪ n t
 disappointed	d ɪ s ə p ɔ ɪ n t ɪ d
+disappointment	d ɪ s ə p ɔ ɪ n t m ə n t
 disapproval	d ɪ s ə p ɹ u v ə l
 disaster	d ɪ z æ s t ɚ
 disastrophe	d ɪ z æ s t ɹ ə f i
@@ -19739,7 +19891,7 @@ dissection	d ɪ s ɛ k ʃ ə n
 dissed	d ɪ s t
 disseize	d ɪ s iː z
 disseizin	d ɪ s iː z ɪ n
-dissemination	d ɨ s ɛ m ɨ n e ɪ ʃ ə n
+dissemination	d ɪ s ɛ m ɪ n e ɪ ʃ ə n
 dissension	d ɪ s ɛ n ʃ ə n
 dissensus	d ɪ s ɛ n s ə s
 dissent	d ə s ɛ n t
@@ -19754,6 +19906,7 @@ disship	d ɪ s ʃ ɪ p
 dissident	d ɪ s ɪ d ə n t
 dissilition	d ɪ s ɪ l ɪ ʃ ə n
 dissimilate	d ɪ s ɪ m ɪ l e ɪ t
+dissimilation	d ɪ s ɪ m ɪ l e ɪ ʃ ə n
 dissimulate	d ɪ s ɪ m j ʊ l e ɪ t
 dissing	d ɪ s ɪ ŋ
 dissipable	d ɪ s ɪ p ɪ b l̩
@@ -19864,7 +20017,7 @@ divers	d a ɪ v ə ɹ z
 divers	d a ɪ v ɜː ɹ z
 diverse	d a ɪ v ɚ s
 diverse	d a ɪ v ɝ s
-diverse	d ɨ v ɝ s
+diverse	d ɪ v ɝ s
 diversification	d a ɪ v ɝ s ɪ f ɪ k e ɪ ʃ ə n
 diversification	d ɪ v ɝ s ɪ f ɪ k e ɪ ʃ ə n
 diversify	d a ɪ v ɝ s ə f a ɪ
@@ -19877,6 +20030,7 @@ divert	d a ɪ v ɝ t
 divert	d ɪ v ɝ t
 diverticulum	d ɑ ɪ v ɜː t ɪ k j ə l ə m
 divertimento	d ə v ɝ t ə m ɛ n t o ʊ
+divertisement	d ɪ v ɜː ɹ t ɪ z m ə n t
 divertive	d a ɪ v ɜː ɹ t ɪ v
 dives	d a ɪ v z
 divest	d a ɪ v ɛ s t
@@ -19885,7 +20039,7 @@ divestment	d a ɪ v ɛ s t m ə n t
 divey	d a ɪ v i
 dividend	d ɪ v ɪ d ɛ n d
 dividual	d ɪ v ɪ d͡ʒ u ə l
-divination	d ɪ v ɨ n e ɪ ʃ ə n
+divination	d ɪ v ɪ n e ɪ ʃ ə n
 divine	d ɪ v a ɪ n
 diviner	d ɪ v a ɪ n ə ɹ
 diving	d a ɪ v ɪ ŋ
@@ -19896,7 +20050,7 @@ divisions	d ɪ v ɪ ʒ ə n z
 divisive	d ɪ v a ɪ s ɪ v
 divisive	d ɪ v ɪ s ɪ v
 divisive	d ɪ v ɪ z ɪ v
-divisor	d ɨ v a ɪ z ɚ
+divisor	d ɪ v a ɪ z ɚ
 divo	d iː v o ʊ
 divorce	d ɪ v ɔ ɹ s
 divorcee	d ɪ v ɔ ɹ s i
@@ -19914,6 +20068,7 @@ dixnary	d ɪ k s ə n ɛ ɹ i
 dixnary	d ɪ k s ə ɹ i
 dixnary	d ɪ k s ɛ ɹ i
 dixon	d ɪ k s ə n
+dixy	d ɪ k s i
 diya	d iː j ə
 diya	d iː ə
 diyarbakır	d i a ɹ b ə k i ɹ
@@ -19935,6 +20090,7 @@ djinn	d͡ʒ ɪ n
 djokovic	d͡ʒ o ʊ k ə v ɪ t͡ʃ
 dmz	d iː ɛ m z iː
 dmz	d iː ɛ m z ɛ d
+dna	d i ɛ n e ɪ
 dnieper	n iː p ə ɹ
 dnipro	n i p r o ʊ
 dnipro	n ɪ p r o ʊ
@@ -20046,8 +20202,10 @@ doink	d ɔ ɪ ŋ k
 doit	d ɔ ɪ t
 dojigger	d uː d͡ʒ ɪ ɡ ə ɹ
 dojo	d o ʊ d͡ʒ o ʊ
+dokkaebi	d o ʊ k e ɪ b i
 dolan	d o ʊ l ə n
 dolasetron	d o ʊ l æ s ə t ɹ ɑ n
+dolbadarn	d ɔ l b a d aː n
 dolcetto	d o ʊ l t͡ʃ ɛ t o ʊ
 doldrum	d ɑ l d ɹ ə m
 doldrums	d ɑ l d ɹ ə m z
@@ -20066,6 +20224,7 @@ dollarization	d ɑ l ɝ ɪ z e ɪ̯ ʃ ɪ n
 dollars	d ɑ l ɚ z
 dollop	d ɑ l ə p
 dolly	d ɑ l i
+dollywood	d ɒ l i w ʊ d
 dolman	d o ʊ l m ə n
 dolmen	d o ʊ l m ə n
 dolmen	d ɑ l m ə n
@@ -20084,6 +20243,7 @@ dolphinarium	d ɑ l f ɪ n ɛ ə ɹ i ə m
 dolt	d o ʊ l t
 dolts	d o ʊ l t s
 dolus	d o ʊ l ə s
+dolwyddelan	d ɔ l w ɪ ð ɛ l a n
 dom	d ɑ m
 doma	d o ʊ m ə
 domable	d o ʊ m ə b l̩
@@ -20303,6 +20463,7 @@ double	d ʌ b ə l
 doubled	d ʌ b l̩ d
 doublet	d ʌ b l ə t
 doubly	d ʌ b l i
+doubly	d ʌ b ə l l i
 doubs	d uː
 doubt	d a ʊ t
 doubted	d a ʊ t ɪ d
@@ -20396,6 +20557,7 @@ dows	d a ʊ z
 dowse	d a ʊ s
 dowse	d a ʊ z
 dowser	d a ʊ z ə
+doxa	d ɑ k s ə
 doxastic	d ɒ k s æ s t ɪ k
 doxazosin	d ɑ k s e ɪ z ə s ɪ n
 doxepin	d ɑ k s ə p ɪ n
@@ -20416,6 +20578,7 @@ drabble	d ɹ æ b ə l
 drachm	d ɹ æ m
 drachma	d ɹ æ k m ə
 drachmae	d ɹ æ k m iː
+drachme	d ɹ æ k m i
 draco	d ɹ e ɪ k o ʊ
 draconian	d ɹ e ɪ k o ʊ n i ə n
 draconian	d ɹ ə k o ʊ n i ə n
@@ -20427,6 +20590,7 @@ draff	d ɹ æ f
 draff	d ɹ ɑː f
 draft	d ɹ æ f t
 drafty	d ɹ æ f t i
+drag	d ɹ æ ɡ
 drageoir	d ɹ æ ʒ w ɑː
 draggable	d ɹ æ ɡ ə b ə l
 dragged	d ɹ æ ɡ d
@@ -20519,7 +20683,7 @@ dreams	d ɹ iː m z
 dreamt	d ɹ ɛ m p t
 dreamtime	d ɹ iː m t a ɪ m
 dreamworker	d ɹ i m w ɝ k ɚ
-drear	d ɹ ɪ ə ɹ
+drear	d ɹ ɪ ɚ
 drear	d ɹ ɪ ɹ
 drearing	d ɹ ɪ ə ɹ ɪ ŋ
 dreary	d ɹ ɪ ɹ i
@@ -20701,7 +20865,6 @@ drusilla	d ɹ u s ɪ l ə
 druthers	d ɹ ʌ ð ɚ z
 druxy	d ɹ ʌ k s i
 dry	d ɹ a ɪ
-dry	d͡ʒ ɹ a ɪ
 dryad	d ɹ a ɪ æ d
 dryad	d ɹ a ɪ ə d
 dryas	d ɹ a ɪ æ s
@@ -20739,7 +20902,7 @@ dubitation	d j u b ɪ t e ɪ ʃ ə n
 dubitation	d u b ɪ t e ɪ ʃ ə n
 dubitative	d j uː b ɪ t ə t ɪ v
 dublin	d ʌ b l ə n
-dublin	d ʌ b l ɨ n
+dublin	d ʌ b l ɪ n
 dubnium	d uː b n i ə m
 dubois	d uː b ɔ ɪ z
 dubonnet	d j uː b ə n e ɪ
@@ -20807,6 +20970,7 @@ dukedom	d j u k d ə m
 dukedom	d u k d ə m
 dukedoms	d j uː k d ə m z
 dukkha	d ʊ k ə
+dulce	d ʌ l s
 dulcet	d ʌ l s ə t
 dulcet	d ʌ l s ɪ t
 dulcify	d ʌ l s ɪ f a ɪ
@@ -21093,10 +21257,13 @@ e'er	ɛ ʔ ɚ
 ea	iː ə
 each	i t͡ʃ
 eager	i ɡ ɚ
+eager	ɪ ɡ ə
+eager	ɪ ɡ ɚ
 eagerly	i ɡ ɚ l i
 eagerness	i ɡ ɚ n ə s
 eagle	i ɡ ə l
 eagle	iː ɡ ə l
+eagle	ɪ ɡ ə l
 eaglesham	iː ɡ ə l s ə m
 eagre	e ɪ ɡ ə ɹ
 eagre	iː ɡ ə ɹ
@@ -21135,7 +21302,7 @@ ears	ɪ ɹ z
 earsh	æː ɹ ʃ
 earshot	ɪ ɹ ʃ ɑ t
 earth	ɝ θ
-earthen	ə ɹ θ ə n
+earthen	ɝ θ ə n
 earthful	ɜː θ f ʊ l
 earthling	ɝ θ l ɪ ŋ
 earthquake	ɝ θ k w e ɪ k
@@ -21155,8 +21322,7 @@ eases	iː z ɪ z
 easesome	iː z s ʌ m
 easie	iː z i
 easier	i z i ɚ
-easily	iː z ə l iː
-easily	iː z ɪ l iː
+easily	i z ə l i
 easiness	iː z ɪ n ə s
 easing	iː z ɪ ŋ
 easings	iː z ɪ ŋ z
@@ -21292,7 +21458,7 @@ ecstatic	ɛ k s t æ t ɪ k
 ecstatica	ɛ k s t æ t ɪ k ə
 ectal	ɛ k t ə l
 ectasia	ɛ k t e ɪ z j ə
-ectasis	ɛ k t ə s ɨ s
+ectasis	ɛ k t ə s ɪ s
 ectodomain	ɛ k t o ʊ d o ʊ m e ɪ n
 ectomorph	ɛ k t o ʊ m ɔː ɹ f
 ectomorph	ɛ k t ə m ɔː ɹ f
@@ -21363,6 +21529,7 @@ edmundston	ɛ d m ə n d s t ə n
 edo	ɛ d o ʊ
 edom	i d ə m
 edomite	iː d ə m a ɪ t
+edonentan	ɛ d ə n ɛ n t æ n
 edro	i d ɹ o ʊ
 edrophonium	ɛ d ɹ ə f o ʊ n i ə m
 educate	ɛ d͡ʒ ə k e ɪ t
@@ -21398,6 +21565,7 @@ eff	ɛ f
 efface	ə f e ɪ s
 efface	ɪ f e ɪ s
 effect	ə f ɛ k t
+effect	ɪ f ɛ k t
 effected	ɪ f ɛ k t ɪ d
 effectively	ɪ f ɛ k t ɪ v l i
 effects	ɪ f ɛ k t s
@@ -21454,7 +21622,7 @@ efs	ɛ f s
 eft	ɛ f t
 efta	ɛ f t ɑː
 eftpos	ɛ f t p ɒ s
-egad	iː ɡ æ d
+egad	i ɡ æ d
 egal	iː ɡ ə l
 egalitarian	ɪ ɡ æ l ɪ t ɛ ɹ i ə n
 egality	ɪ ɡ æ l ɪ t i
@@ -21469,6 +21637,7 @@ egging	ɛ ɡ ɪ ŋ
 eggings	ɛ ɡ ɪ ŋ z
 eggless	ɛ ɡ l ə s
 eggnog	ɛ ɡ n ɑ ɡ
+eggplant	ɛ ɡ p l æ n t
 eggs	ɛ ɡ z
 eggshell	ɛ ɡ ʃ ɛ l
 eggy	ɛ ɡ i
@@ -21531,8 +21700,8 @@ eisteddfod	a ɪ s t ɛ ð v ɒ d
 eisteddfodau	a ɪ s t ɛ ð v ɒ d a ɪ
 eisteddfodic	a ɪ s t ɛ ð v ɒ d ɪ k
 eisteddfodwr	a ɪ s t ɛ ð v ɒ d ə ɹ
-either	a ɪ ð ə ɹ
-either	iː ð ə ɹ
+either	a ɪ ð ɚ
+either	i ð ɚ
 ejaculate	ɪ d͡ʒ æ k j ə l e ɪ t
 ejaculate	ɪ d͡ʒ æ k j ə l ə t
 ejaculator	ɪ d͡ʒ æ k j ə l e ɪ t ə ɹ
@@ -21623,7 +21792,7 @@ electrocute	ɪ l e k t ɹ ə k j uː t
 electrocution	ɪ l ɛ k t ɹ ə k j uː ʃ ə n
 electrocutioner	ɪ l ɛ k t ɹ ə k j u ʃ ə n ɚ
 electrolier	ɪ l ɛ k t ɹ ə l ɪ ə ɹ
-electrolyte	ɨ l ɛ k t ɹ ɵ l a ɪ t
+electrolyte	ɪ l ɛ k t ɹ ɵ l a ɪ t
 electrolytic	ɨ l ɛ k t ɹ ɵ l ɪ t ɪ k
 electron	ɪ l ɛ k t ɹ ɑ n
 electronic	i l ɛ k t ɹ ɑ n ɪ k
@@ -21678,6 +21847,7 @@ elevon	ɛ l ə v ɒ n
 elf	ɛ l f
 elfin	ɛ l f ɪ n
 elgan	ɛ l ɡ ə n
+elgin	ɛ l d ʒ ɪ n
 elgin	ɛ l ɡ ɪ n
 elginism	ɛ l ɡ ɪ n ɪ z ə m̩
 elginist	ɛ l ɡ ɪ n ɪ s t
@@ -21689,8 +21859,8 @@ elie	ɛ l i
 eliezer	ɛ l i iː z ə ɹ
 eliezer	ɛ l i ɛ z ə ɹ
 eligible	ɛ l ɪ d͡ʒ ə b ə l
-elijah	ɨ l a ɪ d͡ʒ ə
-elijah	ɨ l a ɪ ʒ ə
+elijah	ɪ l a ɪ d͡ʒ ə
+elijah	ɪ l a ɪ ʒ ə
 eliminate	ɪ l ɪ m ə n e ɪ t
 elimination	ɪ l ɪ m ɪ n e ɪ ʃ ə n
 elisa	ɪ l ʌ ɪ z ə
@@ -21748,9 +21918,10 @@ elohim	ɛ l o ʊ h i m
 elohim	ɛ l o ʊ h ɪ m
 eloise	ɛ l ə ʊ iː z
 elon	iː l ɔ n
+elongate	i l ɔ ŋ ɡ e ɪ t
 elongate	ɪ l ɔ ŋ ɡ e ɪ t
 elope	ɛ l o ʊ p
-elope	ɨ l o ʊ p
+elope	ɪ l o ʊ p
 eloquate	ɛ l ə k w e ɪ t
 eloquence	ɛ l ə k w ə n s
 elrig	ɛ l ɹ ɪ ɡ
@@ -21766,6 +21937,7 @@ elsin	ɛ l z ɪ n
 elsinore	ɛ l s ə n ɔ ɹ
 elton	ɛ l t ə n
 elu	h ɛ l uː
+elucidate	i l uː s ɪ d e ɪ t
 elucidation	ɪ l u s ɪ d e ɪ ʃ ə n
 elucubrate	ɪ l uː k j ʊ b ɹ e ɪ t
 elucubration	ɪ l uː k j ʊ b ɹ e ɪ ʃ ə n
@@ -21976,6 +22148,7 @@ emphysema	ɛ m f ɪ s i m ə
 emphysema	ɛ m f ɪ z i m ə
 empire	ɛ m p a ɪ ɚ
 empire	ɛ m p a ɪ ɹ
+empiric	ɪ m p ɪ ɹ ɪ k
 empirical	ɪ m p ɪ ɹ ɪ k ə l
 employ	ɛ m p l ɔ ɪ
 employ	ɪ m p l ɔ ɪ
@@ -22147,7 +22320,7 @@ endo	ɛ n d ə ʊ
 endocommensalism	ɛ n d o ʊ k ə m ɛ n s ə l ɪ z m̩
 endocrine	ɛ n d o ʊ k ɹ ɪ n
 endocrinology	ɛ n d ə k r ɪ n ɑ l ə d͡ʒ i
-endogenous	ɨ n d ɑ d͡ʒ ə n ə s
+endogenous	ɪ n d ɑ d͡ʒ ə n ə s
 endolymph	ɛ n d ə l ɪ m f
 endolymphatic	ɛ n d ə l ɪ m f æ t ɪ k
 endometrial	e n d ə m iː t ɹ i ə l
@@ -22326,11 +22499,13 @@ enrage	ɪ n ɹ e ɪ d͡ʒ
 enraged	ɪ n ɹ e ɪ d͡ʒ d
 enrapture	ɛ n ɹ æ p t͡ʃ ə ɹ
 enrapture	ɪ n ɹ æ p t͡ʃ ə ɹ
+enrasentan	ɛ n ɹ ə s ɛ n t æ n
 enrich	ɪ n ɹ ɪ t͡ʃ
 enroll	ɛ n ɹ o ʊ l
 enroll	ɪ n ɹ o ʊ l
 ensanguine	ɛ n s æ ŋ ɡ w ə n
 ensconce	ɛ n s k ɑ n s
+enscripturate	ɪ n s k ɹ ɪ p t͡ʃ ə r e ɪ t
 ensear	ɪ n s ɪ ə ɹ
 ensemble	ɑ n s ɑ m b ə l
 ensete	ɛ n s ə t
@@ -22405,6 +22580,7 @@ entirety	ɪ n t a ɪ ə ɹ ɪ t i
 entitled	ɪ n t a ɪ t l̩ d
 entitlement	ə n t a ɪ t ə l m ə n t
 entity	e n t ɪ t i
+entomb	ɪ n t uː m
 entombment	ɛ n t uː m m ə n t
 entombment	ɪ n t uː m m ə n t
 entomophagy	ɛ n t ə m ɑ f ə d͡ʒ i
@@ -22418,6 +22594,7 @@ entrail	ɛ n t ɹ e ɪ l
 entrail	ɛ n t ɹ ə l
 entrails	ɛ n t ɹ e ɪ l z
 entrails	ɛ n t ɹ ə l z
+entrance	ɛ n t ɹ æ n s
 entrance	ɛ n t ɹ ə n s
 entranced	ɛ n t ɹ æ n s t
 entrances	ɛ n t ɹ ə n s ə z
@@ -22461,14 +22638,13 @@ envelope	ɛ n v ɛ l ə p
 enveloped	ɪ n v ɛ l ə p t
 envenom	ɪ n v ɛ n ə m
 enviable	ɛ n v i ə b l̩
+envie	ɑː n v iː
 envie	ɛ n v a ɪ
 envie	ɪ n v a ɪ
 envied	ɛ n v i d
 envied	ɪ n v a ɪ d
 envious	ɛ n v iː ə s
 environ	ə n v a ɪ ə ɹ ə n
-environment	ɪ n v a ɪ ɚ n m ə n t
-environment	ɪ n v a ɪ ɹ ə n m ə n t
 environmental	ə n v a ɪ ɚ n m ɛ n t ə l
 envisage	ɛ n v ɪ z ɪ d͡ʒ
 envisage	ɪ n v ɪ z ɪ d͡ʒ
@@ -22480,7 +22656,7 @@ envowel	ɛ n v a ʊ ə l
 envoy	ɑ n v ɔ ɪ
 envoy	ɛ n v ɔ ɪ
 envy	ɛ n v i
-enyo	ɨ n a ɪ o ʊ
+enyo	ɪ n a ɪ o ʊ
 enzedder	ɛ n z ɛ d ə ɹ
 enzo	ɛ n z o ʊ
 enzo	ɛ n z ə ʊ
@@ -22495,7 +22671,7 @@ eohippus	iː ə ʊ h ɪ p ə s
 eon	iː ɒ n
 eonian	iː ə ʊ n ɪ ə n
 eonism	i ə n ɪ z ə m
-eos	iː ɒ s
+eos	i ɑ s
 eosin	i ə s ɪ n
 eosinophil	i ə s ɪ n ə f ɪ l
 ep	ɛ p
@@ -22611,7 +22787,7 @@ epiphysis	ə p ɪ f ɪ s ɪ s
 epiphysis	ɪ p ɪ f ɪ s ɪ s
 epiphyte	ɛ p ɪ f ɑ ɪ t
 epirubicin	ɛ p ɪ ɹ u b ɪ s n̩
-epirus	ɨ p a ɪ ə ɹ ə s
+epirus	ɪ p a ɪ ə ɹ ə s
 episcopal	ə p ɪ s k ə p l̩
 episcopalian	ə p ɪ s k ə p e ɪ l i n̩
 episcopate	ɪ p ɪ s k ə p ə t
@@ -22632,6 +22808,7 @@ epistemology	ɛ p ɪ s t ə m ɑ l ə d͡ʒ i
 epistemology	ɪ p ɪ s t ə m ɑ l ə d͡ʒ i
 epistle	ɪ p ɪ s l
 epistle	ɪ p ɪ s ə l
+epistocracy	ɛ p ɪ s t ɑ k ɹ ə s i
 epitaph	ɛ p ɪ t æ f
 epitapher	ɛ p ɪ t æ f ə ɹ
 epitasis	ɪ p ɪ t ə s ɪ s
@@ -22744,8 +22921,8 @@ eratosthenian	ɛ ɹ æ t ə s θ iː n i ə n
 eratosthenian	ɛ ɹ ə t ə s θ iː n i ə n
 erbium	ɝ b i ə m
 erd	ɝ d
-erdoğan	ɛ ə ɹ d o ʊ ɑː n
-ere	ɛ ə ɹ
+erdoğan	ɛ ə ɹ d ə w ɑː n
+ere	ɛ ɚ
 ere	ɪ ə ɹ
 erebus	ɛ ɹ ə b ə s
 erect	ɪ ɹ ɛ k t
@@ -22775,8 +22952,8 @@ erinaceous	ɛ ɹ ə n e ɪ ʃ ə s
 erinaceous	ɛ ɹ ɪ n e ɪ ʃ ə s
 erinyes	ɪ ɹ ɪ n i iː z
 erinys	ɪ ɹ ɪ n ɪ s
-eris	ɛ ɹ ɨ s
-eris	ɪ ə ɹ ɨ s
+eris	ɛ ɹ ɪ s
+eris	ɪ ə ɹ ɪ s
 eriskay	ɛ ɹ ɪ s k e ɪ
 eritrea	ɛ ɹ ɪ t ɹ e ɪ ə
 eritrea	ɛ ɹ ɪ t ɹ i ə
@@ -22876,6 +23053,8 @@ escapologist	ɛ s k ə p ɑ l ə d ʒ ɪ s t
 escapology	ɛ s k ə p ɑ l ə d ʒ i
 escargot	ɛ s k ɑ ɹ ɡ o ʊ
 escarole	ɛ s k ə ɹ o ʊ l
+escarp	ɪ s k ɑ ɹ p
+escarpment	ɪ s k ɑ ɹ p m ə n t
 eschar	ɛ s k ɑ ɹ
 eschatological	ɛ s k ə t ə l ɑ d͡ʒ ɪ k ə l
 eschatology	ɛ s k ə t ɔ l ə d͡ʒ i
@@ -22991,8 +23170,8 @@ esthiomene	ɛ s θ i ɒ m ə n i
 esthonia	ɛ s t o ʊ n i ə
 esthonia	ɛ s θ o ʊ n i ə
 estimable	ɛ s t ɪ m ə b ə l
-estimate	ɛ s t ɨ m e ɪ̪ t
-estimate	ɛ s t ɨ m ɨ t
+estimate	ɛ s t ɪ m e ɪ̪ t
+estimate	ɛ s t ɪ m ɪ t
 estimation	ɛ s t ɪ m e ɪ ʃ ə n
 estimative	ɛ s t ɪ m e ɪ t ɪ v
 estimative	ɛ s t ɪ m ə t ɪ v
@@ -23172,13 +23351,13 @@ euphony	j uː f ə n i
 euphoria	j uː f ɔː ɹ i ə
 euphoriant	j u f ɔ ɹ i ə n t
 euphrates	j uː f ɹ e ɪ t iː z
-euphrosyne	j uː f ɹ ɒ z ɨ n i
+euphrosyne	j uː f ɹ ɒ z ɪ n i
 eupyrion	j uː p ɪ ɹ i ə n
 eurafrican	j ʊ ə ɹ æ f ɹ ɪ k ə n
 euramerica	j ʊ ə ɹ ə m ɛ ɹ ə k ə
 eurasia	j ə ɹ e ɪ ʒ ə
 eurasia	j ʊ ɹ e ɪ ʒ ə
-eureka	j u ɹ iː k ə
+eureka	j ʊ ɹ iː k ə
 euric	j ʊ ə ɹ ɪ k
 euripides	j ə ɹ ɪ p ɪ d i z
 euripides	j ʊ ɹ ɪ p ɪ d i z
@@ -23389,6 +23568,7 @@ exceeding	ɪ k s iː d ɪ ŋ
 exceedingly	ɪ k s iː d ɪ ŋ l i
 excel	ɪ k s ɛ l
 excellence	ɛ k s ə l ə n s
+excellent	ɛ k s ə l ə n t
 excentric	ɛ k s ɛ n t ɹ ɪ k
 except	ɛ k s ɛ p t
 except	ɪ k s ɛ p t
@@ -23422,6 +23602,9 @@ excited	ɪ k s a ɪ t ɪ d
 excitement	ɪ k s a ɪ t m ə n t
 exciting	ɛ k s ʌ ɪ t ɪ ŋ
 exciting	ɪ k s ʌ ɪ t ɪ ŋ
+exciton	ɛ k s a ɪ t ɒ n
+exciton	ɛ k s ɪ t ə n
+exciton	ɪ k s a ɪ t ɑ n
 exclaim	ɛ k s k l e ɪ m
 exclaim	ɪ k s k l e ɪ m
 exclaimed	ɛ k s k l e ɪ m d
@@ -23456,7 +23639,7 @@ excruciating	ɪ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ
 excruciatingly	ɛ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ l i
 excruciatingly	ɪ k s k ɹ uː s iː e ɪ t ɪ ŋ l i
 exculpate	ɛ k s k ə l p e ɪ t
-exculpatory	ɛ k s k ʌ l p ə t ɒ ɹ i
+exculpatory	ɛ k s k ʌ l p ə t ɔ ɹ i
 excursion	ɛ k s k ɜː ɹ ʃ ə n
 excursion	ɛ k s k ɜː ɹ ʒ ə n
 excursus	ɪ k s k ɜː s ə s
@@ -23492,7 +23675,7 @@ exegete	ɛ k s ɪ d͡ʒ i t
 exemestane	ɛ k s ə m ɛ s t e ɪ n
 exemplar	ɛ ɡ z ɛ m p l ɑ ɹ
 exemplar	ɪ ɡ z ɛ m p l ɚ
-exemplary	ɛ ɡ z ɛ m p l ə ɹ i
+exemplary	ɪ ɡ z ɛ m p l ə ɹ i
 exemplify	ɛ ɡ z ɛ m p l ɪ f a ɪ
 exemplify	ɪ ɡ z ɛ m p l ɪ f a ɪ
 exempt	ɛ ɡ z ɛ m p t
@@ -23534,7 +23717,7 @@ exhibition	ɛ k s ɪ b ɪ ʃ ə n
 exhilarate	ɪ ɡ z ɪ l ə ɹ e ɪ t
 exhort	ɛ ɡ z ɔ ɹ t
 exhort	ɪ ɡ z ɔ ɹ t
-exhortative	ɨ ɡ z ɔ ɹ t ə t ɪ v
+exhortative	ɪ ɡ z ɔ ɹ t ə t ɪ v
 exhumation	e k s h j uː m e ɪ ʃ ə n
 exhume	ɛ k s j u m
 exhume	ɪ ɡ z j u m
@@ -23635,6 +23818,7 @@ expenditures	ɛ k s p ɛ n d ɪ t͡ʃ ɚ z
 expenditures	ɪ k s p ɛ n d ɪ t͡ʃ ɚ z
 expends	ɛ k s p ɛ n d z
 expends	ɪ k s p ɛ n d z
+expenny	ɪ k s p ɛ n i
 expense	ɪ k s p ɛ n s
 expenses	ɪ k s p ɛ n s ɪ z
 expensive	ɛ k s p ɛ n s ɪ v
@@ -23646,7 +23830,7 @@ experiences	ɪ k s p ɪ ɹ i ə n s ɪ z
 experiential	ɪ k s p ɪ ɹ i ɛ n ʃ ə l
 experiment	ɪ k s p ɛ ɹ ə m ə n t
 experiment	ɪ k s p ɪ ɹ ə m ə n t
-experimental	ɨ k s p ɛ ɹ ə m ɛ n t ə l
+experimental	ɪ k s p ɛ ɹ ə m ɛ n t ə l
 experiments	ɪ k s p ɛ ɹ ə m ə n t s
 experiments	ɪ k s p ɪ ɹ ə m ə n t s
 expert	ɛ k s p ɚ t
@@ -23686,6 +23870,7 @@ exploratory	ɛ k s p l ɔ ɹ ə t ɔ ɹ i
 explore	ɪ k s p l ɔ ɹ
 explorer	ɛ k s p l ɔː ɹ ə ɹ
 explosion	ɛ k s p l o ʊ ʒ ə n
+explosion	ɪ k s p l o ʊ ʒ ə n
 explosive	ɛ k s p l ə ʊ s ɪ v
 explosive	ɪ k s p l ə ʊ s ɪ v
 exponent	ɛ k s p o ʊ n ə n t
@@ -23698,7 +23883,7 @@ expose	ɛ k s p o ʊ z
 expose	ɪ k s p o ʊ z
 exposition	ɛ k s p ə z ɪ ʃ ə n
 expository	ɛ k s p ɑ z ə t ɔ ɹ i
-expostulate	ɛ k s p ɒ s t j ʊ l e ɪ t
+expostulate	ɛ k s p ɑ s t j ʊ l e ɪ t
 exposure	ɪ k s p o ʊ ʒ ɚ
 exposé	ɛ k s p o ʊ z e ɪ
 expound	ɪ k s p a ʊ n d
@@ -23858,7 +24043,6 @@ exude	ɪ k s u d
 exude	ɪ ɡ z u d
 exult	ɪ ɡ z ʌ l t
 exultation	ɛ ɡ z ʌ l t e ɪ ʃ ə n
-exuma	ɛ k s uː m ə
 exuviate	ɛ k s uː v ɪ e ɪ t
 exuviate	ɛ ɡ z uː v ɪ e ɪ t
 ey	e ɪ
@@ -23953,7 +24137,8 @@ factoid	f æ k t ɔ ɪ d
 factor	f æ k t ɚ
 factorial	f æ k t ɔː ɹ i ə l
 factors	f æ k t ɚ z
-factory	f æ k t ə ɹ i
+factory	f æ k t ɚ i
+factory	f æ k t ɹ i
 factotum	f æ k t o ʊ t ə m
 facts	f æ k s
 facts	f æ k t s
@@ -23977,8 +24162,8 @@ fadge	f æ d͡ʒ
 fading	f e ɪ d ɪ ŋ
 fado	f ɑː d o ʊ
 fady	f e ɪ d i
+fady	f æ d i
 fady	f ɑː d i
-faeces	f iː s iː z
 faena	f a e n ə
 faff	f æ f
 faffy	f æ f i
@@ -24007,7 +24192,7 @@ faint	f e ɪ n t
 faintest	f e ɪ n t ə s t
 fainting	f e ɪ n t ɪ ŋ
 faintly	f e ɪ n t l i
-fair	f ɛ ə ɹ
+fair	f ɛ ɚ
 fairbanks	f ɛ ɹ b æ ŋ k s
 fairer	f ɛ ɹ ɚ
 fairest	f ɛ ɹ ɪ s t
@@ -24103,6 +24288,7 @@ fan	f æ n
 fanac	f æ n æ k
 fanatic	f ə n æ t ɪ k
 fanatical	f ə n æ t ɪ k ə l
+fanaticism	f ə n æ t ɪ s ɪ z ə m
 fancied	f æ n s ɪ d
 fancies	f æ n s i z
 fanciful	f æ n s ɪ f ə l
@@ -24110,6 +24296,7 @@ fancy	f æ n s i
 fand	f æ n d
 fandemonium	f æ n d ə m ə ʊ n i ə m
 fandom	f æ n d ə m
+fandosentan	f æ n d ə s ɛ n t æ n
 fandub	f æ n d ʌ b
 fane	f e ɪ n
 faned	f æ n ɛ d
@@ -24154,6 +24341,7 @@ fantastic	f æ n t æ s t ɪ k
 fantastical	f æ n t æ s t ɪ k ə l
 fantasy	f æ n t ə s i
 fanti	f æ n t i
+fantods	f æ n t ɒ d z
 fanzine	f æ n z iː n
 fap	f æ p
 fapiao	f ɑː p i a ʊ
@@ -24174,7 +24362,7 @@ fare	f ɛ ɹ
 fareham	f ɛ ə ɹ ə m
 farer	f ɛ ɹ ɚ
 fareway	f ɛ ɹ w e ɪ
-farewell	f ɛ ə ɹ w ɛ l
+farewell	f ɛ ɚ w ɛ l
 farfalle	f ɑ ɹ f ɑ l e ɪ
 farfetch	f ɑː ɹ f ɛ t͡ʃ
 fargo	f ɑ ɹ ɡ o ʊ
@@ -24280,6 +24468,7 @@ fathom	f æ ð ə m
 fathomable	f æ ð m ə b ə l
 fathomable	f æ ð ə m ə b ə l
 fatidical	f ə t ɪ d ɪ k ə l
+fatigue	f ə t iː ɡ
 fatiloquent	f e ɪ t ɪ l ə k w ə n t
 fatless	f æ t l ə s
 fatness	f æ t n ə s
@@ -24398,6 +24587,7 @@ febuary	f ɛ b j u æ ɹ i
 febuary	f ɛ b j u ɛ ə ɹ i
 febuxostat	f ə b ʌ k s ə s t æ t
 fecal	f iː k ə l
+feces	f iː s iː z
 feck	f ɛ k
 feckful	f ɛ k f ə l
 feckless	f ɛ k l ə s
@@ -24432,6 +24622,7 @@ feeler	f iː l ə ɹ
 feelgoodery	f i l ɡ ʊ d ə ɹ i
 feeling	f i l ɪ ŋ
 feelings	f iː l ɪ ŋ z
+feels	f i j ə l z
 feels	f iː l z
 feely	f iː l i
 feeney	f i n i
@@ -24447,11 +24638,12 @@ feijoa	f e ɪ d͡ʒ o ʊ ə
 feijoa	f e ɪ h o ʊ ə
 feijoa	f e ɪ ʒ o ʊ ə
 feijoa	f iː d͡ʒ ɐ ʉ ɐ
-feijoada	f ɛ ɪ ʒ w ɑː d ə
+feijoada	f e ɪ ʒ w ɑː d ə
 feinstein	f a ɪ n s t a ɪ n
 feinstein	f a ɪ n s t iː n
 feint	f e ɪ n t
 feinter	f e ɪ n t ə ɹ
+feirie	f ɪ ə r i
 feis	f ɛ ʃ
 feiseanna	f ɛ ʃ ə n ə
 feist	f a ɪ s t
@@ -24480,6 +24672,7 @@ felly	f ɛ l i
 felly	f ɛ l l i
 felon	f ɛ l ə n
 felony	f ɛ l ə n i
+feloprentan	f ɛ l ə p ɹ ɛ n t æ n
 felt	f ɛ l t
 felter	f ɛ l t ə ɹ
 feltham	f ɛ l t ə m
@@ -24580,6 +24773,7 @@ fermium	f ɜː ɹ m i ə m
 fern	f ɝ n
 fern	f ɝː n
 fernandez	f ɚ n æ n d ɛ z
+fernando	f ɝ n æ n d o ʊ
 fernet	f ə ɹ n ɛ t
 ferocious	f ə ɹ ə ʊ ʃ ə s
 ferocity	f ə ɹ ɑ s ɪ t i
@@ -24704,7 +24898,8 @@ fibrillate	f ʌ ɪ b r ɪ l e ɪ t
 fibrillogenic	f ɪ b ɹ ɪ l ə ʊ d͡ʒ ɛ n ɪ k
 fibrillose	f ɪ b ɹ ɪ l ə ʊ s
 fibrin	f a ɪ b ɹ ɪ n
-fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɨ n ə s
+fibrine	f a ɪ b ɹ ɪ n
+fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɪ n ə s
 fibrosis	f a ɪ b ɹ o ʊ s ɪ s
 fibrous	f a ɪ b ɹ ə s
 fibula	f ɪ b j ə l ə
@@ -24772,7 +24967,7 @@ fifeshire	f a ɪ f ʃ ə ɹ
 fifeshire	f a ɪ f ʃ ɪ ə ɹ
 fifi	f i f i
 fifo	f a ɪ f o ʊ
-fifteenth	f ɪ f t iː n θ
+fifteenth	h ɪ f t iː n θ
 fifth	f ɪ f t
 fifth	f ɪ f θ
 fifth	f ɪ θ
@@ -24883,16 +25078,16 @@ fimbriated	f ɪ m b ɹ i e ɪ t ɪ d
 fin	f ɪ n
 finagle	f ɪ n e ɪ ɡ ə l
 final	f a ɪ n ə l
-finale	f ɨ n æ l i
-finale	f ɨ n ɑ l i
+finale	f ɪ n æ l i
+finale	f ɪ n ɑ l i
 finalize	f a ɪ n ə l a ɪ z
 finally	f a ɪ n l i
 finally	f a ɪ n ə l i
 finals	f a ɪ n ə l z
 finance	f a ɪ n æ n s
 finance	f ɪ n æ n s
-finances	f a ɪ n æ n s ɨ z
-finances	f ɪ n æ n s ɨ z
+finances	f a ɪ n æ n s ɪ z
+finances	f ɪ n æ n s ɪ z
 financial	f a ɪ n æ n ʃ ə l
 financial	f ɪ n æ n ʃ ə l
 financier	f a ɪ n æ n s ɪ ə ɹ
@@ -25035,6 +25230,7 @@ fissure	f ɪ ʃ ɚ
 fissure	f ɪ ʒ ɚ
 fist	f ɪ s t
 fisted	f ɪ s t ɪ d
+fister	f ɪ s t ɚ
 fistfight	f ɪ s t f a ɪ t
 fistful	f ɪ s t f ʊ l
 fistiana	f ɪ s t ɪ e ɪ n ə
@@ -25098,7 +25294,6 @@ flabby	f l æ b i
 flabellate	f l ə b ɛ l ə t
 flabellum	f l ə b ɛ l ə m
 flaccid	f l æ k s ɪ d
-flaccid	f l æ s ɪ d
 flaccider	f l æ s ɪ d ɚ
 flack	f l æ k
 flacon	f l æ k ɒ n
@@ -25242,6 +25437,7 @@ flecking	f l ɛ k ɪ ŋ
 fleckings	f l ɛ k ɪ ŋ z
 flecks	f l ɛ k s
 flecky	f l ɛ k i
+flector	f l ɛ k t ə ɹ
 fled	f l ɛ d
 fledge	f l ɛ d͡ʒ
 fledged	f l ɛ d͡ʒ d
@@ -25352,6 +25548,7 @@ floccinaucinihilipilification	f l ɒ k s i n ɒ s i n ɪ h ɪ l ɪ p ɪ l ɪ f �
 floccinaucinihilipilification	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə n
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɒ s ɪ n ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
+flocculent	f l ɑ k j ə l ə n t
 flock	f l ɑ k
 flocks	f l ɔ k s
 flog	f l ɑ ɡ
@@ -25433,6 +25630,7 @@ flowering	f l a ʊ ə ɹ ɪ ŋ
 flowerpot	f l a ʊ ɚ p ɑ t
 flowers	f l a ʊ ɚ z
 flowing	f l o ʊ ɪ ŋ
+flowk	f l a ʊ k
 flown	f l o ʊ n
 flowrate	f l o ʊ ɹ e ɪ t
 flows	f l o ʊ z
@@ -25486,7 +25684,7 @@ fluorapatite	f l ʊ ə ɹ æ p ə t a ɪ t
 fluorate	f l o ɹ e ɪ t
 fluorate	f l ʊ ə ɹ e ɪ t
 fluorescence	f l ʊ ɹ ɛ s ə n s
-fluorescent	f l ɔ ɹ ɛ s ɨ n t
+fluorescent	f l ɔ ɹ ɛ s ə n t
 fluorescently	f l o ʊ ɹ ɛ s ə n t l i
 fluoride	f l ɔ ɹ a ɪ d
 fluoride	f l ʊ ɚ a ɪ d
@@ -25646,6 +25844,7 @@ foodstuff	f uː d s t ʌ f
 foofaraw	f u f ə ɹ ɔ
 foofooraw	f uː f ə ɹ ɔː
 fook	f uː k
+fook	f ʊ k
 fool	f uː l
 fooled	f uː l d
 fooler	f uː l ə ɹ
@@ -25710,9 +25909,9 @@ forbear	f ɔ ɹ b ɛ ɚ
 forbearance	f ɔ ɹ b ɛ ɹ ə n t s
 forbes	f ɔ ɹ b z
 forbid	f ɚ b ɪ d
-forbidden	f ɝ b ɪ d ə n
+forbidden	f ɚ b ɪ d n̩
 forbidding	f ɚ b ɪ d ɪ ŋ
-force	f o ɹ s
+force	f ɔ ɹ s
 forced	f ɔ ɹ s t
 forceful	f ɔ ɹ s f ə l
 forcefulness	f ɔː ɹ s f ə l n ə s
@@ -25859,6 +26058,7 @@ formulae	f ɔː ɹ m j ə l e ɪ
 formulae	f ɔː ɹ m j ə l i
 formulaic	f ɔ ɹ m j ə l e ɪ ɪ k
 formulaicity	f ɔ ɹ m j ə l e ɪ ɪ s ə t iː
+formulary	f ɔː ɹ m j ʊ l ə ɹ i
 formulate	f ɔː ɹ m j ʊ l e ɪ t
 formule	f ɔː ɹ m j uː l
 fornicate	f ɔ ɹ n ɪ k e ɪ t
@@ -25922,11 +26122,11 @@ fortunate	f ɔ ɹ t͡ʃ n ɪ t
 fortunate	f ɔ ɹ t͡ʃ ə n ə t
 fortunate	f ɔ ɹ t͡ʃ ə n ɪ t
 fortunately	f ɔ ɹ t͡ʃ ə n ɪ t l i
-fortune	f ɔ ɹ t͡ʃ u n
+fortune	f o ɹ t͡ʃ u n
 fortune	f ɔ ɹ t͡ʃ ə n
 forty	f ɔ ɹ t i
 fortyish	f ɔː ɹ t i ɪ ʃ
-forum	f o ɹ ə m
+forum	f ɔ ɹ ə m
 forward	f o ʊ w ɚ d
 forward	f ɔ ɹ w ɚ d
 forward	f ɔ ɹ ɚ d
@@ -25939,7 +26139,10 @@ foscarnet	f ɑ s k ɑ ɹ n ɪ t
 fosphenytoin	f ɑ s f ə n ɪ t o ʊ ɪ n
 foss	f ɑ s
 foss	f ɔ s
+fossa	f uː s ə
 fossa	f ɑ s ə
+fossa	f ɔ s ə
+fossa	f ʊ s ə
 fossae	f ɑ s i
 fosse	f ɑ s
 fosse	f ɔ s
@@ -26033,6 +26236,7 @@ fragor	f ɹ e ɪ ɡ ə ɹ
 fragrance	f ɹ e ɪ ɡ ɹ ə n s
 fragrant	f ɹ e ɪ ɡ ɹ ə n t
 fraidy	f ɹ e ɪ d i
+fraight	f ɹ e ɪ t
 frail	f ɹ e ɪ l
 frain	f ɹ e ɪ n
 fraischeur	f ɹ e ɪ ʃ ə ɹ
@@ -26443,6 +26647,7 @@ fubar	f uː b ɑː ɹ
 fubbery	f ʌ b ə ɹ i
 fubble	f ʌ b ə l
 fubu	f u b ʊ
+fuchien	f uː t ʃ i ɛ n
 fuchs	f j uː k s
 fuchsia	f j uː ʃ ə
 fuchsine	f j u k s i n
@@ -26482,6 +26687,7 @@ fuel	f j ʊ ə l
 fuero	f w ɛ ə ɹ ə ʊ
 fufufu	f uː f uː f uː
 fug	f ʌ ɡ
+fuga	f j uː ɡ ə
 fugacious	f j uː ɡ e ɪ ʃ ə s
 fugazi	f u ɡ ɑ z i
 fugged	f ʌ ɡ d
@@ -26561,11 +26767,13 @@ fumble	f ʌ m b ə l
 fumed	f j uː m d
 fumer	f j uː m ə ɹ
 fumes	f j uː m z
+fumfer	f ə m f ə r
 fumigate	f j uː m ɪ ɡ e ɪ t
 fumigation	f j uː m ɪ ɡ e ɪ ʃ ə n
 fuming	f j uː m ɪ ŋ
 fumings	f j uː m ɪ ŋ z
 fun	f ʌ n
+funafuti	f uː n ə f uː t i
 funalicious	f ʌ n ə l ɪ ʃ ə s
 funambulate	f j ʊ n æ m b j ʊ l e ɪ t
 funambulist	f j uː n æ m b j ʊ l ɪ s t
@@ -26589,6 +26797,7 @@ fundraiser	f ʌ n d ɹ e ɪ z ɚ
 fundraising	f ʌ n d ɹ e ɪ z ɪ ŋ
 funds	f ʌ n d z
 funemployed	f ʌ n ɪ m p l ɔ ɪ d
+funen	f j uː n ə n
 funeral	f j u n ə ɹ ə l
 funerary	f j uː n ə ɹ ə ɹ i
 funerial	f j uː n ɪ ə ɹ i ə l
@@ -26660,6 +26869,7 @@ fursona	f ɝ s o ʊ n ə
 fursuiter	f ɝ s u t ɚ
 further	f ɝ ð ɚ
 furtherance	f ɚ ð ə ɹ ə n t s
+furthermore	f ɝ ð ɚ m ɔ ɹ
 furthest	f ɜː ɹ ð ɪ s t
 furtive	f ɝ t ɪ v
 furuncle	f j ʊ ɹ ʌ ŋ k ə l
@@ -26724,7 +26934,6 @@ fuxing	f u ʃ ɪ ŋ
 fuze	f j uː z
 fuzed	f j uː z d
 fuzhou	f u d͡ʒ o ʊ
-fuzhou	f u t͡s o ʊ
 fuzhounese	f u d͡ʒ o ʊ n i z
 fuzz	f ʌ z
 fuzzed	f ʌ z d
@@ -26765,8 +26974,9 @@ gabby	ɡ æ b i
 gabe	ɡ e ɪ b
 gabel	ɡ e ɪ b ə l
 gabfest	ɡ æ b f ɛ s t
-gabion	ɡ e ɪ b ɪ ə n
+gabion	ɡ e ɪ b i ə n
 gable	ɡ e ɪ b ə l
+gablet	ɡ e ɪ b l ə t
 gabon	ɡ ə b ɒ n
 gabriel	ɡ e ɪ b ɹ i ə l
 gabriella	ɡ æ b ɹ i ɛ l ə
@@ -26795,6 +27005,7 @@ gadolinium	ɡ æ d ə l ɪ n i ə m
 gadroon	ɡ ə d ɹ uː n
 gadrooned	ɡ ə d ɹ uː n d
 gadsbud	ɡ æ d z b ʌ d
+gadus	ɡ e ɪ d ə s
 gadzooks	ɡ æ d z uː k s
 gaea	d͡ʒ iː ə
 gaea	ɡ a ɪ ə
@@ -26848,6 +27059,7 @@ gaiting	ɡ e ɪ t ɪ ŋ
 gaits	ɡ e ɪ t s
 gaiwan	ɡ a ɪ w ɑː n
 gaja	ɡ ɑː d͡ʒ ə
+gak	ɡ æ k
 gal	ɡ æ l
 gala	ɡ e ɪ l ə
 gala	ɡ æ l ə
@@ -26877,6 +27089,7 @@ galicia	ɡ ə l ɪ s i ə
 galicia	ɡ ə l ɪ ʃ ə
 galician	ɡ ə l ɪ s i ə n
 galician	ɡ ə l ɪ ʃ ə n
+galileo	ɡ æ l ɪ l e ɪ ə ʊ
 galimatias	ɡ æ l ə m e ɪ ʃ i ə s
 galingale	ɡ æ l ɪ ŋ ɡ e ɪ l
 gall	ɡ ɔː l
@@ -26925,7 +27138,7 @@ galvanic	ɡ æ l v æ n ɪ k
 galvanism	ɡ æ l v ə n ɪ z ə m
 galvanize	ɡ æ l v ə n a ɪ̯ z
 galvanometer	ɡ æ l v ə n ɑ m ə t ɚ
-galveston	ɡ æ l v ə s t ə n
+galveston	ɡ æ l v ɪ s t ə n
 galway	ɡ ɔ l w e ɪ
 galwegian	ɡ ɔ l w i d͡ʒ ə n
 galyak	ɡ æ l j æ k
@@ -26936,9 +27149,9 @@ gamaliel	ɡ æ m ə l iː ə l
 gamaliel	ɡ ə m e ɪ l y ə l
 gamb	ɡ æ m b
 gambell	ɡ æ m b ə l
-gambeson	ɡ æ m b ɨ s ə n
+gambeson	ɡ æ m b ɪ s ə n
 gambia	ɡ æ m b i ə
-gambison	ɡ æ m b ɨ s ə n
+gambison	ɡ æ m b ɪ s ə n
 gambit	ɡ æ m b ɪ t
 gamble	ɡ æ m b ə l
 gambling	ɡ æ m b l ɪ ŋ
@@ -26998,6 +27211,9 @@ gangsteress	ɡ æ ŋ s t ə ɹ ɛ s
 gangue	ɡ æ ŋ
 ganguro	ɡ ɑː n ɡ u ɹ ə ʊ
 ganister	ɡ æ n ɪ s t ə ɹ
+ganj	g ɑː n d ʒ
+ganj	g ʌ n d ʒ
+ganj	ɡ æ n d ʒ
 ganja	ɡ ɑ n d͡ʒ ə
 ganjapreneur	ɡ æ n d͡ʒ ə p ɹ ə n ɜː ɹ
 ganjapreneur	ɡ ɑ n d͡ʒ ə p ɹ ə n ɜː ɹ
@@ -27022,7 +27238,7 @@ gapper	ɡ æ p ə ɹ
 gapping	ɡ æ p ɪ ŋ
 gaps	ɡ æ p s
 gar	ɡ ɑ ɹ
-garage	ɡ ə ɹ ɑ d͡ʒ
+garage	ɡ ə ɹ ɑ d ʒ
 garb	ɡ ɑː ɹ b
 garbage	ɡ ɑ ɹ b ɑː ʒ
 garbage	ɡ ɑ ɹ b ɪ d͡ʒ
@@ -27088,11 +27304,13 @@ garçon	ɡ ɑː ɹ s ɒ n
 garçon	ɡ ɑː ɹ s ɒ̃
 garçonnière	ɡ ɑ ɹ s ə n j ɛ ɚ
 gas	ɡ æ s
+gas	ɡ æ z
 gasahol	ɡ æ s ə h ɑ l
 gasbag	ɡ æ s b æ ɡ
 gascon	ɡ æ s k ə n
 gaseous	ɡ æ ʃ ə s
 gases	ɡ æ s ɪ z
+gases	ɡ æ z ɪ z
 gash	ɡ æ ʃ
 gasket	ɡ æ s k ɪ t
 gaskin	ɡ æ s k ɪ n
@@ -27101,7 +27319,7 @@ gaslight	ɡ æ s l a ɪ t
 gasohol	ɡ æ s ə h ɑ l
 gasoline	ɡ æ s l i n
 gasoline	ɡ æ s l̩ i n
-gasoline	ɡ æ s ə l i n
+gasoline	ɡ æ s ə l iː n
 gasometer	ɡ æ s ɑ m ɪ t ɚ
 gasp	ɡ æ s p
 gasped	ɡ æ s p t
@@ -27133,9 +27351,10 @@ gateshead	ɡ e ɪ t s h ɛ d
 gateway	ɡ e ɪ t w e ɪ
 gather	ɡ æ ð ɚ
 gathered	ɡ æ ð ɚ d
-gathering	ɡ æ ð ə ɹ ɪ ŋ
+gathering	ɡ æ ð ɚ ɪ ŋ
 gatifloxacin	ɡ æ t ɪ f l ɑ k s ə s ɪ n
 gator	ɡ e ɪ t ə ɹ
+gatorade	ɡ e ɪ t ə ɹ e ɪ d
 gau	ɡ a ʊ
 gauche	ɡ a ʊ ʃ
 gauche	ɡ o ʊ ʃ
@@ -27177,6 +27396,7 @@ gaw	ɡ ɔː
 gawa	ɡ a w a
 gawain	ɡ ɑː w e ɪ n
 gawain	ɡ ə w e ɪ n
+gawber	ɡ ɔː b ə ɹ
 gawd	ɡ ɔː d
 gawf	ɡ ɔː f
 gawk	ɡ ɔː k
@@ -27206,7 +27426,7 @@ gazehound	ɡ e ɪ z h a ʊ n d
 gazella	ɡ ə z ɛ l ə
 gazelle	ɡ ə z ɛ l
 gazes	ɡ e ɪ z ə z
-gazes	ɡ e ɪ z ɨ z
+gazes	ɡ e ɪ z ɪ z
 gazette	ɡ ə z ɛ t
 gazillion	ɡ ə z ɪ l j ə n
 gazing	ɡ e ɪ z ɪ ŋ
@@ -27314,12 +27534,12 @@ gendersex	d͡ʒ ɛ n d ɚ s ɛ k s
 gene	d͡ʒ iː n
 genealogy	d͡ʒ i n i æ l ə d ʒ i
 genealogy	d͡ʒ i n i ɑ l ə d ʒ i
+genearch	d ʒ iː n i ɑː ɹ k
 genera	d͡ʒ ɛ n ə ɹ ə
 general	d͡ʒ ɛ n ə ɹ ə l
 general	d͡ʒ ɛ n ɹ ə l
 generalia	d͡ʒ ɛ n ə ɹ e ɪ l i ə
-generalissimo	d͡ʒ ɛ n ə ɹ ə l iː s ɪ m ə ʊ
-generalissimo	d͡ʒ ɛ n ə ɹ ə l ɪ s ɪ m ə ʊ
+generalissimo	d͡ʒ ɛ n ə ɹ ə l i s i m o ʊ
 generally	d͡ʒ ɛ n ɚ l i
 generally	d͡ʒ ɛ n ɚ ə l i
 generals	d͡ʒ ɛ n ə ɹ ə l z
@@ -27467,6 +27687,7 @@ georgie	d͡ʒ ɔ ɹ d͡ʒ i
 geoscientist	d͡ʒ i o ʊ s a ɪ ə n t ɪ s t
 geosmin	d͡ʒ i ɑ z m ɪ n
 geospace	d͡ʒ iː ə ʊ s p e ɪ s
+geospeedometry	d ʒ iː ə ʊ s p iː d ɒ m ɪ t ɹ i
 geosphere	d͡ʒ iː ə s f ɪ ə ɹ
 geosphere	d͡ʒ iː ə ʊ s f ɪ ə ɹ
 geostrophic	d͡ʒ ɪ ə s t ɹ o ʊ f ɪ k
@@ -27479,6 +27700,7 @@ geppetto	d͡ʒ ə p ɛ t o ʊ
 ger	ɡ ɛ ə ɹ
 geraint	ɡ ɛ ɹ a ɪ n t
 gerald	d͡ʒ ɛ ɹ ə l d
+geranium	d ʒ ə ɹ e ɪ n i ə m
 geranylgeranylacetone	d͡ʒ ɛ ɹ ə n ɪ l d͡ʒ ɛ ɹ ə n ɪ l æ s ɪ t ə ʊ n
 gerard	d͡ʒ ə ɹ ɑ ɹ d
 gerbe	d͡ʒ ɜː ɹ b
@@ -27495,6 +27717,7 @@ germanize	d͡ʒ ɝ m ə n a ɪ z
 germans	d͡ʒ ɝ m ə n z
 germany	d͡ʒ ɝ m ə n i
 germen	d͡ʒ ɝ m ə n
+germinal	d ʒ ɜː ɹ m ɪ n ə l
 germinal	d͡ʒ ɝ m ə n ə l
 germinate	d͡ʒ ɜː ɹ m ɪ n e ɪ t
 gern	ɡ ɜː ɹ n
@@ -27509,7 +27732,7 @@ gershon	ɡ ɝ ʃ ɑ n
 gersum	ɡ ɝ s ə m
 gertrude	ɡ ɝ t ɹ u d
 gerund	d͡ʒ ɛ ɹ ə n d
-gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɨ
+gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɪ
 gesellschaft	ɡ ə z ɛ l ʃ a f t
 gesso	d͡ʒ ɛ s ə ʊ
 gest	d͡ʒ ɛ s t
@@ -27568,6 +27791,7 @@ gherao	ɡ ɛ ɹ a ʊ
 gherkin	ɡ ɝ k ɪ n
 ghetto	ɡ ɛ t o ʊ
 ghettoize	ɡ ɛ t o ʊ a ɪ z
+ghey	d ʒ a ɪ
 ghibelline	ɡ ɪ b ə l a ɪ n
 ghibelline	ɡ ɪ b ə l i n
 ghibelline	ɡ ɪ b ə l ə n
@@ -27716,7 +27940,7 @@ gingerol	d͡ʒ ɪ n d͡ʒ ə ɹ ɒ l
 gingham	ɡ ɪ ŋ ə m
 gingiva	d͡ʒ ɪ n d͡ʒ a ɪ v ə
 gingiva	d͡ʒ ɪ n d͡ʒ ɪ v ə
-gingival	d͡ʒ ɪ n d͡ʒ ɨ v ə l
+gingival	d͡ʒ ɪ n d͡ʒ ɪ v ə l
 gingivitis	d͡ʒ ɪ n d͡ʒ ɪ v a ɪ t ə s
 gingras	d͡ʒ i ŋ ɡ ɹ ə s
 gink	ɡ ɪ ŋ k
@@ -27748,16 +27972,20 @@ girlcott	ɡ ɚ l k ɒ t
 girlcott	ɡ ɚ ə l k ɔ t
 girldick	ɡ ɚ l d ɪ k
 girldick	ɡ ɚ ə l d ɪ k
+girlf	ɡ ɝ l f
 girlfriend	ɡ ɝ l f ɹ ɛ n d
 girlish	ɡ ɚ l ɪ ʃ
 girls	ɡ ɝ l z
 girly	ɡ ɝ l i
+girlypop	ɡ ɚ l i p ɑ p
 girona	d͡ʒ ɪ ɹ o ʊ n ə
 gironde	d͡ʒ ɪ ɹ ɑ n d
 girt	ɡ ɝ t
 girth	ɡ ɝ θ
 girus	d͡ʒ a ɪ ɹ ə s
 gisborne	ɡ ɪ z b ɚ n
+giselle	d ʒ ɪ z ɛ l
+giselle	ʒ ɪ z ɛ l
 gismu	ɡ iː s m uː
 gist	d͡ʒ ɪ s t
 git	ɡ ɪ t
@@ -27823,7 +28051,7 @@ gland	ɡ l æ n d
 glands	ɡ l æ n d z
 glandular	ɡ l æ n d͡ʒ ə l ɚ
 glans	ɡ l æ n z
-glare	ɡ l ɛ ə ɹ
+glare	ɡ l ɛ ɚ
 glaring	ɡ l ɛ ɹ ɪ ŋ
 glaringly	ɡ l ɛ ɹ ɪ ŋ l i
 glary	ɡ l ɛ ə ɹ i
@@ -27947,6 +28175,7 @@ globster	ɡ l ɑ b s t ɚ
 globular	ɡ l ɑ b j ə l ɚ
 globule	ɡ l ɑ b j u l
 globulin	ɡ l ɑ b j ə l ɪ n
+globus	ɡ l ə ʊ b ə s
 globy	ɡ l ə ʊ b i
 glockenspiel	ɡ l ɑ k ə n ʃ p i l
 glode	ɡ l ə ʊ d
@@ -27984,6 +28213,8 @@ glossary	ɡ l ɒ s ə ɹ i
 glossitis	ɡ l ɒ s a ɪ t ɪ s
 glossolalia	ɡ l ɑ s ə l e ɪ l i ə
 glossology	ɡ l ɔ s ɑ l ə d͡ʒ i
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t a ɪ n
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t ɪ n
 glossopharyngeal	ɡ l ɑ s o ʊ f ə ɹ ɪ n d͡ʒ i ə l
 glossopharyngeal	ɡ l ɑ s o ʊ f ə ɹ ɪ n d͡ʒ ə l
 glossopharyngeal	ɡ l ɑ s o ʊ f ɛ ɹ ə n d͡ʒ i ə l
@@ -28226,7 +28457,7 @@ gonad	ɡ ə ʊ n æ d
 gondolet	ɡ ɒ n d ə l ɛ t
 gondolier	ɡ ɑ n d ə l ɪ ɹ
 gondwana	ɡ ɑ n d w ɑ n ə
-gone	ɡ ɔː n
+gone	ɡ ɔ n
 goner	ɡ ɔː n ɚ
 gonfalon	ɡ ɑː n f ə l ɑː n
 gong	ɡ ɑ ŋ
@@ -28291,7 +28522,7 @@ goop	ɡ uː p
 goopy	ɡ uː p i
 goos	ɡ uː s
 goos	ɡ uː z
-goose	ɡ uː s
+goose	ɡ ʉː s
 gooseberry	ɡ u s b ɛ ɹ i
 goosefoot	ɡ uː s f ʊ t
 goosish	ɡ uː s ɪ ʃ
@@ -28313,8 +28544,10 @@ gorgeous	ɡ ɔ ɹ d͡ʒ ə s
 gorgeret	ɡ ɔ ɹ d͡ʒ ə ɹ ɛ t
 gorgerette	ɡ ɔ ɹ d͡ʒ ə ɹ ɛ t
 gorgerin	ɡ ɔ ɹ d͡ʒ ə ɹ ɪ n
-gorget	ɡ ɔ ɹ d͡ʒ ə t
-gorget	ɡ ɔ ɹ d͡ʒ ɪ t
+gorget	ɡ o ɹ d͡ʒ ə t
+gorget	ɡ o ɹ d͡ʒ ɛ t
+gorget	ɡ o ɹ d͡ʒ ɪ t
+gorget	ɡ o ɹ ʒ e ɪ
 gorgias	ɡ ɔ ɹ d͡ʒ i ə s
 gorgon	ɡ ɔː r ɡ ə n
 gorhen	ɡ ɔː h ɛ n
@@ -28323,7 +28556,7 @@ gork	ɡ ɔː ɹ k
 gorm	ɡ ɔː ɹ m
 gormy	ɡ ɔ ɹ m i
 goropism	ɡ ə ɹ ə ʊ p ɪ z ə m
-gorp	ɡ ɔː ɹ p
+gorp	ɡ ɔ ɹ p
 gorse	ɡ ɔ ɹ s
 gorsedd	ɡ ɔː ɹ s ɛ ð
 gorseddau	ɡ ɔː ɹ s ɛ ð a ɪ
@@ -28335,6 +28568,7 @@ gosewehr	ɡ o ʊ z w ɛ ə ɹ
 gosh	ɡ ɑː ʃ
 gosha	ɡ o ʊ ʃ ə
 goshbustified	ɡ ɒ ʃ b ʌ s t ɪ f a ɪ d
+gosht	ɡ o ʊ ʃ t
 gosling	ɡ ɑ z l ɪ ŋ
 gospel	ɡ ɑ s p ə l
 gosplan	ɡ ɒ s p l æ n
@@ -28401,7 +28635,8 @@ government	ɡ ʌ v ɚ n m ə n t
 governmental	ɡ ʌ v ə n m ɛ n t ə l
 governments	ɡ ʌ v ɚ n m ə n t s
 governor	ɡ ʌ v ə n ə ɹ
-governor	ɡ ʌ v ə ɹ n ə ɹ
+governor	ɡ ʌ v ə n ɚ
+governor	ɡ ʌ v ɚ n ɚ
 governorate	ɡ ʌ v ə ɹ n ə ɹ ə t
 govvy	ɡ ʌ v i
 gow	ɡ a ʊ
@@ -28583,6 +28818,8 @@ grasped	ɡ ɹ æ s p t
 grasping	ɡ ɹ æ s p ɪ ŋ
 grass	ɡ ɹ æ s
 grass	ɡ ɹ ɑː s
+grasshawk	ɡ ɹ æ s h ɔː k
+grasshawk	ɡ ɹ ɑː s h ɔː k
 grasshopper	ɡ ɹ æ s h ɑ p ə ɹ
 grassley	ɡ ɹ æ s l i
 grassley	ɡ ɹ ɑː s l i
@@ -28702,7 +28939,7 @@ greenery	ɡ ɹ iː n ə ɹ i
 greenfield	ɡ ɹ i n f i l d
 greengage	ɡ ɹ iː n ɡ e ɪ d͡ʒ
 greenhouse	ɡ ɹ iː n h a ʊ s
-greeniac	ɡ ɹ i n i æ k
+greeniac	ɡ ɹ iː n i æ k
 greening	ɡ ɹ iː n ɪ ŋ
 greenings	ɡ ɹ iː n ɪ ŋ z
 greenish	ɡ ɹ iː n ɪ ʃ
@@ -28735,7 +28972,7 @@ greeze	ɡ ɹ iː z
 greffier	ɡ ɹ ɛ f i ə ɹ
 greg	ɡ ɹ ɛ ɡ
 gregale	ɡ ɹ e ɪ ɡ ɑː l e ɪ
-gregarious	ɡ ɹ ɨ ɡ ɛ ɹ i ə s
+gregarious	ɡ ɹ ɪ ɡ ɛ ɹ i ə s
 gregg	ɡ ɹ ɛ ɡ
 gregorian	ɡ ɹ ɪ ɡ ɔː ɹ i ə n
 gregory	ɡ ɹ ɛ ɡ ə ɹ i
@@ -28755,8 +28992,10 @@ greven	ɡ ɹ i v ə n
 greviere	ɡ ɹ ɛ v j ɛ ə ɹ
 grew	ɡ ɹ u ʊ̯
 grew	ɡ ɹ uː
+grex	ɡ ɹ ɛ k s
 grexit	ɡ ɹ ɛ k s ɪ t
 grexit	ɡ ɹ ɛ ɡ z ɪ t
+grey	ɡ ɹ e ɪ
 greyhound	ɡ ɹ e ɪ h a ʊ n d
 greyish	ɡ ɹ e ɪ ɪ ʃ
 greylag	ɡ ɹ e ɪ l æ ɡ
@@ -28766,6 +29005,7 @@ gribenes	ɡ ɹ ɪ b ə n ə s
 grid	ɡ ɹ ɪ d
 gridded	ɡ ɹ ɪ d ɪ d
 gridding	ɡ ɹ ɪ d ɪ ŋ
+griddle	ɡ ɹ ɪ d ə l
 gride	ɡ ɹ a ɪ d
 griding	ɡ ɹ a ɪ d ɪ ŋ
 gridlock	ɡ ɹ ɪ d l ɑ k
@@ -28788,6 +29028,7 @@ griff	ɡ ɹ ɪ f
 griffe	ɡ ɹ ɪ f
 griffin	ɡ ɹ ɪ f ɪ n
 griffith	ɡ ɹ ɪ f ɪ θ
+griffon	ɡ ɹ ɪ f ə n
 grift	ɡ ɹ ɪ f t
 grifter	ɡ ɹ ɪ f t ɚ
 grifting	ɡ ɹ ɪ f t ɪ ŋ
@@ -28795,7 +29036,7 @@ grig	ɡ ɹ ɪ ɡ
 grike	ɡ ɹ a ɪ k
 grill	ɡ ɹ ɪ l
 grillade	ɡ ɹ i j ɑː d
-grillade	ɡ ɹ ɨ l ɑː d
+grillade	ɡ ɹ ɪ l ɑː d
 grillbilly	ɡ ɹ ɪ l b ɪ l i
 grille	ɡ ɹ ɪ l
 grilled	ɡ ɹ ɪ l d
@@ -28974,6 +29215,7 @@ gruel	ɡ ɹ uː ə l
 gruelling	ɡ ɹ u l ɪ ŋ
 gruelling	ɡ ɹ u ə l ɪ ŋ
 grues	ɡ ɹ uː z
+gruesome	ɡ ɹ uː s ʌ m
 gruff	ɡ ɹ ʌ f
 gruffish	ɡ ɹ ʌ f ɪ ʃ
 gruit	ɡ ɹ a ɪ t
@@ -29023,7 +29265,7 @@ guadeloupe	ɡ w ɑ d ə l ʊ p
 guadeloupe	ɡ w ɑː d ə l uː p
 guadiana	ɡ w ɑ d i ɑ n ə
 guadiana	ɡ w ɑ d j ɑ n ə
-guaifenesin	ɡ w a ɪ f ɛ n ɨ s ɪ n
+guaifenesin	ɡ w a ɪ f ɛ n ɪ s ɪ n
 guakong	ɡ ʊ ɐ k o ŋ
 guam	ɡ w ɑ m
 guama	ɡ ʊ ɐ m a
@@ -29042,6 +29284,7 @@ guanines	ɡ w ɑː n iː n z
 guano	ɡ w ɑː n ə ʊ
 guanxi	k w a n ʃ i
 guanxi	ɡ w a n ʃ i
+guanylate	ɡ w ɑː n ɪ l e ɪ t
 guarana	ɡ w ə ɹ ɑː n ə
 guaranine	ɡ w ɑː ɹ ə n iː n
 guarantee	ɡ ɛ ə ɹ ə n t iː
@@ -29091,6 +29334,10 @@ guffaw	ɡ ə f ɔ
 guhr	ɡ ʊ ə ɹ
 gui	d ʒ iː j uː a ɪ
 gui	ɡ uː i
+guiana	g a ɪ æ n ə
+guiana	g a ɪ ɑː n ə
+guiana	ɡ i æ n ə
+guiana	ɡ i ɑː n ə ,
 guiche	ɡ iː ʃ
 guidance	ɡ a ɪ d ə n s
 guide	ɡ a ɪ d
@@ -29192,6 +29439,7 @@ gulpings	ɡ ʌ l p ɪ ŋ z
 gulps	ɡ ʌ l p s
 guly	ɡ j u l i
 gum	ɡ ʌ m
+gumbo	ɡ ʌ m b o ʊ
 gumdrop	ɡ ʌ m d ɹ ɑː p
 gummed	ɡ ʌ m d
 gumming	ɡ ʌ m ɪ ŋ
@@ -29201,6 +29449,7 @@ gumption	ɡ ʌ m p ʃ ə n
 gums	ɡ ʌ m z
 gumshoe	ɡ ʌ m ʃ uː
 gun	ɡ ʌ n
+guna	ɡ ʊ n ə
 gunai	ɡ ʌ n a ɪ
 gunate	ɡ u n e ɪ t
 gundelet	ɡ ʌ n d ə l ə t
@@ -29258,6 +29507,7 @@ gusle	ɡ ʊ s l ə
 gusset	ɡ ʌ s ɪ t
 gust	ɡ ʌ s t
 gustable	ɡ ʌ s t ə b ə l
+gustatory	ɡ ʌ s t ə t ɔ ɹ i
 gustavia	ɡ ʊ s t æ v i ə
 gusted	ɡ ʌ s t ɪ d
 gustfulness	ɡ ʌ s t f ə l n ə s
@@ -29291,6 +29541,7 @@ guys	ɡ a ɪ z
 guyu	ɡ uː j uː
 guyver	ɡ a ɪ v ə
 guz	ɡ ʌ z
+guze	ɡ j uː z
 guzheng	ɡ uː d͡ʒ ʌ ŋ
 guzman	ɡ u z m ɑ n
 guzzle	ɡ ʌ z ə l
@@ -29303,6 +29554,8 @@ gwyneth	ɡ w ɪ n e θ
 gwyneth	ɡ w ɪ n ə θ
 gwyneth	ɡ w ɪ n ɪ θ
 gwyniad	ɡ w ɪ n iː ɑː ɹ d
+gyaru	ɡ j æ ɹ uː
+gyaru	ɡ j ɑː ɹ uː
 gybe	d͡ʒ a ɪ b
 gylany	ɡ ɪ l ə n i
 gyle	ɡ a ɪ l
@@ -29484,7 +29737,7 @@ hagging	h æ ɡ ɪ ŋ
 haggis	h æ ɡ ɪ s
 haggis	h ɑ d͡ʒ i s
 haggle	h æ ɡ ə l
-hagiographer	h e ɪ d͡ʒ i ɑ ɡ ɹ ə f ə ɹ
+hagiographer	h æ ɡ i ɑ ɡ ɹ ə f ɚ
 hagiographic	h æ ɡ i o ʊ ɡ ɹ æ f ɪ k
 hagiography	h e ɪ d͡ʒ i ɒ ɡ ɹ ə f i
 hagiography	h æ ɡ i ɒ ɡ ɹ ə f i
@@ -29513,13 +29766,11 @@ hainan	h a ɪ n ɑː n
 haines	h e ɪ n z
 haint	h e ɪ n t
 haiphong	h a ɪ f ɒ ŋ
-hair	h ɛ ə
 hair	h ɛ ə ɹ
-hair	h ɛ ɚ
-hair	h ɛː
 hairbow	h ɛ ə ɹ b ə ʊ
 haircolor	h ɛ ə k ʌ l ɚ
 haircolor	h ɛ ɚ k ʌ l ɚ
+haircut	h ɛ ə ɹ k ʌ t
 hairdo	h ɛ ə d uː
 hairen	h ɛ ə ɹ ə n
 hairline	h ɛ ɹ l a ɪ n
@@ -29568,8 +29819,8 @@ halfness	h æ f n ə s
 halfpence	h e ɪ p ə n s
 halfpenny	h e ɪ p ə n i
 halfway	h æ f w e ɪ
-halibut	h æ l ɨ b ə t
-halibut	h ɒ l ɨ b ə t
+halibut	h æ l ɪ b ə t
+halibut	h ɒ l ɪ b ə t
 halicarnassus	h æ l ɪ k ɑ ɹ n æ s ə s
 halicore	h ə l ɪ k ə ɹ iː
 halide	h e ɪ l a ɪ d
@@ -29584,7 +29835,7 @@ hall	h ɔ l
 hallage	h ɔː l ɪ d͡ʒ
 hallatrow	h æ l ə t ɹ ə ʊ
 hallecret	h æ l ɪ k r ɛ t
-hallelujah	h æ l ɪ l j uː j ə
+hallelujah	h æ l ə l j uː j ə
 hallewell	h æ l ɪ w ɛ l
 halley	h æ l i
 hallmark	h ɔ l m ɑ ɹ k
@@ -29674,7 +29925,7 @@ hamsa	h æ m s ə
 hamsa	h ɑ m s ə
 hamster	h æ m p s t ɚ
 hamstring	h æ m s t ɹ ɪ ŋ
-hamtramck	h æ m t r æ m ɨ k
+hamtramck	h æ m t r æ m ɪ k
 hamulose	h æ m j ʊ l ə ʊ z
 han	h e ɪ n
 han	h æ n
@@ -29707,6 +29958,7 @@ handiwork	h æ n d i w ɝ k
 handkerchief	h e ɪ ŋ k ɚ t͡ʃ ɪ f
 handkerchief	h æ ŋ k ɚ t͡ʃ ɪ f
 handle	h æ n d l̩
+handle	h ɛ ə n d l̩
 handlebar	h æ n d ə l b ɑː ɹ
 handled	h æ n d l̩ d
 handler	h æ n d l ɚ
@@ -29814,6 +30066,8 @@ hard	h ɑ ɹ d
 hardcore	h ɑː ɹ d k ɔː ɹ
 harden	h ɑ ɹ d n̩
 hardened	h ɑ ɹ d n̩ d
+hardener	h ɑ ɹ d n̩ ɚ
+hardener	h ɑ ɹ d ə n ɚ
 harder	h ɑ ɹ ɾ ɚ
 hardest	h ɑ ɹ d ɪ s t
 hardline	h ɑː ɹ d l a ɪ n
@@ -29826,7 +30080,7 @@ hardwood	h ɑ ɹ d w ʊ d
 hardy	h ɑ ɹ d i
 hare	h ɛ ə
 hare	h ɛ ɚ
-hare	h ɛ ɹ
+hare	h ɛː
 harem	h æ ɹ ə m
 harem	h ɛ ə ɹ ə m
 hares	h e ɹ z
@@ -29867,8 +30121,8 @@ harpist	h ɑ ɹ p ɪ s t
 harpoon	h ɑː ɹ p uː n
 harpsichord	h ɑ ɹ p s ɪ k ɔ ɹ d
 harpy	h ɑ ɹ p i
-harquebus	h ɑ ɹ k w ɨ b ʌ s
-harquebus	h ɑ ɹ k ɨ b ʌ s
+harquebus	h ɑ ɹ k w ɪ b ʌ s
+harquebus	h ɑ ɹ k ɪ b ʌ s
 harrage	h æ ɹ ɪ d͡ʒ
 harras	h æ ɹ ə s
 harridan	h æ ɹ ɪ d ə n
@@ -29882,7 +30136,6 @@ harrogate	h æ ɹ ə ɡ ə t
 harrow	h æ ɹ o ʊ
 harrow	h ɛ ɹ o ʊ
 harry	h æ ɹ i
-harry	h ɛ ə ɹ i
 harry	h ɛ ɹ i
 harsh	h ɑ ɹ ʃ
 hart	h ɑ ɹ t
@@ -29922,7 +30175,7 @@ hasn't	h æ z n̩ t
 hasp	h æ s p
 hasp	h ɑː s p
 hassium	h æ s i ə m
-hassle	h æ s l
+hassle	h æ s l̩
 hast	h æ s t
 hasta	h æ s t ə
 hasta	h ʌ s t ə
@@ -30178,7 +30431,7 @@ hebrides	h ɛ b ɹ ə d iː z
 hecate	h ɛ k ə t i
 hecate	h ɛ k ɪ t
 hecatomb	h ɛ k ə t o ʊ m
-hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɨ k o ʊ ɹ ɔ n
+hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hechsher	h ɛ k ʃ ə ɹ
 heck	h ɛ k
 hecka	h ɛ k ə
@@ -30271,7 +30524,7 @@ heliacal	h ɪ l a ɪ ə k ə l
 helianthus	h iː l iː æ n θ ə s
 helical	h iː l ɪ k ə l
 helical	h ɛ l ɪ k ə l
-helicopter	h ɛ l ɨ k ɑ p t ɚ
+helicopter	h ɛ l ɪ k ɑ p t ɚ
 heligoland	h ɛ l ɪ ɡ o ʊ l æ n d
 helimagnetic	h ɛ l i m æ ɡ n ɛ t ɪ k
 heling	h iː l ɪ ŋ
@@ -30364,7 +30617,7 @@ hemodynamic	h i m o ʊ d a ɪ n æ m ɪ k
 hemodynamics	h i m o ʊ d a ɪ n æ m ɪ k s
 hemopoietic	h iː m ə p ɔ ɪ ɛ t ɪ k
 hemorrhage	h ɛ m ə ɹ ɪ d͡ʒ
-hemorrhagiparous	h ɛ m ə r ɨ d͡ʒ ɪ p ə r ə s
+hemorrhagiparous	h ɛ m ə r ɪ d͡ʒ ɪ p ə r ə s
 hemorrhoid	h ɛ m ə ɹ ɔ ɪ d
 hemorrhoid	h ɛ m ɹ ɔ ɪ d
 hemosiderosis	h iː m ə ʊ s ɪ d ə ɹ ə ʊ s ɪ s
@@ -30389,7 +30642,7 @@ hendecanol	h ɛ n d ɛ k ə n ɒ l
 hendecasyllabic	h ɛ n d ɛ k ə s ɪ l æ b ɪ k
 henderson	h ɛ n d ɚ s ə n
 hendiadys	h ɛ n d a ɪ ə d ɪ s
-hendiatris	h ɛ n d a ɪ ə t ɹ ɨ s
+hendiatris	h ɛ n d a ɪ ə t ɹ ɪ s
 henge	h ɛ n d͡ʒ
 henna	h ɛ n ə
 hennepin	h ɛ n ɪ p ɪ n
@@ -30430,6 +30683,7 @@ herb	h
 herb	h ɜː ɹ b
 herb	h ɝ b
 herbaceous	h ɝ b e ɪ ʃ ə s
+herbage	h ɚ b ɪ d ʒ
 herbal	ɝ b ə l
 herbary	h ɜː ɹ b ə ɹ i
 herbary	ɜː ɹ b ə ɹ i
@@ -30463,7 +30717,7 @@ hereon	h ɪ ə ɹ ɒ n
 herero	h ɛ r ɛ ə r o ʊ
 heresiarch	h ə ɹ i z i ɑ ɹ k
 heresy	h ɛ ɹ ə s i
-heretic	h ɛ ɹ ɨ t ɪ k
+heretic	h ɛ ɹ ɪ t ɪ k
 heretical	h ə ɹ ɛ t ɪ k ə l
 heretofore	h ɪ ɹ t ə f o ɹ
 heretofore	h ɪ ɹ t ə f ɔ ɹ
@@ -30473,7 +30727,7 @@ herkimer	h ɚ k ɪ m ɚ
 herman	h ɝ m ə n
 hermaphrodite	h ɝ m æ f ɹ ə d a ɪ t
 hermaphroditus	h ɚ m æ f ɹ ə d a ɪ t ə s
-hermeneutical	h ɝ m ə n j uː t ɨ k ə l
+hermeneutical	h ɝ m ə n j uː t ɪ k ə l
 hermeneutics	h ɜː ɹ m ə n j uː t ɪ k s
 hermes	h ɝ m iː z
 hermetic	h ə ɹ m ɛ t ɪ k
@@ -30523,6 +30777,7 @@ hertz	h ɝ t s
 herzegovina	h ɛ ə ɹ t s ə ɡ o ʊ v ɪ n ə
 herzegovina	h ɜ ɹ t s ə ɡ o ʊ v iː n ə
 hes	h iː z
+hes	h ɛ s
 hes	h ɛ z
 hesiod	h iː s i ə d
 hesiod	h ɛ s i ə d
@@ -30564,6 +30819,7 @@ heteropathic	h ɛ t ə ɹ ə ʊ p æ θ ɪ k
 heterophenomenological	h ɛ t ə ɹ ə ʊ f ə n ɒ m ɪ n ə l ɒ d͡ʒ ɪ k ə l
 heteroradical	h ɛ t ɜ ɹ ə ɹ æ d ɪ k ə l
 heterorganic	h ɛ t ə ɹ ɔː ɹ ɡ æ n ɪ k
+heteroscedasticity	h ɛ t ə ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
 heterosexual	h ɛ t ə ɹ o ʊ s ɛ k ʃ u ə l
 heterosexual	h ɛ t ə ɹ ə s ɛ k ʃ u ə l
 heterotroph	h ɛ ɾ ə ɹ ə t ɹ o ʊ f
@@ -30586,11 +30842,11 @@ hew	h j uː
 hewed	h j uː d
 hewing	h j uː ɪ ŋ
 hewings	h j uː ɪ ŋ z
-hewitt	h j uː ɨ t
+hewitt	h j uː ɪ t
 hewn	h j uː n
 hews	h j uː z
 hex	h ɛ k s
-hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɨ k o ʊ ɹ ɔ n
+hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hexad	h ɛ k s æ d
 hexadecile	h ɛ k s ə d ɛ s a ɪ l
 hexadecile	h ɛ k s ə d ɛ s ə l
@@ -30696,7 +30952,7 @@ higham	h a ɪ ə m
 higher	h a ɪ ɚ
 higher	h a ɪ ɹ
 highest	h a ɪ ɪ s t
-highfalutin	h a ɪ f ə l u t ɨ n
+highfalutin	h a ɪ f ə l u t ɪ n
 highflier	h a ɪ f l a ɪ ə ɹ
 highland	h a ɪ l ə n d
 highland	h a ɪ l ɪ n d
@@ -30797,7 +31053,7 @@ hippyish	h ɪ p i ɪ ʃ
 hips	h ɪ p s
 hipshot	h ɪ p ʃ ɒ t
 hipster	h ɪ p s t ɚ
-hir	h i ɹ
+hir	h ɪ ɹ
 hiragana	h ɪ ɹ ə ɡ æ n ə
 hiragana	h ɪ ɹ ə ɡ ɑː n ə
 hiram	h a ɪ ɹ ə m
@@ -30867,6 +31123,8 @@ hithe	h ʌ ɪ ð
 hither	h ɪ ð ɚ
 hitherto	h ɪ ð ɚ t u
 hitler	h ɪ t l ɚ
+hitman	h ɪ t m æː n
+hitman	h ɪ t m ə n
 hits	h ɪ t s
 hitter	h ɪ t ɚ
 hitting	h ɪ t ɪ ŋ
@@ -30948,6 +31206,7 @@ hogshead	h ɑ ɡ z h ɛ d
 hogwarts	h ɔ ɡ w ɔ ɹ t s
 hogwash	h ɒ ɡ w ɒ ʃ
 hohenzollern	h o ʊ ə n z ɑ l ə ɹ n
+hohhot	h o ʊ h ɒ t
 hoik	h ɔ ɪ k
 hoise	h ɔ ɪ z
 hoisin	h ɔ ɪ s ɪ n
@@ -31062,7 +31321,7 @@ homie	h o ʊ m i
 homiletical	h ɒ m ɪ l ɛ t ɪ k ə l
 homily	h ɑ m ɪ l i
 homing	h o ʊ m ɪ ŋ
-hominy	h ɒ m ɨ n i
+hominy	h ɒ m ɪ n i
 hommage	o ʊ m ɑː ʒ
 hommage	ɒ m ɑː ʒ
 homo	h o ʊ m o ʊ
@@ -31146,6 +31405,7 @@ honeymoon	h ʌ n i m uː n
 honeymooner	h ʌ n i m u n ɚ
 honeys	h ʌ n i z
 honeysuckle	h ʌ n iː s ʌ k ə l
+honfidence	h ʌ n f ɪ d ə n s
 hongbao	h ɔ ŋ b a ʊ
 hongi	h ɒ ŋ i
 hongkong	h ɒ ŋ k ɒ ŋ
@@ -31164,6 +31424,8 @@ honor	ɑ n ɚ
 honorable	ɑ n ə ɹ ə b l̩
 honorable	ɑ n ɹ ə b l̩
 honorarium	ɑ n ə ɹ ɛ ɹ i ə m
+honorary	ɑ n ə r ɛ r i
+honoree	ɑ n ɚ i
 honorific	ɑː n ə ɹ ɪ f ɪ k
 honorificabilitudinitatibus	ɑ n ə ɹ ɪ f ɪ k ə b ɪ l ə t j u d ɪ n ɪ t e ɪ t ɪ b ə s
 honors	ɑ n ɚ z
@@ -31198,6 +31460,7 @@ hoojah	h uː d͡ʒ ə
 hook	h ʊ k
 hookah	h u k ə
 hookah	h ʊ k ə
+hookaroon	h ʊ k ə ɹ uː n
 hooked	h ʊ k t
 hooker	h ʊ k ɚ
 hooking	h ʊ k ɪ ŋ
@@ -31253,6 +31516,7 @@ hopenosis	h ə ʊ p n ə ʊ s ɪ s
 hopes	h o ʊ p s
 hopi	h o ʊ p i
 hoping	h o ʊ p ɪ ŋ
+hopium	h o ʊ p i ə m
 hopkins	h ɑ p k ɪ n z
 hoplite	h ɒ p l a ɪ t
 hopper	h ɑ p ɚ
@@ -31319,8 +31583,8 @@ horsemen	h ɔ r s m ə n
 horsepower	h ɔ ɹ s p a ʊ ɚ
 horseradish	h ɔ ɹ s ɹ æ d ɪ ʃ
 horseradished	h ɔ ɹ s ɹ æ d ɪ ʃ t
-horses	h ɔ r s ə z
-horses	h ɔ r s ɪ z
+horses	h o ɹ s ə z
+horses	h o ɹ s ɪ z
 horseshoe	h ɔː ɹ s ʃ uː
 horseshoe	h ɔː ɹ ʃ uː
 horsetail	h ɔː ɹ s t e ɪ l
@@ -31349,7 +31613,7 @@ hosings	h o ʊ z ɪ ŋ z
 hospice	h ɑ s p ɪ s
 hospitable	h ɑ s p ɪ t ə b l̩
 hospital	h ɑ s p ɪ t l̩
-hospital	h ɑ s p ɪ t̬ l̩
+hospital	h ɑ s p ɪ ɾ l̩
 hospitality	h ɑ s p ɪ t æ l ɪ t i
 hospitalize	h ɒ s p ɪ t ə l a ɪ z
 hoss	h ɔː s
@@ -31628,7 +31892,6 @@ humpback	h ʌ m p b æ k
 humped	h ʌ m p t
 humper	h ʌ m p ɚ
 humph	h ə m f
-humph	h ʌ m f
 humphrey	h ʌ m f ɹ i
 humping	h ʌ m p ɪ ŋ
 humpings	h ʌ m p ɪ ŋ z
@@ -31771,7 +32034,7 @@ hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ i ə
 hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ ə
 hydrant	h a ɪ d ɹ ə n t
 hydrargyron	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ɒ n
-hydrargyrum	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ə m
+hydrargyrum	h a ɪ d ɹ ɑː ɹ d͡ʒ ɪ ɹ ə m
 hydrate	h a ɪ d ɹ e ɪ t
 hydration	h a ɪ d ɹ e ɪ ʃ ə n
 hydraulic	h a ɪ d ɹ ɔː l ɪ k
@@ -31806,6 +32069,7 @@ hydroponic	h ʌ ɪ d ɹ ə p ɒ n ɪ k
 hydroponics	h a ɪ d ɹ ə p ɑ n ɪ k s
 hydropsy	h a ɪ d ɹ ɑ p s i
 hydroptic	h a ɪ d ɹ ɒ p t ɪ k
+hydroquinone	h a ɪ d ɹ ə k w ɪ n ə ʊ n
 hydrostatic	h a ɪ d ɹ ə ʊ s t æ t ɪ k
 hydrous	h a ɪ d ɹ ə s
 hydrovolcanic	h a ɪ d ɹ o ʊ v ɑ l k æ n ɪ k
@@ -31844,6 +32108,7 @@ hymenopteran	h a ɪ m ə n ɑ p t ə ɹ ə n
 hymie	h a ɪ m i
 hymn	h ɪ m
 hymnal	h ɪ m n ə l
+hymnic	h ɪ m n ɪ k
 hymnody	h ɪ m n ə d i
 hyoglossi	h a ɪ o ʊ ɡ l ɑ s a ɪ
 hyoglossi	h a ɪ o ʊ ɡ l ɔ s a ɪ
@@ -31909,6 +32174,7 @@ hypermyoglobinemia	h a ɪ p ɚ m a ɪ o ʊ ɡ l o ʊ b ɪ n i m i ə
 hypernatremia	h a ɪ p ɚ n ə t ɹ i m i ə
 hypernatremic	h a ɪ p ɚ n ə t ɹ i m ɪ k
 hypernym	h a ɪ p ɚ n ɪ m
+hyperon	h a ɪ p ə ɹ ɒ n
 hyperparasite	h a ɪ p ɚ p æ ɹ ə s a ɪ t
 hyperplasia	h a ɪ p ɚ p l e ɪ ʒ ə
 hyperplasma	h a ɪ p ə ɹ p l æ z m ə
@@ -31931,10 +32197,12 @@ hyphen	h a ɪ f ə n
 hyphenation	h a ɪ f ə n e ɪ ʃ ə n
 hyphy	h a ɪ f iː
 hyping	h a ɪ p ɪ ŋ
+hypnic	h ɪ p n ɪ k
 hypnos	h ɪ p n o ʊ s
 hypnos	h ɪ p n ɒ s
 hypnosis	h ɪ p n o ʊ s ɪ s
 hypnotic	h ɪ p n ɒ t ɪ k
+hypnotism	h ɪ p n ə t ɪ z ə m
 hypnotist	h ɪ p n ə t ɪ s t
 hypnotize	h ɪ p n ə t a ɪ̯ z
 hypo	h a ɪ p o ʊ
@@ -31955,6 +32223,7 @@ hypodorian	h a ɪ p ə ʊ d ɔː ɹ i ə n
 hypoglossal	h a ɪ p ə ɡ l ɑ s ə l
 hypoglossus	h a ɪ p ə ɡ l ɑ s ə s
 hypoglycemic	h a ɪ p ə ʊ ɡ l a ɪ s iː m ɪ k
+hypohalous	h a ɪ p ə ʊ h e ɪ l ə s
 hypolemma	h a ɪ p o ʊ l ɛ m ə
 hyponatremia	h a ɪ p o ʊ n e ɪ t ɹ iː m i ə
 hyponym	h a ɪ p o ʊ n ɪ m
@@ -31982,6 +32251,7 @@ hypotrochoid	h a ɪ p o ʊ t ɹ o ʊ k ɔ ɪ d
 hypotrochoid	h a ɪ p ə t ɹ o ʊ k ɔ ɪ d
 hypsipyle	h ɪ p s ɪ p ɪ l iː
 hypsometry	h ɪ p s ɑ m ə t ɹ i
+hypural	h a ɪ p j ʊ ə ɹ ə l
 hyraceum	h a ɪ r e ɪ s i ə m
 hyrax	h a ɪ ɹ æ k s
 hyssop	h ɪ s ə p
@@ -32077,7 +32347,7 @@ ichnology	ɪ k n ɒ l ə d͡ʒ ɪ
 ichnusaite	ɪ k n u s ə a ɪ t
 ichor	a ɪ k ɔ ɹ
 ichor	ɪ k ə ɹ
-ichthyic	ɪ k θ iː ɨ k
+ichthyic	ɪ k θ iː ɪ k
 ichthyology	ɪ k θ i ɒ l ə d͡ʒ i
 ichthyonym	ɪ k θ i ə n ɪ m
 ichthyosaur	ɪ k θ i ə s ɔː ɹ
@@ -32099,7 +32369,7 @@ icosahedra	a ɪ k ɒ s ə h iː d ɹ ə
 icosahedron	a ɪ k o ʊ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɒ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɔ s ə h iː d ɹ ə n
-icositetrachoron	a ɪ k o ʊ s ɨ t ɛ t ɹ ə k o ʊ ɹ ɔ n
+icositetrachoron	a ɪ k o ʊ s ɪ t ɛ t ɹ ə k o ʊ ɹ ɔ n
 icq	a ɪ s iː k j uː
 icy	a ɪ s i
 id	a ɪ d iː
@@ -32133,6 +32403,7 @@ ident	a ɪ d ɛ n t
 identic	a ɪ d ɛ n t ɪ k
 identical	a ɪ d ɛ n t ɪ k l̩
 identical	ɪ d ɛ n t ɪ k l̩
+identically	a ɪ d ɛ n t ɪ k ə l i
 identification	a ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identification	ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identified	a ɪ d ɛ n t ɪ f a ɪ d
@@ -32141,8 +32412,8 @@ identify	a ɪ d ɛ n t ɪ f a ɪ
 identify	ɪ d ɛ n t ɪ f a ɪ
 identikit	a ɪ d e n t ə k ɪ t
 identitarian	a ɪ d ɛ n t ɪ t ɛ ə ɹ i ə n
-identity	a ɪ d ɛ ɾ̃ ə ɾ i
-identity	a ɪ d ɛ ɾ̃ ɪ ɾ i
+identity	a ɪ d ɛ n t ə t i
+identity	a ɪ d ɛ n t ɪ t i
 ideocracy	ɪ d i ɑ k ɹ ə s i
 ideocratic	ɪ d i o ʊ k ɹ æ t ɪ k
 ideogram	ɪ d i o ʊ ɡ ɹ æ m
@@ -32186,6 +32457,7 @@ idiotropic	ɪ d i o ʊ t ɹ ɒ p ɪ k
 idiotropic	ɪ d i ə t ɹ o ʊ p ɪ k
 idiots	ɪ d iː ə t s
 idiotype	ɪ d iː o ʊ t a ɪ p
+idjit	ɪ d ʒ ɪ t
 idle	a ɪ d ə l
 idleness	a ɪ d ə l n ə s
 idlesse	a ɪ d l ə s
@@ -32217,6 +32489,7 @@ ifs	ɪ f s
 iftar	ɪ f t ɑː ɹ
 igbo	i b o ʊ
 igbo	i ɡ b o ʊ
+ight	a ɪ t
 igloo	ɪ ɡ l uː
 ignatius	ɪ ɡ n e ɪ ʃ ə s
 igneous	ɪ ɡ n i ə s
@@ -32229,7 +32502,7 @@ ignominy	ɪ ɡ n ɑ m ə n i
 ignominy	ɪ ɡ n ə m ə n i
 ignominy	ɪ ɡ n ə m ɪ n i
 ignoramus	ɪ ɡ n ə ɹ e ɪ m ə s
-ignorance	ɪ ɡ n ə ɹ ə n s
+ignorance	ɪ ɡ n ɚ ə n s
 ignorant	ɪ ɡ n ə ɹ ə n t
 ignoranter	ɪ ɡ n ə ɹ ə n t ə ɹ
 ignore	ɪ ɡ n ɔ ɹ
@@ -32366,6 +32639,7 @@ imhotep	ɪ m h o ʊ t ɛ p
 imidazole	ɪ m ə d æ z o ʊ l
 imidazole	ɪ m ɪ d æ z o ʊ l
 imide	a ɪ m a ɪ d
+imine	ɪ m iː n
 imipramine	ɪ m ɪ p ɹ ə m iː n
 imitate	ɪ m ɪ t e ɪ t
 imitation	ɪ m ɪ t e ɪ ʃ ə n
@@ -32381,6 +32655,7 @@ immaterial	ɪ m ə t ɪ ɹ i ə l
 immature	ɪ m ə t j ʊ ə ɹ
 immature	ɪ m ə t͡ʃ ə ɹ
 immature	ɪ m ə t͡ʃ ʊ ə ɹ
+immaturely	ɪ m ə t j ʊ ə ɹ l i
 immaturity	ɪ m ə t͡ʃ ʊ ɹ ɪ t i
 immeability	ɪ m i ə b ɪ l ɪ t i
 immeasurability	ɪ m ɛ ʒ ə ɹ ə b ɪ l ə t i
@@ -32443,6 +32718,7 @@ impactful	ɪ m p æ k t f ə l
 impaction	ɪ m p æ k ʃ ə n
 impactor	ɪ m p æ k t ɚ
 impair	ɪ m p ɛ ə
+impairment	ɪ m p ɛ ə ɹ m ə n t
 impala	ɪ m p ɑː l ə
 impale	ɪ m p e ɪ l
 impaled	ɪ m p e ɪ l d
@@ -32500,9 +32776,9 @@ impermissible	ɪ m p ɝ m ɪ s ɪ b l
 impersonal	ɪ m p ɝ s ə n ə l
 impersonate	ɪ m p ɜː s ə n e ɪ t
 impertinence	ɪ m p ɝ t n ə n s
-impertinence	ɪ m p ɝ t ɨ n ə n s
+impertinence	ɪ m p ɝ t ɪ n ə n s
 impertinent	ɪ m p ɝ t n ə n t
-impertinent	ɪ m p ɝ t ɨ n ə n t
+impertinent	ɪ m p ɝ t ɪ n ə n t
 imperturbable	ɪ m p ɚ t ɝ b ə b ə l
 impervious	ɪ m p ɝ v i ə s
 impetigo	ɪ m p ə t a ɪ ɡ o ʊ
@@ -32538,7 +32814,8 @@ implicit	ɪ m p l ɪ s ɪ t
 implied	ɪ m p l a ɪ d
 implies	ɪ m p l a ɪ z
 implike	ɪ m p l a ɪ k
-implore	ɪ m p l ɔ ɹ
+implore	ɪ m p l o ɹ
+implosion	ɪ m p l ə ʊ ʒ ə n
 imply	ɪ m p l a ɪ
 impolite	ɪ m p ə l a ɪ t
 imponderable	ɪ m p ɑː n d ə ɹ ə b l
@@ -32910,6 +33187,7 @@ indirection	ɪ n d ɪ ɹ ɛ k ʃ ə n
 indirectly	ɪ n d a ɪ ɹ ɛ k t l i
 indirectly	ɪ n d ɪ ɹ ɛ k t l i
 indiscovery	ɪ n d ɪ s k ʌ v ə ɹ i
+indiscretion	ɪ n d ɪ s k ɹ ɛ ʃ ə n
 indisposition	ɪ n d ɪ s p ə z ɪ ʃ ə n
 indisputable	ɪ n d ɪ s p j u t ə b ə ɫ
 indissipable	ɪ n d ɪ s ɪ p ə b ə l
@@ -33012,6 +33290,7 @@ inexplicable	ɪ n ɪ k s p l ɪ k ə b l̩
 inexpugnable	ɪ n ɛ k s p ʌ ɡ n ə b ə l
 inexpugnable	ɪ n ɪ k s p ʌ ɡ n ə b ə l
 infallible	ɪ n f æ l ɪ b l̩
+infame	ɪ n f e ɪ m
 infamous	ɪ n f ə m ə s
 infamy	ɪ n f ə m i
 infancy	ɪ n f ə n s i
@@ -33034,7 +33313,7 @@ infelt	ɪ n f ɛ l t
 infer	ɪ n f ɝ
 inference	ɪ n f ə ɹ ə n s
 inferior	ɪ n f ɪ ɹ i ɚ
-infernal	ɪ n f ə ɹ n ə l
+infernal	ɪ n f ɝ n ə l
 inferno	ɪ n f ɝ n o ʊ
 inferred	ɪ n f ɝ d
 infertile	ɪ n f ɝ t ɪ l
@@ -33215,9 +33494,10 @@ injudiciously	ɪ n d͡ʒ ʊ d ɪ ʃ ə s l ɪ
 injunction	ɪ n d͡ʒ ʌ n k ʃ ə n
 injure	ɪ n d͡ʒ ɚ
 injured	ɪ n d͡ʒ ɚ d
+injuria	ɪ n d ʒ ʊ ə ɹ i ə
 injurious	ɪ n d͡ʒ ɝ i ə s
 injurious	ɪ n d͡ʒ ʊ ɹ i ə s
-injury	ɪ n d͡ʒ ə ɹ i
+injury	ɪ n d͡ʒ ɚ i
 injury	ɪ n d͡ʒ ɹ i
 injustice	ɪ n d͡ʒ ʌ s t ɪ s
 ink	i ŋ k
@@ -33257,6 +33537,7 @@ innocuousness	ɪ n ɒ k j u ə s n ə s
 innovation	ɪ n ə v e ɪ ʃ ə n
 innovative	ɪ n o ʊ v e ɪ ɾ ɪ v
 innovative	ɪ n ə v e ɪ ɾ ɪ v
+innovator	ɪ n ə v e ɪ t ə ɹ
 innovent	ɪ n ə v ɛ n t
 innovented	ɪ n ə v ɛ n t ɪ d
 innoventor	ɪ n ə v ɛ n t ɚ
@@ -33270,6 +33551,7 @@ inoculent	ɪ n ɑ k j ə l ə n t
 inodiate	ɪ n ə ʊ d i e ɪ t
 inoptimal	ɪ n ɒ p t ɪ m ə l
 inordinate	ɪ n ɔ ɹ d n̩ ə t
+inorganic	ɪ n ɔ ɹ ɡ æ n ɪ k
 inorganity	ɪ n ɔː ɹ ɡ æ n ɪ t i
 inosculate	ɪ n ɒ s k j ʊ l e ɪ t
 inosite	ɪ n ə s a ɪ t
@@ -33291,8 +33573,6 @@ inquire	ɪ n k w a ɪ ɹ
 inquired	ɪ n k w a ɪ ɹ d
 inquiries	ɪ n k w ɪ ɹ i z
 inquiring	ɪ n k w a ɪ ɹ ɪ ŋ
-inquiry	ɪ n k w a ɪ ə ɹ i
-inquiry	ɪ n k w ɪ ɹ i
 inquisition	ɪ ŋ k w ɪ z ɪ ʃ ə n
 inquisitive	ɪ ŋ k w ɪ z ə t ɪ v
 inquisitor	ɪ n k w ɪ z ə t ə ɹ
@@ -33367,11 +33647,13 @@ inspect	ɪ n s p ɛ k t
 inspection	ɪ n s p ɛ k ʃ ə n
 inspector	ɪ n s p ɛ k t ɚ
 inspiration	ɪ n s p ə ɹ e ɪ ʃ ə n
+inspirational	ɪ n s p ə ɹ e ɪ ʃ ə n ə l
 inspire	ɪ n s p a ɪ ɹ
 inspired	ɪ n s p a ɪ ɹ d
 inspiring	ɪ n s p a ɪ ɹ ɪ ŋ
 inspissate	ɪ n s p ɪ s e ɪ t
 inspo	ɪ n s p o ʊ
+insta	ɪ n s t ə
 instadeath	ɪ n s t ə d ɛ θ
 instagram	ɪ n s t ə ɡ ɹ æ m
 instagrammable	ɪ n s t ə ɡ r æ m ə b ə l
@@ -33386,6 +33668,7 @@ instant	ɪ n s t ə n t
 instantaneous	ɪ n s t ə n t e ɪ n i ə s
 instanter	ɪ n s t æ n t ɚ
 instantial	ɪ n s t æ n ʃ ə l
+instantially	ɪ n s t æ n ʃ ə l i
 instantiate	ɪ n s t æ n ʃ i e ɪ t
 instantiation	ɪ n s t æ n ʃ i e ɪ ʃ ə n
 instar	ɪ n s t ɑ ɹ
@@ -33456,8 +33739,11 @@ insurgent	ɪ n s ə ɹ d͡ʒ ə n t
 insusurration	ɪ n s uː s ə ɹ e ɪ ʃ ə n
 int'resting	ɪ n t ɹ ɛ s t ɪ ŋ
 intact	ɪ n t æ k t
+intaglio	ɪ n t æ l i j o ʊ
 intaglio	ɪ n t æ l j o ʊ
+intaglio	ɪ n t æ ɡ l i o ʊ
 intaglio	ɪ n t ɑ l j o ʊ
+intaglio	ɪ n t ɑ ɡ l i o ʊ
 intake	ɪ n t e ɪ k
 intangible	ɪ n t æ n d͡ʒ ə b ə l
 intarweb	ɪ n t ɑ ɚ w ɛ b
@@ -33501,7 +33787,7 @@ intention	ɪ n t ɛ n ʃ ə n
 intentional	ɪ n t ɛ n ʃ ə n ə l
 intentions	ɪ n t ɛ n ʃ ə n z
 intentive	ɪ n t ɛ n t ɪ v
-intentively	ɨ n t ɛ n t ɪ v l i
+intentively	ɪ n t ɛ n t ɪ v l i
 intently	ɪ n t ɛ n t l i
 inter	ɪ n t ɝ
 interabled	ɪ n t ɚ e ɪ b l̩ d
@@ -33514,6 +33800,7 @@ interacts	ɪ n t ə ɹ æ k s
 interacts	ɪ n t ə ɹ æ k t s
 interagency	ɪ n t ə ɹ e ɪ d͡ʒ ə n s i
 interarytenoid	ɪ n t ɚ æ ɹ ə t i n ɔ ɪ d
+interaxillary	ɪ n t ə ɹ æ k s ɪ l ə ɹ i
 interbedded	ɪ n t ɚ b ɛ d ə d
 interbred	ɪ n t ɚ b ɹ ɛ d
 interbreed	ɪ n t e ɹ b ɹ i d
@@ -33557,7 +33844,7 @@ interface	ɪ n t ɚ f e ɪ s
 interfaces	ɪ n t ə f e ɪ s
 interfere	ɪ n t ɚ f ɪ ɹ
 interfered	ɪ n t ɚ f ɪ ɹ d
-interference	ɪ n t ə ɹ f i ɹ ɨ n s
+interference	ɪ n t ə ɹ f i ɹ ɪ n s
 interfrastically	ɪ n t ɚ f ɹ æ s t ɪ k ʌ l i
 interim	ɪ n t ə ɹ ɪ m
 interior	ɪ n t ɪ ɹ i ɚ
@@ -33576,6 +33863,8 @@ interlocutor	ɪ n t ə ɹ l ɑ k j u t ə ɹ
 interlocutor	ɪ n t ə ɹ l ɑ k j ə t ə ɹ
 interlocutor	ɪ n t ə ɹ l ɑ k ə t ə ɹ
 interlocutory	ɪ n t ə ɹ l ə k j uː t ə ɹ i
+interloper	ɪ n t ɚ l o ʊ̯ p ɚ
+interloper	ɪ ɾ̃ ɚ l o ʊ̯ p ɚ
 interlude	ɪ n t ə ɹ l j uː d
 interlude	ɪ n t ə ɹ l uː d
 intermarry	ɪ n t ə ɹ m æ ɹ i
@@ -33618,6 +33907,7 @@ interocular	ɪ n t ə ɹ ɒ k j ə l ə ɹ
 interosseus	ɪ n t ə ɹ ɒ s i ə s
 interpellate	ɪ n t ə ɹ p ɛ l e ɪ t
 interpellate	ɪ n t ɜ ɹ p ə l e ɪ t
+interpetiolar	ɪ n t ə ɹ p ɛ t i ə ʊ l ə ɹ
 interphrasally	ɪ n t ɚ f ɹ e ɪ z ʌ l i
 interphrasic	ɪ n t ɚ f ɹ æ s ɪ k
 interphrastic	ɪ n t ɚ f ɹ æ s t ɪ k
@@ -33649,6 +33939,7 @@ intersex	ɪ n t ɚ s ɛ k s
 intershell	ɪ n t ɚ ʃ ɛ l
 interslavic	ɪ n t ɚ s l ɑː v ɪ k
 intersow	ɪ n t ə ɹ s ə ʊ
+interspecial	ɪ n t ɚ s p iː ʃ i ə l
 interspecific	ɪ n t ɚ s p ə s ɪ f ɪ k
 intersperse	ɪ n t ə ɹ s p ɜː ɹ s
 interstate	ɪ n t ɚ s t e ɪ t
@@ -33750,7 +34041,7 @@ intrude	ɪ n t ɹ uː d
 intrusion	ɪ n t ɹ uː ʒ ə n
 intrusive	ɪ n t ɹ uː s ɪ v
 intuit	ɪ n t u ɪ t
-intuition	ɪ n t u w ɪ ʃ ɨ n
+intuition	ɪ n t u w ɪ ʃ ə n
 intuitive	ɪ n t j uː ɪ t ɪ v
 intuitiveness	ɪ n t j uː ɪ t ɪ v n ə s
 intumescent	ɪ n t u m ɛ s ə n t
@@ -33800,6 +34091,7 @@ invertebrate	ɪ n v əː t ɪ b r ə t
 invest	ɪ n v ɛ s t
 invested	ɪ n v ɛ s t ɪ d
 investigation	ɪ n v ɛ s t ə ɡ e ɪ ʃ ə n
+investigation	ɪ n v ɛ s t ɪ ɡ e ɪ ʃ ə n
 investigative	ɪ n v ɛ s t ɪ ɡ e ɪ t ɪ v
 investigative	ɪ n v ɛ s t ɪ ɡ ə t ɪ v
 investment	ɪ n v ɛ s m ə n t
@@ -33813,6 +34105,7 @@ invidious	ɪ n v ɪ d i ə s
 invigilator	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ə ɹ
 invigilatrix	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ɹ ɪ k s
 invigorate	ɪ n v ɪ ɡ ə ɹ e ɪ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə t i
 invincible	ɪ n v ɪ n s ə b ə l
 invincible	ɪ n v ɪ n s ɪ b ə l
 inviolable	ɪ n v a ɪ ə l ə b l̩
@@ -33913,15 +34206,14 @@ ire	a ɪ ɹ
 ireland	a ɪ ə ɹ l ə n d
 irenarch	a ɪ ɹ ɪ n ɑː ɹ k
 irene	a ɪ ɹ iː n
-irenic	a ɪ ɹ iː n ɪ k
-irenic	a ɪ ɹ ɛ n ɪ k
+irenic	a ɪ ɹ i n ɪ k
 iri	a ɪ ɑː ɹ a ɪ
 irides	a ɪ ɹ ɪ d i z
 irides	ɪ ɹ ɪ d i z
 iridescence	ɪ ɹ ɪ d ɛ s ə n s
 iridescent	ɪ ɹ ɪ d ɛ s ə n t
 iridium	ɪ ɹ ɪ d i ə m
-iridocyclitis	i ɹ ɨ d o ʊ s ɨ k l a ɪ t ə s
+iridocyclitis	i ɹ ɪ d o ʊ s ɪ k l a ɪ t ə s
 iris	a ɪ ɹ ɪ s
 irised	a ɪ ɹ ɪ s t
 irish	a ɪ ə ɹ ɪ ʃ
@@ -33940,6 +34232,7 @@ irony	a ɪ ɹ ə n i
 iroquois	ɪ ɹ ə k w ɔ ɪ
 iroquois	ɪ ɹ ə k ɔ ɪ
 irp	ɜː ɹ p
+irradicate	ɪ ɹ æ d ɪ k e ɪ t
 irrational	ɪ ɹ æ ʃ ə n ə l
 irrawaddy	ɪ ɹ ə w ɑ d i
 irrealis	ɪ ɹ i æ l ɪ s
@@ -33988,6 +34281,7 @@ irritation	ɪ ɹ ɪ t e ɪ ʃ ə n
 irruent	ɪ ɹ ɪ ʊ ə n t
 irrumation	ɪ ɹ ʊ m e i ʃ ə n
 irs	a ɪ ɑ ɹ ɛ s
+irtysh	ɪ ə ɹ t ɪ ʃ
 irukandji	ɪ ɹ ə k æ n d͡ʒ i
 irv	ɝ v
 irvin	ɝ v ɪ n
@@ -34044,6 +34338,8 @@ islay	ɪ z l e ɪ
 isle	a ɪ̯ l
 islet	a ɪ l ə t
 ism	ɪ z ə m
+ismael	ɪ z m e ɪ l
+ismael	ɪ z m e ɪ ə l
 ismahel	ɪ z m ə h ɛ l
 ismaili	ɪ s m ɑː i l i
 ismaili	ɪ s m ʌ ɪ iː l i
@@ -34097,7 +34393,7 @@ israel	ɪ z ɹ i ə l
 israeli	ɪ z ɹ e ɪ l i
 israelite	ɪ z ɹ e ɪ ə l a ɪ t
 israelite	ɪ z ɹ i ə l a ɪ t
-israelite	ɪ z ɹ ɨ l a ɪ t
+israelite	ɪ z ɹ ɪ l a ɪ t
 issue	ɪ ʃ j u
 issued	ɪ ʃ j u d
 issued	ɪ ʃ u d
@@ -34211,6 +34507,7 @@ jabs	d͡ʒ æ b z
 jacal	h ə k ɑː l
 jacana	d͡ʒ æ k ɑː n ə
 jace	d͡ʒ e ɪ s
+jacent	d ʒ e ɪ s ə n t
 jacinda	d͡ʒ ə s ɪ n d ə
 jacinth	d͡ʒ e ɪ s ɪ n θ
 jacinth	d͡ʒ æ s ɪ n θ
@@ -34245,6 +34542,7 @@ jacobite	d͡ʒ æ k ə b a ɪ t
 jacobs	d͡ʒ e ɪ k ə b z
 jacobson	d͡ʒ e ɪ k ə b s ə n
 jaconet	d͡ʒ æ k ə n ɪ t
+jacqueline	d ʒ æ k ə l ɪ n
 jacques	d͡ʒ æ k
 jacques	ʒ ɑː k
 jactitation	d͡ʒ æ k t ɪ t e ɪ ʃ ə n
@@ -34392,6 +34690,7 @@ java	d͡ʒ ɑː v ə
 javan	d͡ʒ ɑː v ə n
 javanka	d͡ʒ ə v ɑː ŋ k ə
 javans	d͡ʒ ɑː v ə n z
+javascript	d ʒ ɑː v ə s k ɹ ɪ p t
 javel	d͡ʒ æ v ə l
 javelin	d͡ʒ æ v ə l ɪ n
 javertian	ʒ ə v ɛ ɹ ʃ ə n
@@ -34448,7 +34747,7 @@ jeffrey	d͡ʒ ɛ f ɹ i
 jegging	d͡ʒ ɛ ɡ ɪ ŋ
 jeggings	d͡ʒ ɛ ɡ ɪ ŋ z
 jehovah	d͡ʒ ə h o ʊ v ə
-jehovist	d͡ʒ ə h o ʊ v ɨ s t
+jehovist	d͡ʒ ə h o ʊ v ɪ s t
 jehovistic	d͡ʒ i h o ʊ v ɪ s t ɪ k
 jehovistic	d͡ʒ ə h o ʊ v ɪ s t ɪ k
 jejune	d͡ʒ i d ʒ uː n
@@ -34480,6 +34779,7 @@ jeopard	d͡ʒ ɛ p ə ɹ d
 jeopardize	d͡ʒ ɛ p ə d ʌ ɪ z
 jeopardy	d͡ʒ ɛ p ɚ d i
 jepson	d͡ʒ ɛ p s ə n
+jerboa	d ʒ ɜː ɹ b ə ʊ ə
 jeremiad	d͡ʒ ɛ ɹ ə m a ɪ ə d
 jeremiah	d͡ʒ ɛ ɹ ə m a ɪ ə
 jeremias	d͡ʒ ɛ ɹ ə m a ɪ ə s
@@ -34707,6 +35007,7 @@ joggle	d͡ʒ ɒ ɡ ə l
 joh	d͡ʒ ə ʊ
 johanna	d͡ʒ ə ʊ h æ n ə
 johanna	d͡ʒ ə ʊ æ n ə
+johannes	d ʒ ə ʊ h æ n ɪ s
 johannesburg	d͡ʒ o ʊ h æ n ɪ s b ɜː r ɡ
 johannesburg	d͡ʒ o ʊ h ɑː n ɪ s b ɜː r ɡ
 johannine	d͡ʒ o ʊ h æ n a ɪ n
@@ -34769,6 +35070,7 @@ josiah	d͡ʒ o ʊ z a ɪ ə
 josser	d͡ʒ ɒ s ə ɹ
 jostle	d͡ʒ ɑ s ə l
 josue	d͡ʒ ɒ s j u iː
+josue	h o ʊ s w e ɪ
 jot	d͡ʒ ɑ t
 jota	h o ʊ t ə
 jotation	d͡ʒ ə ʊ t e ɪ ʃ ə n
@@ -34921,6 +35223,7 @@ jumping	d͡ʒ ʌ m p ɪ ŋ
 jumpings	d͡ʒ ʌ m p ɪ ŋ z
 jumps	d͡ʒ ʌ m p s
 jumpy	d͡ʒ ʌ m p i
+jun	d ʒ ʌ n
 juncate	d͡ʒ ʌ ŋ k ɪ t
 junco	d͡ʒ ʌ ŋ k o ʊ
 junction	d͡ʒ ʌ ŋ k ʃ ə n
@@ -34953,6 +35256,7 @@ jupe	ʒ uː p
 jupiter	d͡ʒ u p ɪ t ɚ
 jupon	d͡ʒ u p ɑ n
 jura	d͡ʒ ʊ ɹ ə
+jural	d ʒ ʊ ə ɹ ə l
 jurat	d͡ʒ ʊ ɹ æ t
 jurator	d͡ʒ ʊ r e ɪ t ə r
 juratorial	d͡ʒ ʊ ə r ə t ɔ ə r ɪ ə l
@@ -34976,7 +35280,7 @@ justice	d͡ʒ ʌ s t ɪ s
 justiciar	d͡ʒ ʌ s t ɪ s i ɑː ɹ
 justification	d͡ʒ ʌ s t ɪ f ɪ k e ɪ ʃ ə n
 justificatory	d͡ʒ ə s t ɪ f ə k ə t ɔ ɹ i
-justificatory	d͡ʒ ʌ s t ɨ f ə k e ɪ t ə ɹ i
+justificatory	d͡ʒ ʌ s t ɪ f ə k e ɪ t ə ɹ i
 justified	d͡ʒ ʌ s t ɪ f a ɪ d
 justify	d͡ʒ ʌ s t ɪ f a ɪ
 justin	d͡ʒ ʌ s t ɪ n
@@ -35000,6 +35304,7 @@ juxtapose	d͡ʒ ʌ k s t ə p o ʊ z
 juxtaposit	d͡ʒ ʌ k s t ə p ɒ z ɪ t
 juxtaposition	d͡ʒ ʌ k s t ə p ə z ɪ ʃ ə n
 juxtology	d͡ʒ ʌ k s t ɑ l ə d͡ʒ i
+jwics	d ʒ e ɪ w ɪ k s
 jy	d͡ʒ a ɪ
 jynges	d͡ʒ ɪ n d͡ʒ iː z
 jynges	d͡ʒ ɪ n d͡ʒ ɪ z
@@ -35008,6 +35313,7 @@ jynx	d͡ʒ ɪ ŋ k s
 jyothis	d͡ʒ o ʊ t ɪ s
 jäger	j e ɪ ɡ ɚ
 jägerbomb	j e ɪ ɡ ɚ b ɑ m
+jägermeister	j e ɪ ɡ ə r m a ɪ s t ə r
 jèrriais	ʒ ɛ ɹ i e ɪ
 jõgeva	j ə ʊ ɡ ɪ v ə
 jõgeva	j ʊ ɡ ɪ v ə
@@ -35032,6 +35338,8 @@ kaddish	k ɑ d ɪ ʃ
 kadkhoda	k æ d k ə ʊ d ə
 kadkhoda	k æ d x ə ʊ d ə
 kady	k e ɪ d i
+kaffir	k æ f ɚ
+kafir	k ɑː f ɪ ɹ
 kafka	k ɑ f k ɑ
 kafka	k ɑ f k ə
 kafkaesque	k ɑ f k ə ɛ s k
@@ -35072,7 +35380,7 @@ kakistocracy	k æ k ɪ s t ɑ k ɹ ə s i
 kakuro	k ɑ k ʊ ɹ o ʊ
 kalamazoo	k æ l ə m ə z uː
 kalanchoe	k æ l ə n k o ʊ ɪ
-kalarippayattu	k a ɭ ə ɾ i pː a j ə tː ɨ
+kalarippayattu	k a ɭ ə ɾ i pː a j ə tː ɪ
 kalashnikov	k ə l æ ʃ n ə k ɑ f
 kale	k e ɪ l
 kale	k e ɪ l i
@@ -35116,6 +35424,7 @@ kangchenjunga	k ʌ ŋ t͡ʃ ə n d͡ʒ ʌ ŋ ɡ ə
 kangding	k ɒ ŋ d ɪ ŋ
 kanghui	k ɒ ŋ h w i
 kangling	k æ ŋ ɡ ə l ɪ ŋ ɡ
+kango	k ɑ ŋ ɡ o ʊ
 kangri	k æ ŋ ɡ ɹ i
 kangxi	k ɑ ŋ ʃ iː
 kanigget	k ə n ɪ ɡ ə t
@@ -35203,6 +35512,7 @@ kashers	k ɑ ʃ ɚ z
 kashmir	k æ ʃ m i ɹ
 kashmir	k æ ʒ m i ɹ
 kashmiri	k æ ʃ m i ɹ i
+kashrut	k ɑː ʃ ɹ uː t
 kashubian	k ə ʃ uː b ɪ ə n
 kasich	k e ɪ s ɪ k
 kasserine	k æ s ə ɹ ɪ n
@@ -35454,6 +35764,7 @@ khamsin	k æ m s ɪ n
 khan	k ɑː n
 khanjar	k a n d͡ʒ ə
 khanji	k ɑː n d͡ʒ i
+khariboli	k a ɹ iː b o ʊ ɫ iː
 kharkiv	h ɑ ɹ k i v
 kharkiv	h ɑ ɹ k ɪ v
 kharkiv	h ɑː k iː v
@@ -35550,6 +35861,8 @@ kierkegaardianism	k ɪ ɹ k ə ɡ ɑ ɹ d i ə n ɪ z ə m
 kiev	k iː ɛ f
 kiev	k iː ɛ v
 kiev	k iː ɪ v
+kiev	k j ɛ f
+kiev	k j ɛ v
 kievan	k iː ɛ f ə n
 kievan	k iː ɛ v ə n
 kif	k iː f
@@ -35633,6 +35946,7 @@ kinematic	k ɪ n ə m æ t ɪ k
 kinematics	k ɪ n ə m æ t ɪ k s
 kines	k a ɪ n z
 kineses	k a ɪ n z ɪ z
+kinesics	k ə n i s ɪ k s
 kinesiology	k ə n i z i ɔ l ə d͡ʒ ɪ
 kinesis	k ə n iː s ɪ s
 kinesthesia	k a ɪ n ɪ s θ i ʒ ə
@@ -35688,9 +36002,9 @@ kippens	k ɪ p ə n z
 kipper	k ɪ p ə ɹ
 kirby	k ɝ b i
 kirghiz	k ɪ ɹ ɡ iː z
-kiribati	k iː ɹ ɨ b æ s
-kiribati	k iː ɹ ɨ b ɑ s
-kiribati	k iː ɹ ɨ b ɑ t i
+kiribati	k iː ɹ ɪ b æ s
+kiribati	k iː ɹ ɪ b ɑ s
+kiribati	k iː ɹ ɪ b ɑ t i
 kiritimati	k ə ɹ ɪ s m ə s
 kirk	k ɝ k
 kirkby	k ɝ b i
@@ -35698,6 +36012,7 @@ kirkcaldy	k ə ɹ k ɔː d i
 kirkcudbright	k ɚ k u b ɹ i
 kirkheaton	k ə r k h iː t ə n
 kirkwood	k ɝ k w ʊ d
+kirmess	k ɜː ɹ m ə s
 kirpan	k ɪ ə ɹ p ɑː n
 kirsch	k ɜː ɹ ʃ
 kirsch	k ɪ ə ɹ ʃ
@@ -35816,6 +36131,7 @@ knapweed	n æ p w iː d
 knar	n ɑ ɹ
 knarr	n ɔː ɹ
 knarred	n ɑː ɹ d
+knarry	n ɑː ɹ i
 knave	n e ɪ v
 knavery	n e ɪ v ə ɹ i
 knaves	n e ɪ v z
@@ -35908,6 +36224,7 @@ knuff	n ʌ f
 knur	n ɜː ɹ
 knurl	n ɝ l
 knurly	n ɜː ɹ l i
+knurry	n ɜː ɹ i
 knuth	k ə n uː θ
 knysna	n a ɪ z n ə
 ko	k ə ʊ
@@ -35953,7 +36270,7 @@ kolkata	k o ʊ l k ɑ t ə
 kolkhoz	k ə l k ɒ z
 kolkhozy	k ə l k ɒ z ɪ
 kolo	k o ʊ l o ʊ
-kolyma	k ə l ɨ m a
+kolyma	k ə l ɪ m a
 kombu	k ɒ m b uː
 kombucha	k ɑ m b u t͡ʃ ə
 kombucha	k ɑ m b u ʃ ə
@@ -36011,6 +36328,7 @@ kraken	k ɹ æ k ə n
 kraken	k ɹ ɑː k ə n
 kramatorsk	k ɹ æ m ə t ɔ ɹ s k
 kramer	k ɹ e ɪ m ɚ
+krang	k ɹ æ ŋ
 kraut	k ɹ a ʊ t
 kremlin	k ɹ e m l ɪ n
 kretek	k ɹ ɛ t ɛ k
@@ -36100,6 +36418,7 @@ kye	k a ɪ
 kye	k j e ɪ
 kyiv	k iː v
 kyiv	k iː ɪ v
+kyiv	k j ɪ v
 kyivan	k iː ɪ v ə n
 kyke	k a ɪ k
 kyla	k a ɪ l ə
@@ -36111,6 +36430,7 @@ kylix	k a ɪ l ɪ k s
 kylixes	k a ɪ l ɪ k s ə z
 kylym	k ɪ l ɪ m
 kynodesme	k a ɪ n ə ʊ d ɛ z m i
+kyoto	k i j o ʊ t o ʊ
 kyoto	k j o ʊ t o ʊ
 kyphotone	k a ɪ f ə t ə ʊ n
 kyra	k a ɪ ɹ ə
@@ -36247,11 +36567,13 @@ lagevrio	l ə ɡ ɛ v ɹ i o ʊ
 laggard	l æ ɡ ɚ d
 laggy	l æ ɡ i
 lagid	l æ d͡ʒ ɪ d
-lagids	l æ d͡ʒ ɨ d z
+lagids	l æ d͡ʒ ɪ d z
 lagniappe	l æ n j æ p
 lagomorphic	l æ ɡ ə m ɔ ɹ f ɪ k
 lagoon	l ə ɡ uː n
 lagtime	l æ ɡ t a ɪ m
+lagune	l ə ɡ j uː n
+lagune	l ə ɡ uː n
 lah	l ɑ
 lahar	l ɑ h ɑ ɹ
 lahore	l ə h ɔː r
@@ -36267,7 +36589,7 @@ laicize	l e ɪ ɪ s a ɪ z
 laid	l e ɪ d
 laik	l e ɪ k
 lain	l e ɪ n
-lair	l ɛ ə ɹ
+lair	l ɛ ɚ
 laird	l ɛ ə ɹ d
 lairy	l ɛ ə ɹ i
 laisse	l e ɪ s
@@ -36356,7 +36678,7 @@ lanai	l ə n a ɪ
 lanark	l æ n ə ɹ k
 lancaster	l æ n k æ s t ɚ
 lancaster	l æ ŋ k ə s t ə ɹ
-lancaster	l æ ŋ k ɨ s t ɚ
+lancaster	l æ ŋ k ɪ s t ɚ
 lance	l æ n s
 lancefield	l æ n s f iː l d
 lancelot	l æ n s ə l ɒ t
@@ -36486,12 +36808,11 @@ large	l ɑ ɹ d͡ʒ
 largely	l ɑ ɹ d͡ʒ l i
 largeness	l ɑː d͡ʒ n ə s
 larger	l ɑ ɹ d͡ʒ ɚ
-largess	l ɑ ɹ d͡ʒ ɛ s
-largess	l ɑ ɹ ʒ ɛ s
-largesse	l ɑ ɹ d͡ʒ ɛ s
+largesse	l ɑ ɹ d ʒ ɛ s
 largest	l ɑ ɹ d͡ʒ ɪ s t
 lariat	l æ ɹ ɪ ə t
 larissa	l ə ɹ ɪ s ə
+larixinic	l æ ɹ ɪ k s ɪ n ɪ k
 lark	l ɑ ɹ k
 larnax	l ɑ ɹ n æ k s
 larne	l ɑː ɹ n
@@ -36502,12 +36823,13 @@ larrup	l æ ɹ ə p
 larva	l ɑ ɹ v ə
 larvae	l ɑ ɹ v i
 larval	l ɑ ɹ v ə l
+larve	l ɑː ɹ v
 laryngeal	l æ ɹ ə n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n d͡ʒ ə l
 laryngeal	l ɛ ɹ ə n d͡ʒ i ə l
 larynges	l ə ɹ ɪ n d͡ʒ iː z
-laryngitis	l æ ɹ ɪ n d͡ʒ a ɪ t ɪ s
+laryngitis	l ɛ ɹ ɪ n d͡ʒ a ɪ t ɪ s
 larynx	l æ ɹ ɪ ŋ k s
 larynx	l ɛ ɹ ɪ ŋ k s
 las	l ɑː z
@@ -36647,7 +36969,9 @@ laundromat	l ɔː n d ɹ ə ʊ m æ t
 laundry	l ɔː n d ɹ i
 laura	l ɔ ɹ ə
 lauraceous	l ɔ ɹ e ɪ ʃ ə s
+laureate	l ɑ ɹ i e ɪ t
 laureate	l ɑ ɹ i ə t
+laureate	l ɔ ɹ i e ɪ t
 laureate	l ɔ ɹ i ə t
 laureation	l ɔː ɹ i e ɪ ʃ ə n
 laurel	l ɔ ɹ ə l
@@ -36711,6 +37035,7 @@ lay	l e ɪ
 layabout	l e ɪ ə b a ʊ t
 layan	l ʌ j ʌ n
 layer	l e ɪ ɚ
+layer	l ɛ ɚ
 layers	l e ɪ ɚ z
 layin'	l e ɪ ɪ n
 laying	l e ɪ ɪ ŋ
@@ -36824,6 +37149,8 @@ leaven	l ɛ v ə n
 leaves	l iː v z
 leaving	l iː v ɪ ŋ
 lebanon	l ɛ b ə n ɑ n
+lebanon	l ɛ b ə n ə n
+lecce	l ɛ t ʃ e ɪ
 lech	l ɛ k
 lech	l ɛ t͡ʃ
 lechayim	l ə h a ɪ ɪ m
@@ -36841,6 +37168,7 @@ lectical	l ɛ k t ɪ k ə l
 lectinological	l ɛ k t ɪ n ə l ɒ d͡ʒ ɪ k ə l
 lectinologist	l ɛ k t ɪ n ɒ l ə d͡ʒ ɪ s t
 lection	l ɛ k ʃ ə n
+lector	l ɛ k t ə ɹ
 lecture	l ɛ k t͡ʃ ɚ
 lecturer	l ɛ k t͡ʃ ə ɹ ɚ
 lectures	l ɛ k t͡ʃ ɚ z
@@ -36881,7 +37209,7 @@ lefty	l ɛ f t i
 leg	l ɛ ɡ
 legacy	l ɛ ɡ ə s i
 legal	l i ɡ ə l
-legal	l ɨ ɡ æ l
+legal	l ɪ ɡ æ l
 legalist	l i ɡ ə l ɪ s t
 legalize	l iː ɡ ə l a ɪ z
 legally	l iː ɡ ə l i
@@ -36921,10 +37249,13 @@ leguleian	l ɛ ɡ j ʊ l iː ə n
 legume	l ə ɡ j uː m
 legume	l ɛ ɡ j uː m
 legume	l ɪ ɡ j uː m
+legumen	l ɪ ɡ j uː m ə n
 legumes	l ɛ ɡ j uː m z
 legumes	l ɪ ɡ j uː m z
 legwork	l ɛ ɡ w ɚ k
 leh	l e ɪ
+lehavdil	l ə h ɑ v d i l
+lehavdil	l ə h ɑ v d ɪ l
 lehua	l ɛ h uː ə
 lei	l e ɪ
 leia	l e ɪ ə
@@ -36981,6 +37312,7 @@ length	l ɛ ŋ k θ
 lengthen	l ɛ ŋ k θ ə n
 lengthening	l ɛ ŋ k θ ə n ɪ ŋ
 lengthman	l ɛ ŋ θ m ə n
+lengthsman	l ɛ ŋ θ s m ə n
 lenient	l iː n i ə n t
 lenify	l iː n ɪ f a ɪ
 lenify	l ɛ n ɪ f a ɪ
@@ -36997,6 +37329,7 @@ lenite	l iː n a ɪ t
 lenite	l ə n a ɪ t
 lenition	l i n ɪ ʃ ə n
 lenition	l ə n ɪ ʃ ə n
+lenity	l ɛ n ɪ t i
 lennon	l ɛ n ə n
 lenox	l ɛ n ɪ k s
 lens	l ɛ n z
@@ -37099,6 +37432,7 @@ lettuce	l ɛ t ɪ s
 leu	l e ɪ uː
 leuchars	l uː k ə ɹ z
 leuchars	l uː x ə ɹ s
+leucinemia	l j uː s ɪ n iː m i ə
 leucite	l u s a ɪ t
 leucoderm	l uː k ə d ɝ m
 leucodermic	l uː k ə d ɜː m ɪ k
@@ -37145,8 +37479,8 @@ leveret	l ɛ v ə ɹ ɪ t
 leveret	l ɛ v ɹ ɪ t
 leverpostej	l e ɪ v ə ɹ p ɒ s t a ɪ
 levet	l ɛ v ɪ t
-levetiracetam	l ɛ v ɨ t ɪ r æ s ɨ t æ m
-levi	l iː v a ɪ
+levetiracetam	l ɛ v ɪ t ɪ r æ s ɪ t æ m
+levi	l iː v a j
 leviathan	l ə v a ɪ ə θ ə n
 levidrome	l i v a ɪ d ɹ o ʊ m
 levidrome	l i v ɪ d ɹ o ʊ m
@@ -37196,8 +37530,6 @@ li	l iː
 liability	l a ɪ ə b ɪ l ɪ t i
 liable	l a ɪ̯ ə b ə l
 liaise	l iː e ɪ z
-liaison	l a ɪ ə s ə n
-liaison	l i e ɪ s ɑ n
 liaison	l i e ɪ z ɑ n
 liam	l iː ə m
 liana	l iː ɑː n ə
@@ -37266,7 +37598,6 @@ licorice	l ɪ k ə ɹ ɪ s
 licorice	l ɪ k ə ɹ ɪ ʃ
 lid	l ɪ d
 lidar	l a ɪ d ɑ ɹ
-liddat	l a ɪ d ɛ t
 lidge	l ɪ d͡ʒ
 lidocaine	l a ɪ d ə k e ɪ n
 lids	l ɪ d z
@@ -37342,6 +37673,8 @@ ligiid	l ɪ d ʒ i ɪ d
 ligma	l ɪ ɡ m ə
 lignify	l ɪ ɡ n ɪ f a ɪ
 lignite	l ɪ ɡ n a ɪ̯ t
+lignose	l ɪ ɡ n ə ʊ s
+lignose	l ɪ ɡ n ə ʊ z
 ligula	l ɪ ɡ j ʊ l ə
 liguria	l ɪ ɡ j ʊ ɹ i ə
 lihou	l iː uː
@@ -37372,6 +37705,7 @@ lilac	l a ɪ l ɑ k
 lilac	l a ɪ l ə k
 lilangeni	l ɪ l æ ŋ ɡ e ɪ n i
 lilian	l ɪ l i ə n
+liliana	l ɪ l i ɑ n ə
 liliate	l ɪ l i ə t
 lilies	l ɪ l i z
 liliger	l a ɪ l a ɪ ɡ ə ɹ
@@ -37449,6 +37783,7 @@ lindsey	l ɪ n z i
 lindworm	l ɪ n d w ɜː ɹ m
 line	l a ɪ n
 lineage	l ɪ n i ɪ d͡ʒ
+lineages	l ɪ n i ɪ d ʒ ɪ z
 lineal	l ɪ n i ə l
 linear	l ɪ n i ɚ
 linearithmic	l ɪ n i ə ɹ ɪ ð m ɪ k
@@ -37714,7 +38049,6 @@ llama	l ɑ m ə
 llandeilo	h l æ n d a ɪ l ə ʊ
 llandudno	l æ n d ɪ d n o ʊ
 llanegwad	ɬ æ n ɛ ɡ w ə d
-llaneilian	ɬ a n eː l ɪ a n
 llanero	l j ɑː n ɛː ɹ ə ʊ
 llanero	l ɑː n ɛː ɹ ə ʊ
 llanfyllin	ɬ æ n v ʌ ɬ ɪ n
@@ -37725,7 +38059,6 @@ llano	l æ n ə ʊ
 llanrumney	h l æ n ɹ ʌ m n i
 llanrwst	h l æ n ɹ uː s t
 llansamlet	ɬ æ n s æ m l ə t
-llanymynech	ɬ æ n ə m ʌ n ɛ x
 llewelyn	l uː ɛ l ɪ n
 llewelyn	l ə w ɛ l ɪ n
 llynfi	ɬ ɪ n v i
@@ -37767,6 +38100,7 @@ lobster	l ɑ b s t ɚ
 lobsterman	l ɒ b s t ə ɹ m ə n
 lobsterwoman	l ɒ b s t ə ɹ w ʊ m ə n
 lobule	l ɑ b j u l
+loc	l o ʊ k
 local	l o ʊ k l̩
 locale	l o ʊ k æ l
 localism	l o ʊ k ə l ɪ z ə m
@@ -37817,8 +38151,8 @@ loess	l o ʊ ə s
 loess	l ɛ s
 loess	l ʌ s
 loft	l ɔ f t
+lofton	l ɒ f t ə n
 lofty	l ɔː f t i
-log	l ɑ ɡ
 log	l ɔ ɡ
 logan	l o ʊ ɡ ə n
 logarithm	l ɑ ɡ ə ɹ ɪ ð m
@@ -37863,7 +38197,7 @@ logo	l o ʊ ɡ o ʊ
 logodaedaly	l o ʊ ɡ o ʊ d i d ə l i
 logogram	l ɑ ɡ ə ɡ ɹ æ m
 logogram	l ɔː ɡ ə ɡ ɹ æ m
-logological	l ɑ ɡ o ʊ l ɑ d͡ʒ ɨ k ə l
+logological	l ɑ ɡ o ʊ l ɑ d͡ʒ ɪ k ə l
 logomachy	l o ʊ ɡ ɑ m ə k i
 logophor	l o ʊ ɡ ɵ f o ʊ ɹ
 logorrhea	l ɔ ɡ ə ɹ i ə
@@ -37887,7 +38221,6 @@ lojban	l o ʊ ʒ b æ n
 lojban	l o ʊ ʒ b ɑː n
 lojban	l ɒ ʒ b æ n
 loki	l o ʊ k i
-lol	l o l
 lol	l o ʊ l
 lol	l ɑ l
 lol	l ɔ l
@@ -37898,6 +38231,7 @@ lolita	l o ʊ l l i ɾ ə
 lolita	l ə l l i ɾ ə
 loll	l ɑ l
 lollapalooza	l ɑ l ə p ə l u z ə
+lollard	l ɒ l ɑː ɹ d
 lollipop	l ɑ l i p ɑ p
 lollop	l ɒ l ə p
 lollygag	l ɒ l ɪ ɡ æ ɡ
@@ -37919,7 +38253,9 @@ loneliness	l o ʊ n l i n ə s
 lonely	l o ʊ n l i
 loner	l o ʊ n ɚ
 lonesome	l o ʊ n s ə m
+long	l ɒ ŋ
 long	l ɔ ŋ
+long	l ʊ ŋ
 longan	l ɑ ŋ ɡ ə n
 longdon	l ɒ ŋ d ə n
 longe	l ʌ n d͡ʒ
@@ -38005,6 +38341,7 @@ lopsided	l ɑ p s a ɪ d ɪ d
 loquacious	l o ʊ k w e ɪ ʃ ə s
 loquat	l o ʊ k w ɑ t
 lorazepam	l ɔ ɹ æ z ə p æ m
+lorazepam	l ɚ æ z ə p æ m
 lorcha	l ɔ ɹ t͡ʃ ə
 lorcha	l ɔ ɹ ʃ ə
 lorchel	l ɔː ɹ k ə l
@@ -38101,6 +38438,7 @@ lovable	l ʌ v ə b ə l
 lovage	l ʌ v ə d͡ʒ
 lovastatin	l o ʊ v ə s t æ t n̩
 lovastatin	l ʌ v ə s t æ t n̩
+love	l ʊ v
 love	l ʌ v
 lovecraft	l ʌ v k ɹ æ f t
 lovecraftian	l ʌ v k ɹ æ f t i ə n
@@ -38213,7 +38551,6 @@ luftwaffe	l ʊ f t w ɑ f ə
 lug	l ʌ ɡ
 luganda	l uː ɡ æ n d ə
 luganda	l uː ɡ ɑː n d ə
-luge	l u ʒ
 luged	l uː ʒ d
 luger	l u ɡ ɚ
 luggage	l ʌ ɡ ɪ d͡ʒ
@@ -38301,6 +38638,7 @@ lupine	l uː p a ɪ n
 lupine	l uː p ɪ n
 lupulin	l u p j ə l ɪ n
 lupus	l uː p ə s
+lur	l ʊ ə ɹ
 lurch	l ɝ t͡ʃ
 lure	l ɔ ɹ
 lure	l ɝ
@@ -38377,6 +38715,7 @@ luxury	l ʌ k ʃ ə ɹ i
 luxury	l ʌ ɡ ʒ ə ɹ i
 luzon	l u z ɔ n
 lviv	l ə v iː v
+lyam	l a ɪ ə m
 lycan	l a ɪ k ə n
 lycanthrope	l a ɪ k æ n θ ɹ o ʊ p
 lycanthrope	l a ɪ k ə n θ ɹ o ʊ p
@@ -38432,6 +38771,7 @@ lyra	l ɪ ə ɹ ə
 lyre	l a ɪ ɚ
 lyre	l a ɪ ɹ
 lyric	l ɪ ɹ ɪ k
+lyrical	l ɪ ɹ ɪ k ə l
 lyricist	l ɪ ɹ ɪ s ɪ s t
 lyrics	l ɪ ɹ ɪ k s
 lyrid	l a ɪ ɹ ɪ d
@@ -38529,6 +38869,7 @@ machismo	m ə t͡ʃ i z m o ʊ
 macho	m ɑː t͡ʃ o ʊ
 machoness	m ɑ t͡ʃ o ʊ n ə s
 macilent	m a s ɪ l ə n t
+macitentan	m æ s ɪ t ɛ n t æ n
 mack	m æ k
 mackerel	m æ k ɹ ə l
 mackey	m æ k i
@@ -38571,6 +38912,7 @@ macrovirus	m æ k ɹ o ʊ v a ɪ ɹ ə s
 macroworld	m æ k ɹ o ʊ w ɝ l d
 macs	m æ k s
 macspaunday	m ə k s p ɔː n d e ɪ
+macula	m æ k j ʊ l ə
 maculature	m æ k j ʊ l ə t j ʊ ə ɹ
 maculature	m æ k j ʊ l ə t͡ʃ ə ɹ
 maculele	m ɑː k u l e ɪ l e ɪ
@@ -38662,6 +39004,7 @@ maggot	m æ ɡ ə t
 maggots	m æ ɡ ə t s
 maggoty	m æ ɡ ə t i
 maghreb	m ɑː ɡ ɹ ɛ b
+maghreb	m ʌ ɡ ɹ ə b
 maghull	m ə ɡ ʌ l
 magi	m e ɪ d͡ʒ a ɪ
 magi	m e ɪ ɡ a ɪ
@@ -38848,6 +39191,7 @@ malagasy	m æ l ə ɡ e ɪ z i
 malagasy	m æ l ə ɡ æ s i
 malagueta	m ɑ l ə ɡ e ɪ d ə
 malagueta	m ɑ l ə ɡ w e ɪ d ə
+malai	m ə l a ɪ
 malaise	m ə l e ɪ z
 malakoplakia	m æ l ə k o ʊ p l æ k i ə
 malamute	m æ l ə m j uː t
@@ -38951,6 +39295,7 @@ malt	m ɔ l t
 malta	m ɑ l t ə
 malta	m ɔ l t ə
 maltalent	m æ l t æ l ə n t
+maltaxation	m æ l t æ k s e ɪ ʃ ə n
 maltese	m ɑ l t i z
 maltitol	m ɔː l t ə t ɑ l
 malum	m æ l ə m
@@ -39009,6 +39354,7 @@ manchuria	m æ n t͡ʃ ʊ ə ɹ i ə
 manchurian	m æ n t͡ʃ ʊ ə ɹ i ə n
 mancia	m æ n t͡ʃ ə
 mancipatory	m æ n s ɪ p e ɪ t ə ɹ i
+manciple	m æ n s ɪ p ə l
 mancunian	m æ n k j u n i ə n
 mand	m æ n d
 mand	m ɑː n d
@@ -39021,6 +39367,7 @@ mandate	m æ n d e ɪ t
 mandatory	m æ n d ə t ɔ ɹ i
 mandela	m æ n d ɛ l ə
 mandement	m æ n d m ə n t
+mandeville	m æ n d ə v ɪ l
 mandible	m æ n d ɪ b ə l
 mandibles	m æ n d ə b ə l z
 mandibles	m æ n d ɪ b ə l z
@@ -39118,6 +39465,7 @@ manitoba	m æ n ɪ t o ʊ b ə
 manitou	m a n ɪ t uː
 manitowoc	m æ n ɪ t ə w ɔː k
 manizer	m æ n a ɪ z ə ɹ
+manjuristics	m æ n d͡ʒ ə ɹ ɪ s t ɪ k s
 mank	m æ ŋ k
 mankind	m æ n k a ɪ n d
 mankiw	m æ n k j uː
@@ -39130,7 +39478,7 @@ manna	m æ n ə
 manned	m æ n d
 mannequin	m æ n ə k ɪ n
 manner	m æ n ɚ
-mannerism	˞ m æ n ə ɹ ɪ z ə m
+mannerism	m æ n ə ɹ ɪ z ə m
 manners	m æ n ɚ z
 mannish	m æ n ɪ ʃ
 mannopeptimycin	m n æ ə ʊ p ɛ p t ɪ m a ɪ s ɪ n
@@ -39151,6 +39499,7 @@ manship	m æ n ʃ ɪ p
 mansi	m æ n s i
 mansi	m ɑː n s i
 mansion	m æ n t͡ʃ ə n
+mansion	m æ n ʃ ə n
 manslot	m æ n z l ɑ t
 manson	m æ n s ə n
 mansonia	m æ n s o ʊ n i ə
@@ -39215,6 +39564,7 @@ mapless	m æ p l ə s
 mapping	m æ p ɪ ŋ
 maprotiline	m ə p ɹ o ʊ t ə l iː n
 maps	m æ p s
+mapuche	m ə p uː t ʃ e ɪ
 maputo	m ə p uː t ə ʊ
 maquette	m æ k ɛ t
 mar	m ɑ ɹ
@@ -39253,7 +39603,7 @@ marches	m ɑː t͡ʃ ɪ z
 marches	m ɒ ɹ t͡ʃ ə z
 marching	m ɑ ɹ t͡ʃ ɪ ŋ
 marchioness	m ɑ ɹ ʃ ə n ɛ s
-marchioness	m ɑ ɹ ʃ ə n ɨ s
+marchioness	m ɑ ɹ ʃ ə n ɪ s
 marchland	m ɑ ɹ t͡ʃ l æ n d
 marchpane	m ɑ ɹ t͡ʃ p e ɪ n
 marcia	m ɑ ɹ ʃ ə
@@ -39324,6 +39674,8 @@ mariupol	m ɑː ɹ i uː p o ʊ l
 marjoram	m ɑ ɹ d͡ʒ ə ɹ ə m
 mark	m ɑ ɹ k
 marked	m ɑ ɹ k t
+marked	m ɑ ɹ k ə d
+marked	m ɑ ɹ k ɪ d
 marker	m ɑː ɹ k ə ɹ
 market	m ɑ ɹ k ə t
 market	m ɑ ɹ k ɪ t
@@ -39336,6 +39688,8 @@ markovian	m ɑ ɹ k o ʊ v i ə n
 marks	m ɑ ɹ k s
 marksman	m ɑ ɹ k s m ə n
 marksmanship	m ɑ ɹ k s m ə n ʃ ɪ p
+markèd	m ɑ ɹ k ə d
+markèd	m ɑ ɹ k ɪ d
 marl	m ɑ ɹ l
 marley	m ɑ ɹ l i
 marlin	m ɑ ɹ l ɪ n
@@ -39433,7 +39787,6 @@ masaccio	m ə z ɑː t͡ʃ i o ʊ
 masala	m ə s ɑː l ə
 masbate	m ə s b ɑ t ɛ
 masc	m æ s k
-masc	m ɑː s k
 mascara	m æ s k æ ɹ ə
 mascaron	m æ s k ə ɹ ɒ n
 mascarpone	m æ s k ə ɹ p ə ʊ n i
@@ -39515,7 +39868,7 @@ masterman	m æ s t ɚ m ə n
 mastermind	m æ s t ɚ m a ɪ n d
 masterpiece	m æ s t ɚ p i s
 masters	m æ s t ɚ z
-mastery	m æ s t ə ɹ i
+mastery	m æ s t ɚ i
 mastic	m æ s t ɪ k
 masticate	m æ s t ɪ k e ɪ t
 mastication	m æ s t ɪ k e ɪ ʃ ə n
@@ -39558,7 +39911,7 @@ materialistic	m ə t ɪ ə ɹ i ə l ɪ s t ɪ k
 materials	m ə t ɪ ɹ i ə l z
 materiel	m ə t ɪ ɹ i ɛ l
 materiel	m ə t ɪ ɹ j ɛ l
-maternal	m ə t ɜ ɹ n ə l
+maternal	m ə t ɝ n ə l
 maternity	m ə t ɜː ɹ n ɪ t i
 mates	m e ɪ t s
 math	m æ θ
@@ -39625,6 +39978,7 @@ maturate	m æ t͡ʃ ə ɹ e ɪ t
 mature	m ə t j ʊ ə ɹ
 mature	m ə t͡ʃ ɝ
 mature	m ə t͡ʃ ʊ ə ɹ
+maturely	m ə t j ʊ ə ɹ l i
 maturity	m ə t ʊ ə ɹ ə t i
 matutinal	m æ t͡ʃ ə t a ɪ n ə l
 matutinal	m ə t j u t ə n l̩
@@ -39704,7 +40058,6 @@ maykop	m a ɪ k ɒ p
 mayn't	m e ɪ n t
 mayn't	m e ɪ ə n t
 maynooth	m ə n uː θ
-mayo	m e ɪ o ʊ
 mayo	m e ɪ ə ʊ
 mayonnaise	m e ɪ ə n e ɪ z
 mayonnaise	m æ n e ɪ z
@@ -39734,6 +40087,7 @@ mccobb	m ə k ɑ b
 mcconaughey	m ə k k ɑ n ə h e ɪ̯
 mccoy	m ə k ɔ ɪ
 mccrea	m ɪ k k r e ɪ
+mccrum	m ɪ k ɹ ʌ m
 mcdonald	m ə k d ɑ n ə l d
 mcghie	m ɪ ɡ iː
 mcgough	m ə ɡ j uː
@@ -39785,6 +40139,7 @@ meant	m ɛ n t
 meantime	m iː n t a ɪ m
 meanwhile	m iː n w a ɪ l
 mear	m ɪ ɹ
+measle	m i z ə l
 measles	m i z ə l z
 measlings	m iː z l ɪ ŋ z
 measly	m i z l i
@@ -39874,6 +40229,7 @@ medieval	m ɪ d i v ə l
 medievaldom	m ɪ d i v ə l d ə m
 medina	m ə d i n ə
 mediocre	m i d i o ʊ k ə ɹ
+mediocrity	m i d ɪ ɑ k ɹ ɪ t i
 mediolanum	m e ɪ d i o ʊ l ɑ n ə m
 mediolanum	m ɛ d i o ʊ l ɑ n ə m
 medish	m iː d ɪ ʃ
@@ -39896,6 +40252,7 @@ medusa	m ə d uː s ə
 medusa	m ɪ d j uː s ə
 medusa	m ɪ d j uː z ə
 medusoid	m ə d u s ɔ ɪ d
+medway	m ɛ d w e ɪ
 meed	m iː d
 meedless	m iː d l ə s
 meef	m iː f
@@ -39956,6 +40313,7 @@ meghalaya	m e ɪ ɡ ə l e ɪ ə
 meghan	m e ɪ ɡ ə n
 meghan	m iː ɡ ə n
 meghan	m ɛ ɡ ə n
+meghna	m e ɡ n a
 megiddo	m ə ɡ ɪ d ə ʊ
 megillah	m ə ɡ ɪ l ə
 megilp	m ə ɡ ɪ l p
@@ -39996,7 +40354,7 @@ melee	m ɛ l e ɪ
 melena	m ə l iː n ə
 melena	m ɛ l ɪ n ə
 melena	m ɪ l iː n ə
-melete	m ɛ l ɨ t i
+melete	m ɛ l ɪ t i
 melic	m ɛ l ɪ k
 melinda	m ə l ɪ n d ə
 melinda	m ɛ l ɪ n d ə
@@ -40018,7 +40376,7 @@ mellon	m ɛ l ɒ n
 mellow	m ɛ l o ʊ
 melly	m ɛ l i
 melodeon	m ə l o ʊ d i ə n
-melodic	m ɨ l ɒ d ɪ k
+melodic	m ɪ l ɒ d ɪ k
 melodious	m ə l ə ʊ d i ə s
 melodrama	m ɛ l ə d ɹ ɑː m ə
 melodramata	m ɛ l ə d ɹ ɑ m ə t ə
@@ -40085,17 +40443,19 @@ mendoza	m ɛ n d o ʊ z ə
 menelaus	m ɛ n ɪ l e ɪ ə s
 menendez	m ə n ɛ n d ɛ z
 mengzhou	m ʌ ŋ d͡ʒ o ʊ
+menhaden	m ɛ n h e ɪ d ə n
 menhir	m ɛ n h ɪ ə ɹ
 menial	m iː n i ə l
 meningeal	m ɛ n ə n d͡ʒ i ə l
+meningitis	m ɛ n ɪ n d ʒ a ɪ t ɪ s
 meninx	m i n ɪ ŋ k s
 meninx	m ɛ n ɪ ŋ k s
 meniscus	m ə n ɪ s k ə s
 meniscus	m ɛ n ɪ s k ə s
 mennish	m ɛ n ɪ ʃ
 menobranch	m ɛ n ə b ɹ æ ŋ k
-menoetius	m ɨ n iː ʃ i ə s
-menoetius	m ɨ n iː ʃ ə s
+menoetius	m ɪ n iː ʃ i ə s
+menoetius	m ɪ n iː ʃ ə s
 menopause	m ɛ n o ʊ p ɔː z
 menopause	m ɛ n ə p ɔː z
 menorah	m ɪ n ɔː ɹ ə
@@ -40158,6 +40518,7 @@ merc	m ɝ k
 mercantile	m ɝ k ə n t a ɪ l
 mercaptopurine	m ɚ k æ p t ə p j ʊ ɹ i n
 mercator	m ɜ ɹ k e ɪ t ɜ ɹ
+merce	m ɜː ɹ s
 merced	m ɜː r s ɛ d
 mercedes	m ɚ s e ɪ d i z
 mercenary	m ɝ s ə n ɛ ɹ i
@@ -40243,7 +40604,7 @@ meropic	m ɛ ɹ ɒ p ɪ k
 merovingian	m ɛ ɹ ə v ɪ n d͡ʒ i ə n
 merrily	m ɛ ɹ ɪ l i
 merriment	m ɛ ɹ i m ə n t
-merriment	m ɛ ɹ i m ɨ n t
+merriment	m ɛ ɹ i m ɪ n t
 merry	m e ɪ ɹ i
 merry	m ɛ ɹ i
 merrythought	m ɛ ɹ ɪ θ ɔː t
@@ -40381,6 +40742,7 @@ metaverse	m ɛ t ə v ɜː ɹ s
 mete	m iː t
 meteor	m iː t i ɚ
 meteoric	m iː t i ɒ ɹ ɪ k
+meteorical	m iː t i ɒ ɹ ɪ k ə l
 meteorite	m i t i ə ɹ a ɪ t
 meteoritics	m iː t ɪ ə ɹ ɪ t ɪ k s
 meteorological	m i t i ə ɹ ə l ɑ d͡ʒ ɪ k l̩
@@ -40413,6 +40775,7 @@ methicilin	m ɛ θ ɪ s ɪ l ɪ n
 methicillin	m ɛ θ ɪ s ɪ l ɪ n
 methimazole	m ə θ ɪ m ə z o ʊ l
 methionine	m ɛ θ a ɪ ə n iː n
+methioninemia	m ə θ a ɪ ə n ɪ n iː m i ə
 methionyl	m ə θ a ɪ ə n ɪ l
 methoctramine	m ɛ θ ɑ k t ɹ ə m iː n
 method	m ɛ θ ə d
@@ -40443,12 +40806,11 @@ methyprylon	m ɛ θ ɪ p ɹ a ɪ l ɒ n
 metic	m ɛ t ə k
 metical	m ɛ t ɪ k ɑː l
 meticillin	m ɛ t ɪ s ɪ l ɪ n
-meticulous	m ɨ t ɪ k j u l ə s
-meticulous	m ɨ t ɪ k j ɨ l ɨ s
+meticulous	m ɪ t ɪ k j u l ə s
+meticulous	m ɪ t ɪ k j ɪ l ɪ s
 metings	m iː t ɪ ŋ z
 metis	m e ɪ t iː
 metis	m e ɪ t iː s
-metis	m iː t ɨ s
 metis	m iː t ɪ s
 meto	m ɛ d o ʊ
 metoclopramide	m ɛ t ə k l o ʊ p ɹ ə m a ɪ d
@@ -40472,7 +40834,7 @@ metronym	m ɛ t ɹ o ʊ n ɪ m
 metropole	m ɛ t ɹ ə p o ʊ l
 metropoleis	m ɛ t ɹ ɒ p ə l e ɪ z
 metropolises	m ɛ t ɹ ɒ p ɒ l ɪ s ɪ z
-metropolitan	m ɛ t ɹ ɵ p ɑ l ɨ t ə n
+metropolitan	m ɛ t ɹ ɵ p ɑ l ɪ t ə n
 metrorrhagia	m iː t r ɔː ɹ e ɪ d͡ʒ ɪ ə
 metroscopy	m ə t ɹ ɑ s k ə p i
 mets	m ɛ t s
@@ -40483,6 +40845,7 @@ metz	m ɛ t s
 metzian	m ɛ t s i ə n
 meu	m j u
 meum	m i ə m
+meuse	m j uː z
 meute	m j uː t
 mevushal	m ɪ v uː ʃ ɑː l
 mevushal	m ɪ v ʊ ʃ ə l
@@ -40491,7 +40854,6 @@ mew	m j uː
 mews	m j uː z
 mexicali	m ɛ k s ɪ k æ l i
 mexican	m ɛ k s ə k ə n
-mexican	m ɛ k s ɪ k ə n
 mexico	m ɛ k s ɪ k o ʊ
 mexicoke	m ɛ k s ɪ k ə ʊ k
 mexiletine	m ɛ k s ɪ l ə t iː n
@@ -40514,6 +40876,7 @@ mi'kmaq	m ɪ ɡ m ɔː
 mi'kmaq	m ɪ ɡ ə m ɒ k
 mia	m iː ə
 miami	m a ɪ æ m i
+miami	m a ɪ æ m ə
 miasma	m a ɪ æ z m ə
 miasma	m i æ z m ə
 miasmatic	m a ɪ ə z m æ t ɪ k
@@ -40600,6 +40963,7 @@ miculek	m ɪ t͡ʃ ə l ɛ k
 mid	m ɪ d
 midas	m a ɪ d ə s
 midazolam	m ɪ d æ z ə l æ m
+midbroad	m ɪ d b ɹ ɔː d
 midday	m ɪ d d e ɪ
 middelmannetjie	m ɪ d ə l m æ n ə k i
 middelmannetjie	m ɪ d ə l m æ n ə t͡ʃ i
@@ -40701,7 +41065,6 @@ milliary	m ɪ l i ə ɹ i
 milliary	m ɪ l j ə ɹ i
 milligram	m ɪ l ɪ ɡ ɹ æ m
 milliner	m ɪ l ɪ n ɚ
-millinery	m ɪ l n ɚ i
 millinery	m ɪ l ɪ n ɚ i
 milling	m ɪ l ɪ ŋ
 million	m ɪ l j ə n
@@ -40794,7 +41157,7 @@ minim	m ɪ n ɪ m
 minimal	m ɪ n ə m ə l
 minimifidian	m ɪ n ɪ m ɪ f ɪ d i ə n
 minimize	m ɪ n ə m a ɪ z
-minimize	m ɪ n ɨ m a ɪ z
+minimize	m ɪ n ɪ m a ɪ z
 minimum	m ɪ n ə m ə m
 mining	m a ɪ n ɪ ŋ
 minion	m ɪ n j ə n
@@ -40902,6 +41265,8 @@ mirrour	m ɪ ɹ ə
 mirrour	m ɪ ɹ ɚ
 mirtazapine	m ɪ ɹ t æ z ə p i n
 mirth	m ɜ ɹ θ
+mirthless	m ɝ θ l ə s
+mirthless	m ɝ θ l ɪ s
 misandry	m ɪ s æ n d ɹ i
 misanswer	m ɪ s æ n s ə ɹ
 misanswer	m ɪ s ɑː n s ə ɹ
@@ -40963,6 +41328,7 @@ miser	m a ɪ z ə ɹ
 miserabilist	m ɪ z ə ɹ ə b ə l ɪ s t
 miserable	m ɪ z ə ɹ ə b ə l
 miserabler	m ɪ z ɹ ə b ə l ə ɹ
+miserere	m ɪ z ə ɹ ɛ ə ɹ i
 misericordia	m ɪ s ə ɹ ɪ k ɔː ɹ d i ə
 miserly	m a ɪ z ə ɹ l i
 misery	m ɪ z ə ɹ i
@@ -41046,7 +41412,7 @@ misregard	m ɪ s ɹ ɪ ɡ ɑː ɹ d
 misregister	m ɪ s ɹ ɛ d͡ʒ ɪ s t ə ɹ
 misremember	m ɪ s ɹ ɪ m ɛ m b ɚ
 misrepair	m ɪ s ɹ ɪ p ɛ ə ɹ
-misrepresentation	m ɪ s ɹ ɛ p ɹ ɨ z ɛ n t e ɪ ʃ ə n
+misrepresentation	m ɪ s ɹ ɛ p ɹ ɪ z ɛ n t e ɪ ʃ ə n
 misrespect	m ɪ s ɹ ɪ s p ɛ k t
 misrule	m ɪ s ɹ uː l
 miss	m ɪ s
@@ -41223,6 +41589,7 @@ mocha	m o ʊ k ə
 mochi	m o ʊ t ʃ i
 mochi	m ɒ t ʃ i
 mock	m ɑ k
+mock	m ɔ k
 mockado	m ɒ k e ɪ d ə ʊ
 mockery	m ɑ k ə ɹ i
 mocking	m ɑ k ɪ ŋ
@@ -41274,6 +41641,7 @@ mofetil	m o ʊ f ə t ɪ l
 moffie	m ɒ f i
 moffitt	m ɒ f ɪ t
 mofo	m o ʊ f o ʊ
+mog	m ɔ ɡ
 moggach	m ɒ ɡ ə x
 moggy	m ɔ ɡ i
 mogollon	m o ʊ ɡ ə j o ʊ n
@@ -41312,8 +41680,8 @@ mol	m o l
 mol	m o ʊ l
 mola	m o ʊ l ə
 molar	m o ʊ l ɚ
-molasses	m ə l æ s ɨ z
-molasses	m ə l ɑ s ɨ z
+molasses	m ə l æ s ɪ z
+molasses	m ə l ɑ s ɪ z
 mold	m o ʊ l d
 moldavite	m ɒ l d ə v ʌ ɪ t
 molding	m o ʊ l d ɪ ŋ
@@ -41333,7 +41701,7 @@ molestation	m o ʊ l ɪ s t e ɪ ʃ ə n
 molester	m ə l ɛ s t ɚ
 moliminous	m o ʊ l ɪ m ɪ n ə s
 molina	m ɵ l i n ə
-molineux	m ɒ l ɨ n j uː
+molineux	m ɒ l ɪ n j uː
 molise	m ɔ l i z e ɪ
 moll	m ɒ l
 mollie	m ɑ l i
@@ -41383,6 +41751,7 @@ moncton	m ʌ ŋ k t ə n
 monday	m ʌ n d e ɪ
 monday	m ʌ n d i
 mondegreen	m ɑ n d ə ɡ ɹ iː n
+mondial	m ɒ n d i ə l
 monet	m o ʊ n e ɪ
 monetary	m ɑ n ɪ t ɛ ɹ i
 monetary	m ʌ n ə t ɛ ɹ i
@@ -41511,6 +41880,7 @@ montenegro	m ɑ n t ɪ n i ɡ ɹ o ʊ
 monterey	m ɑ n ə ɹ e ɪ
 montero	m ɒ n t ɛ ə ɹ o ʊ
 monterrey	m ɑ n t ə ɹ e ɪ
+montes	m ɒ n t i z
 montevideo	m ɒ n t ɪ v ɪ d e ɪ ə ʊ
 montezuma	m ɒ n t ɪ z uː m ə
 montferrat	m ɑ n t f ə ɹ ɑ t
@@ -41521,6 +41891,7 @@ month	m ʌ n θ
 monthiversary	m ʌ n θ ɪ v ɝ s ə ɹ i
 monthly	m ʌ n θ l i
 months	m ʌ n θ s
+montiform	m ɒ n t ɪ f ɔː m
 montjuïc	m ɒ n t ʒ uː iː k
 montpelier	m ɑ n t p ɪ l j ɚ
 montpelier	m ɔ n t p i l i ɚ
@@ -41557,6 +41928,8 @@ moon	m u n
 moonbat	m uː n b æ t
 moonbeam	m u n b i m
 mooncake	m u n k e ɪ k
+moonflask	m uː n f l æ s k
+moonflask	m uː n f l ɑː s k
 moong	m ʊ ŋ
 moonlight	m u n l a ɪ t
 moonlit	m uː n l ɪ t
@@ -41774,7 +42147,7 @@ motivate	m o ʊ t ɪ v e ɪ t
 motivate	m o ʊ ɾ ə v e ɪ t
 motive	m o ʊ t ɪ v
 motives	m o ʊ t ɪ v z
-motley	m ɒ t l i
+motley	m ɑ t l i
 motlopi	m o ʊ t l o ʊ p i
 motor	m o ʊ t ə ɹ
 motorbike	m ə ʊ t ə ɹ b a ɪ k
@@ -41850,7 +42223,7 @@ mow	m o ʊ
 mower	m o ʊ ɚ
 mowing	m ə ʊ ɪ ŋ
 mown	m o ʊ n
-moxa	m ɒ k s ə
+moxa	m ɑ k s ə
 moxibustion	m ɒ k s ɪ b ʌ s t͡ʃ ə n
 moxie	m ɒ k s i
 moy	m ɔ ɪ
@@ -41879,6 +42252,7 @@ mses	m ɪ z ə z
 mss	m ɪ z ə z
 mth	ɛ m θ
 mthwakazi	ə m t w ɑː k ɑː z i
+mtskheta	m ə t s k e ɪ t ə
 mtso	m ɛ t s o ʊ
 mu	m j u
 mu	m j uː
@@ -41933,6 +42307,7 @@ muggy	m ʌ ɡ i
 mugham	m u ɡ ɑ m
 mugient	m j uː d͡ʒ i ə n t
 mugient	m j uː d͡ʒ ə n t
+mugwort	m ʌ ɡ w ɝ t
 mugwump	m ʌ ɡ w ʌ m p
 mugwumps	m ʌ ɡ w ʌ m p s
 muh	m ə
@@ -41966,7 +42341,7 @@ muleteer	m j uː l ə t ɪ ə ɹ
 mulga	m ʌ l ɡ ə
 mulgrave	m ʌ l ɡ ɹ e ɪ v
 mulhouse	m ə l uː z
-muliebral	m j uː l ɨ iː b ɹ ə l
+muliebral	m j uː l ɪ iː b ɹ ə l
 muliebrity	m j u l i ɛ b ɹ ə t i
 mull	m ʌ l
 mullah	m ʊ l ə
@@ -41978,7 +42353,7 @@ mullered	m ʊ l ə ɹ d
 mullet	m ʌ l ə t
 mullet	m ʌ l ɪ t
 mulligan	m ʌ l ɪ ɡ ə n
-mulligatawny	m ʌ l ɨ ɡ ə t ɔː n i
+mulligatawny	m ʌ l ɪ ɡ ə t ɔː n i
 mullins	m ʌ l ɪ n z
 mullion	m ʌ l i ə n
 multibillion	m ʌ l t i b ɪ l j ə n
@@ -42023,7 +42398,7 @@ mum	m ʌ m
 mumbai	m ʊ m b a ɪ
 mumble	m ʌ m b ə l
 mumchance	m ʌ m t͡ʃ æ n s
-mummerset	m ʌ m ə ɹ s ɛ t
+mummerset	m ʌ m ɚ s ɛ t
 mummiform	m ʌ m ɪ f ɔ ɹ m
 mummy	m ʌ m i
 mump	m ʌ m p
@@ -42032,6 +42407,7 @@ mums	m ʌ m z
 mun	m ʌ n
 munchies	m ʌ n t͡ʃ i z
 munchkin	m ʌ n t͡ʃ k ɪ n
+muncie	m ʌ n s i
 mund	m ʊ n d
 mund	m ʌ n d
 mundane	m ʌ n d e ɪ n
@@ -42041,12 +42417,17 @@ mundungus	m ə n d ə ŋ ɡ ə s
 mung	m uː ŋ
 mung	m ʌ ŋ
 munge	m ʌ n d͡ʒ
+munged	m ʌ n d͡ʒ d
+munged	m ʌ ŋ d
 munger	m ʌ n d͡ʒ ɚ
+munger	m ʌ ŋ ɚ
+munging	m ʌ n d͡ʒ ɪ ŋ
+munging	m ʌ ŋ ɪ ŋ
 munich	m j uː n ɪ k
 municipal	m j u n ɪ s ɪ p ə l
 municipium	m j u n ə s ɪ p i ə m
 munificence	m j uː n ɪ f ɪ s ə n s
-munificent	m j u n ɪ f ɨ s n̩ t
+munificent	m j u n ɪ f ɪ s n̩ t
 munite	m j uː n a ɪ t
 munity	m j uː n ɪ t i
 munji	m ʊ n d͡ʒ i
@@ -42169,6 +42550,7 @@ mussed	m ʌ s t
 mussel	m ʌ s ə l
 musselburgh	m ʌ s ə l b ə ɹ ə
 mussitate	m ʌ s ɪ t e ɪ t
+mussitation	m ʌ s ɪ t e ɪ ʃ ə n
 mussolini	m ʊ s ə l iː n i
 mussuck	m ʌ s ə k
 mussulman	m ʌ s ə l m ə n
@@ -42260,6 +42642,7 @@ myocardial	m a ɪ o ʊ k ɑ ɹ d i ə l
 myoclonus	m a ɪ o ʊ k l o ʊ n ə s
 myofilament	m a ɪ o ʊ f ɪ l ə m ə n t
 myoglobinemia	m a ɪ o ʊ ɡ l o ʊ b ɪ n i m i ə
+myokine	m a ɪ ə ʊ k a ɪ n
 myoma	m a ɪ o ʊ m ə
 myometrium	m a ɪ ə ʊ m iː t ɹ i ə m
 myopia	m a ɪ o ʊ p i ə
@@ -42354,7 +42737,7 @@ nacho	n ɑ t͡ʃ o ʊ
 nachos	n ɑ t͡ʃ o ʊ z
 nachos	n ɑ x ə s
 nack	n æ k
-nackawic	n æ k ɘ w ɪ k
+nackawic	n æ k ə w ɪ k
 nacogdoches	n æ k ə d o ʊ t͡ʃ ɪ s
 nacre	n e ɪ k ə ɹ
 nacreous	n e ɪ k ɹ i ə s
@@ -42489,7 +42872,7 @@ naratriptan	n ɑː ɹ ə t ɹ ɪ p t æ n
 narc	n ɑː ɹ k
 narcissine	n ɑ ɹ s ɪ s i n
 narcissism	n ɑ ɹ s ə s ɪ z m
-narcissistic	n ɑ ɹ s ɨ s ɪ s t ɪ k
+narcissistic	n ɑ ɹ s ɪ s ɪ s t ɪ k
 narcissus	n ɑ ɹ s ɪ s ə s
 narcokleptocracy	n ɑ ɹ k o ʊ k l ɛ p t ɑ k ɹ ə s i
 narcolepsy	n ɑː ɹ k ə l ɛ p s i
@@ -42505,10 +42888,11 @@ naris	n ɛ ə ɹ ɪ s
 nark	n ɑː ɹ k
 narrabundah	n æ r ə b ʌ n d ə
 narrate	n æ ɹ e ɪ t
+narration	n æ ɹ e ɪ ʃ ə n
 narration	n ɛ ɚ ɹ e ɪ ʃ ə n
 narrative	n æ ɹ ə t ɪ v
 narrative	n ɛ ɹ ə t ɪ v
-narrator	n æ ɹ e ɪ t ə ɹ
+narrator	n æ ɹ e ɪ t ɚ
 narrow	n æ ɹ o ʊ
 narrow	n ɛ ɹ o ʊ
 narrowly	n ɛ ɹ o ʊ l i
@@ -42631,7 +43015,7 @@ nauseated	n ɔː z i e ɪ t ɪ d
 nauseatic	n ɔː z i æ t ɪ k
 nauseous	n ɔː ʃ ə s
 nauseous	n ɔː ʒ ə s
-nausicaa	n ɔː s ɪ k e ɪ ə
+nausicaa	n ɔː s ɪ k i ə
 nausicaan	n ɔː s ə k e ɪ ə n
 nautch	n ɔː t͡ʃ
 nautical	n ɑ t ɪ k ə l
@@ -42700,6 +43084,7 @@ neave	n iː v
 neb	n ɛ b
 nebbiolo	n ɛ b i o ʊ l o ʊ
 nebbish	n ɛ b ɪ ʃ
+nebentan	n ə b ɛ n t æ n
 nebracetam	n ə b ɹ æ s ɪ t æ m
 nebraska	n ə b ɹ æ s k ə
 nebuchadnezzar	n ɛ b ə k ə d n ɛ z ɚ
@@ -42734,8 +43119,8 @@ necktie	n ɛ k t a ɪ
 neckwear	n ɛ k w ɛ ɚ
 necrectomy	n ə k ɹ ɛ k t ə m i
 necrocracy	n ə k ɹ ɑ k ɹ ə s i
-necrolysis	n ɘ k ɹ ɔ l ə s ə s
-necrolysis	n ɘ k ɹ ɔ l ə s ɪ s
+necrolysis	n ə k ɹ ɔ l ə s ə s
+necrolysis	n ə k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ɪ s ɪ s
 necromancer	n e k ɹ ə m æ n s ɚ
@@ -42755,7 +43140,7 @@ necropolises	n ɛ k ɹ ɒ p ɒ l ɪ s ɪ z
 necropsy	n ɛ k ɹ ɑ p s i
 necrosectomy	n ɛ k ɹ o ʊ z ɛ k t ə m i
 nectar	n ɛ k t ə ɹ
-nectarine	n ɛ k t ə ɹ i n
+nectarine	n ɛ k t ə ɹ iː n
 ned	n ɛ d
 neddy	n ɛ d i
 nederland	n i d ɚ l ə n d
@@ -43018,6 +43403,7 @@ nevin	n ɛ v ɪ n
 nevirapine	n ə v a ɪ ɹ ə p i n
 nevirapine	n ə v ɪ ɹ ə p i n
 nevis	n iː v ɪ s
+nevus	n iː v ə s
 new	n j u
 newall	n uː ə l
 newark	n uː ə ɹ k
@@ -43052,7 +43438,7 @@ newman	n u m ə n
 newness	n j uː n ə s
 newport	n u p ɔ ɹ t
 newquay	n j uː k iː
-news	n j uː z
+news	n j u z
 newsletter	n j u z l ɛ t ɚ
 newspaper	n j u z p e ɪ p ɚ
 newspapers	n u s p e ɪ p ɚ z
@@ -43377,7 +43763,7 @@ noetic	n o ʊ ɛ t ɪ k
 nog	n ɒ ɡ
 nogai	n o ʊ ɡ a ɪ
 noggin	n ɑ ɡ n̩
-noggin	n ɑ ɡ ɨ n
+noggin	n ɑ ɡ ɪ n
 nogoodnik	n o ʊ ɡ ʊ d n ɪ k
 noice	n ɔ ɪ s
 noil	n ɔ ɪ l
@@ -43507,6 +43893,8 @@ norepinephrine	n ɔː ɹ ɛ p ɪ n ɛ f ɹ ɪ n
 norethindrone	n ɔ ɹ ɛ θ ɪ n d ɹ o ʊ n
 norethisterone	n ɔ ɹ ə θ ɪ s t ə ɹ o ʊ n
 norfloxacin	n ɔ ɹ f l ɑ k s ə s ɪ n
+norfolk	n ɔː ɹ f o ʊ l k
+norfolk	n ɔː ɹ f ə k
 norgestimate	n ɔ ɹ d͡ʒ ɛ s t ɪ m e ɪ t
 norgestrel	n ɔ ɹ d͡ʒ ɛ s t ɹ ə l
 noria	n ɔ ɹ i ə
@@ -43631,7 +44019,7 @@ novemdecillion	n o ʊ v ə m d ə s ɪ l i ə n
 novercal	n ə ʊ v ɜː ɹ k ə l
 novgorod	n ɒ v ɡ ə ɹ ɒ d
 novgorod	n ɔː v ɡ ə ɹ ə t
-novice	n ɑː v ɪ s
+novice	n ɑ v ɪ s
 novitiate	n ə v ɪ ʃ i ə t
 novitious	n ə ʊ v ɪ ʃ ə s
 novity	n ɑ v ɪ t i
@@ -43713,6 +44101,7 @@ numbered	n ʌ m b ɚ d
 numberous	n ʌ m b ə ɹ ə s
 numberous	n ʌ m b ɹ ə s
 numbers	n ʌ m b ɚ z
+numby	n ʌ m i
 numchuck	n ʌ m t͡ʃ ʌ k
 numen	n uː m ə n
 numeral	n u m ə ɹ ə l
@@ -43884,7 +44273,6 @@ obedient	ə b i d i ə n t
 obediential	ə ʊ b iː d i ɛ n ʃ ə l
 obeisance	o ʊ b e ɪ s ə n s
 obeisance	o ʊ b iː s ə n s
-obeisance	ə b e ɪ s ə n s
 obeisance	ə b iː s ə n s
 obeli	ɑ b ə l a ɪ
 obelisk	ɑ b ə l ɪ s k
@@ -43952,6 +44340,8 @@ obliquity	o ʊ b l ɪ k w ɪ ɾ i
 obliquity	ə b l ɪ k w ɪ ɾ i
 oblite	ə b l a ɪ t
 obliterate	ə b l ɪ t ə ɹ e ɪ t
+obliterate	ə b l ɪ t ə ɹ ə t
+obliterated	ə b l ɪ t ə ɹ e ɪ t ɪ d
 obliviality	ə b l ɪ v i æ l ɪ t i
 oblivion	ə b l ɪ v iː ə n
 oblivious	ə b l ɪ v iː ə s
@@ -44028,7 +44418,7 @@ obtaining	ə b t e ɪ n ɪ ŋ
 obtend	ɒ b t ɛ n d
 obtend	ə b t ɛ n d
 obtest	ɒ b t ɛ s t
-obtrusive	ə b t ɹ uː s ɪ v
+obtrusive	ə b t ɹ u s ɪ v
 obtund	ɑ b t ʌ n d
 obtund	ə b t ʌ n d
 obtuse	ə b t j u s
@@ -44138,7 +44528,6 @@ octogenary	ɑ k t ɑ d͡ʒ ə n ɛ r i
 octogram	ɒ k t o ʊ ɡ ɹ æ m
 octogram	ɒ k t ə ɡ ɹ æ m
 octopawn	ɒ k t ə p ɔː n
-octopodes	ɒ k t ɒ p ə d iː z
 octopus	ɑ k t ə p ə s
 octopus	ɑ k t ə p ʊ s
 octosyllabic	ɑ k t o ʊ s ɪ l æ b ɪ k
@@ -44195,7 +44584,7 @@ odysseus	o ʊ d ɪ s i ə s
 odysseus	o ʊ d ɪ s j uː s
 odysseus	ə d ɪ s j uː s
 odyssey	ɑ d ə s i
-odyssey	ɑ d ɨ s i
+odyssey	ɑ d ɪ s i
 oe	o i
 oe	o ʊ
 oe	ɔ ɪ
@@ -44255,6 +44644,7 @@ officer	ɔ f ə s ɚ
 officer	ɔ f ɪ s ɚ
 officers	ɔ f ɪ s ɚ z
 offices	ɔ f ɪ s ɪ z
+officetel	ɒ f ɪ s t ɛ l
 officey	ɔ f ɪ s i
 official	ə f ɪ ʃ ə l
 officialdom	ə f ɪ ʃ ə l d ə m
@@ -44301,7 +44691,6 @@ ogler	ə ʊ ɡ ə l ə ɹ
 ogonek	o ʊ ɡ ə n ɛ k
 ogre	o ʊ ɡ ɚ
 ogress	o ʊ ɡ ɹ ɛ s
-ogress	ə ʊ ɡ ɹ ə s
 ogun	ə ʊ ɡ ə n
 oh	o ʊ
 ohana	ə h ɑː n ə
@@ -44654,6 +45043,7 @@ ophiuchus	ɑ f i j uː k ə s
 ophthalmia	ɑ p θ æ l m i ə
 ophthalmic	ɑ f θ æ l m ɪ k
 ophthalmic	ɑ p θ æ l m ɪ k
+ophthalmitis	ɒ f θ æ l m a ɪ t ɪ s
 ophthalmologist	ɑ f θ æ l m ɑ l ə d͡ʒ ɪ s t
 ophthalmologist	ɑ f θ ə l m ɑ l ə d͡ʒ ɪ s t
 ophthalmologist	ɑ p θ ə l m ɑ l ə d͡ʒ ɪ s t
@@ -44732,6 +45122,7 @@ optimistic	ɑ p t ɪ m ɪ s t ɪ k
 optimize	ɑ p t ɪ m a ɪ z
 optimum	ɑ p t ɪ m ə m
 option	ɑ p ʃ ə n
+optional	ɑ p ʃ ə n ə l
 optoacoustic	ɑ p t o ʊ ə k u s t ɪ k
 optocoupler	ɑ p t o ʊ k ʌ p l ɚ
 optoelectronics	ɑ p t o ʊ ɪ l ɛ k t ɹ ɑ n ɪ k s
@@ -44754,8 +45145,7 @@ oracle	ɒ ɹ ə k ə l
 oracle	ɔ ɹ ə k ə l
 oracular	ɔ ɹ æ k j u l ɚ
 oracular	ɔ ɹ æ k j ə l ɚ
-oral	o ɹ ə l
-oral	ɑ ɹ ə l
+oral	ɔ ɹ ə l
 orally	ɔː ɹ ə l i
 orang	o ʊ r æ ŋ
 orang	ɔ r æ ŋ
@@ -44978,6 +45368,8 @@ orthopraxy	ɔː ɹ θ ə p ɹ æ k s i
 orthopyroxene	ɔ ɹ θ o ʊ p a ɪ ɹ ɑ k s i n
 orthoquartzite	ɔ ɹ θ o ʊ k w ɔ ɹ t s a ɪ t
 orthorhombic	ɔː ɹ θ ə ɹ ɒ m b ɪ k
+orthosexual	ɔː ɹ θ ə s ɛ k s j u ə l
+orthosexual	ɔː ɹ θ ə s ɛ k ʃ u ə l
 ortiz	ɔ ɹ t i s
 ortiz	ɔ ɹ t i z
 ortolan	ɔ ɹ t ə l æ n
@@ -45045,7 +45437,7 @@ ossicone	ɒ s ɪ k ə ʊ n
 ossifier	ɒ s ɪ f a ɪ ə ɹ
 ossifrage	ɒ s ɪ f ɹ ɪ d͡ʒ
 ossify	ɑ s ə f a ɪ
-ossining	ɒ s ɨ n ɪ ŋ
+ossining	ɑ s ɪ n ɪ ŋ
 ossuarium	ɒ s j u ɛ ə ɹ i ə m
 ostensible	ɑ s t ɛ n s ɪ b ə l
 ostensibly	ɑː s t ɛ n s ə b l i
@@ -45067,6 +45459,8 @@ ostiary	ɒ s t i ə ɹ i
 ostiary	ɒ s t͡ʃ ə ɹ i
 ostinato	ɒ s t ɪ n ɑ t o ʊ
 ostler	ɑː s l ɚ
+ostracean	ɒ s t ɹ e ɪ ʃ i ə n
+ostracean	ɒ s t ɹ e ɪ ʃ ə n
 ostracize	ɑ s t ɹ ə s a ɪ z
 ostracon	ɑ s t ɹ ə k ɑ n
 ostreaceous	ɒ s t ɹ i e ɪ ʃ ə s
@@ -45076,6 +45470,7 @@ ostrich	ɔ s t ɹ ɪ d͡ʒ
 ostrich	ɔ s t ɹ ɪ t͡ʃ
 ostrichism	ɑ s t ɹ i t͡ʃ ɪ z ə m
 ostrobogulous	ɑː s t ɹ ə b ɑː ɡ j ə l ə s
+ostrogoth	ɒ s t r ə ɡ ɒ θ
 oswaldtwistle	ɒ z ə l t w ɪ z ə l
 oswego	ɒ s w iː ɡ o ʊ
 otago	ə t ɑ ɡ o ʊ
@@ -45144,6 +45539,9 @@ ounce	a ʊ n s
 ounces	a ʊ n s ɪ z
 ouphe	a ʊ f
 ouphe	uː f
+ouppy	o ʊ ʌ p i
+ouppy	u p i
+ouppy	ʌ p i
 our	a ʊ ɚ
 our	æ ɔ ə
 our	ɐː
@@ -45364,10 +45762,10 @@ overreact	o ʊ v ə ɹ ɹ i æ k t
 overreactive	o ʊ v ə ɹ ɹ i æ k t ɪ v
 overreactor	o ʊ v ə ɹ ɹ i æ k t ɚ
 overridden	o ʊ v ɚ ɹ ɪ d ə n
-override	o ʊ v ə ɹ ɹ a ɪ d
+override	o ʊ v ɚ ɹ a ɪ d
 overriding	ə ʊ v ə ɹ ɹ a ɪ d ɪ ŋ
 overrode	ə ʊ v ə ɹ ə ʊ d
-overrule	ə ʊ v ə ɹ ɹ uː l
+overrule	o ʊ v ɚ ɹ u l
 overrun	o ʊ v ɚ ɹ ʌ n
 oversaw	o ʊ v ɚ s ɔ
 oversea	ə ʊ v ə ɹ s iː
@@ -45384,7 +45782,7 @@ overshoot	o ʊ v ɚ s h u t
 overshorten	o ʊ v ɚ ʃ ɔ ɹ t ə n
 overshot	o ʊ v ɚ ʃ ɑ t
 overside	ə ʊ v ə ɹ s a ɪ d
-oversight	o ʊ v ə ɹ s a ɪ t
+oversight	o ʊ v ɚ s a ɪ t
 oversit	ə ʊ v ə ɹ s ɪ t
 overskirt	ə ʊ v ə s k ɜː t
 overslaugh	ə ʊ v ə ɹ s l ɔː
@@ -45468,6 +45866,7 @@ owie	a ʊ w iː
 owing	o ʊ ɪ ŋ
 owl	a ʊ l
 owler	a ʊ l ɚ
+owlet	a ʊ l ə t
 owlful	a ʊ l f l̩
 owlful	a ʊ l f ʊ l
 owling	a ʊ l ɪ ŋ
@@ -45617,6 +46016,7 @@ paedobaptism	p ɛ d o ʊ b æ p t ɪ z ə m
 paedomorphic	p i d ə m ɔ ɹ f ɪ k
 paedomorphic	p ɛ d ə m ɔ ɹ f ɪ k
 paedophile	p e d ə f ɑ e l
+paedophile	p iː d ə f a ɪ l
 paedophile	p ɛ d ə ʉ f ɑ e l
 paedopsychology	p i d o ʊ p s a ɪ k ɑ l ə d͡ʒ i
 paedopsychology	p i d o ʊ s a ɪ k ɑ l ə d͡ʒ i
@@ -45650,6 +46050,7 @@ paginate	p æ d͡ʒ ə n e ɪ t
 pagination	p æ d͡ʒ ə n e ɪ ʃ ə n
 paging	p e ɪ d͡ʒ ɪ ŋ
 pagings	p e ɪ d͡ʒ ɪ ŋ z
+pagnol	p ɑː n j ɔː l
 pagoclone	p e ɪ ɡ ə k l ə ʊ n
 pagoda	p ə ɡ o ʊ d ə
 pah	p ɑː
@@ -45691,6 +46092,7 @@ paisa	p a ɪ s ə
 paisano	p a ɪ s ɑ n o ʊ
 paisano	p a ɪ z ɑ n o ʊ
 paise	p a ɪ s ə
+paise	p e ɪ z
 paisley	p e ɪ z l i
 pajama	p ə d͡ʒ æ m ə
 pajama	p ə d͡ʒ ɑː m ə
@@ -45892,6 +46294,7 @@ pandour	p æ n d ɔː ɹ
 pandour	p æ n d ʊ ə ɹ
 pane	p e ɪ n
 paned	p e ɪ n d
+paneer	p ə n iː ɹ
 panegyric	p æ n ə d͡ʒ a ɪ ɹ ɪ k
 panegyric	p æ n ə d͡ʒ ɪ ɹ ɪ k
 panegyrically	p æ n ə d͡ʒ ɪ ɹ ə k ə l i
@@ -46023,12 +46426,13 @@ papillon	p æ p i ɒ n
 papillon	p æ p ɪ j ɒ̃
 papillon	p æ p ɪ l ɒ n
 papillon	p ə p ɪ l i ə n
+papio	p e ɪ p iː o ʊ
 papish	p e ɪ p ɪ ʃ
 papoose	p ə p uː s
 pappardelle	p æ p ɑ ɹ d ɛ l e ɪ
 pappy	p æ p i
 paprika	p æ p ɹ iː k ə
-paprika	p æ p ɹ ɨ k ə
+paprika	p æ p ɹ ɪ k ə
 paprika	p ə p ɹ iː k ə
 papula	p æ p j ʊ l ə
 papyri	p æ p ɚ a ɪ
@@ -46058,6 +46462,7 @@ paracrine	p æ ɹ ə k ɹ ɪ n
 parade	p ə r ɑ d
 parade	p ə ɹ e ɪ d
 parades	p ə ɹ e ɪ d z
+paradiastole	p ɛ r ə d a ɪ æ s t ə l i
 paradiddle	p æ ɹ ə d ɪ d ə l
 paradigm	p e ɪ ɹ ə d a ɪ m
 paradigm	p æ ɹ ə d a ɪ m
@@ -46086,6 +46491,7 @@ paragoge	p æ ɹ ə ɡ ə ʊ d͡ʒ i
 paragon	p æ ɹ ə ɡ ɑ n
 paragon	p æ ɹ ə ɡ ɔ n
 paragon	p æ ɹ ə ɡ ə n
+paragraph	p æ ɹ ə ɡ ɹ æ f
 paragraph	p ɛ ɹ ə ɡ ɹ æ f
 paragraphs	p ɛ ɹ ə ɡ ɹ æ f s
 paraguay	p æ ɹ ə ɡ w e ɪ
@@ -46190,6 +46596,7 @@ parenthetically	p æ ɹ ə n θ ɛ t ɪ k l i
 parenting	p ɛ ə ɹ ə n t ɪ ŋ
 parents	p æ ɹ ə n t s
 parents	p ɛ ɹ ə n t s
+pareo	p ɑː ɹ i ə ʊ
 parergy	p æ ɹ ə ɹ d͡ʒ i
 paresthesis	p ə ɹ iː s θ ɪ s ɪ s
 paretic	p ə ɹ ɛ t ɪ k
@@ -46354,7 +46761,7 @@ paschal	p a s k ə l
 pasco	p æ s k ə ʊ
 pash	p æ ʃ
 pasha	p ɑ ʃ ə
-pashes	p æ ʃ ɨ z
+pashes	p æ ʃ ɪ z
 pashto	p æ ʃ t ə ʊ
 pashto	p ʌ ʃ t ə ʊ
 pasifika	p ʌ s ɪ f ɪ k ʌ
@@ -46379,8 +46786,6 @@ passengers	p æ s ə n d͡ʒ ɚ z
 passepied	p æ s p i e ɪ
 passer	p æ s ə ɹ
 passerine	p æ s ə ɹ a ɪ n
-passerine	p æ s ə ɹ iː n
-passerine	p æ s ə ɹ ə n
 passes	p æ s ɪ z
 passify	p æ s ə f a ɪ
 passify	p æ s ɪ f a ɪ
@@ -46395,7 +46800,7 @@ passively	p æ s ɪ v l i
 passivity	p æ s ɪ v ɪ t i
 passless	p æ s l ə s
 passport	p æ s p ɔ ɹ t
-password	p æ s w ɜː ɹ d
+password	p æ s w ɝ d
 passé	p æ s e ɪ
 past	p æ s t
 pasta	p ɑ s t ə
@@ -46428,6 +46833,7 @@ pasts	p æ s t s
 pasture	p æ s t ɚ
 pasture	p æ s t͡ʃ ɚ
 pasty	p e ɪ s t i
+pasty	p æ s t i
 pat	p æ t
 patagium	p æ t ə d͡ʒ a ɪ ə m
 patagium	p ə t e ɪ d͡ʒ i ə m
@@ -46581,7 +46987,7 @@ pawpaw	p ɔː p ɔː
 pawprint	p ɔː p ɹ ɪ n t
 paws	p ɑː z
 paws	p ɔː z
-pawtucket	p ə t ʌ k ɨ t
+pawtucket	p ə t ʌ k ɪ t
 pax	p æ k s
 paxis	p æ k s ɪ s
 paxlovid	p æ k s l o ʊ v ɪ d
@@ -46679,7 +47085,7 @@ pecten	p ɛ k t ə n
 pecten	p ɛ k t ɪ n
 pectin	p ɛ k t ɪ n
 pectinate	p ɛ k t ə n e ɪ t
-pectoral	p ɛ k t ɔ ɹ ə l
+pectoral	p ɛ k t o ɹ ə l
 pectoral	p ɛ k t ə ɹ ə l
 peculation	p ɛ k j ʊ l e ɪ ʃ ə n
 peculiar	p ə k j uː l j ʊ ə ɹ
@@ -46845,7 +47251,7 @@ pendragon	p ɛ n d ɹ æ ɡ ə n
 pends	p ɛ n d z
 pendulum	p ɛ n d͡ʒ ə l ə m
 pendulum	p ɪ n d͡ʒ ə l ə m
-penelope	p ɨ n ɛ l ə p i
+penelope	p ɪ n ɛ l ə p i
 peneplain	p iː n ɪ p l e ɪ n
 peneplain	p ɛ n ɪ p l e ɪ n
 penes	p i n i z
@@ -46872,6 +47278,7 @@ peninitial	p ɛ n ɪ n ɪ ʃ ə l
 peninsula	p ə n ɪ n s ə l ə
 peninsular	p ə n ɪ n s ə l ə ɹ
 penis	p i n ɪ s
+penises	p i n ɪ s ɪ z
 penitent	p ɛ n ɪ t ə n t
 penitential	p ɛ n ɪ t ɛ n ʃ ə l
 penitentiary	p ɛ n ɪ t ɛ n ʃ ə ɹ i
@@ -47150,6 +47557,7 @@ perniones	p ɝ n i o ʊ n i z
 perniosis	p ɝ n i o ʊ s ɪ s
 pernoctate	p ɚ n ɑ k t e ɪ t
 pernoctation	p ɜ ɹ n ɑ k t e ɪ ʃ ə n
+pernod	p ɛ ɹ n o ʊ
 peroneal	p ə ɹ o ʊ n i ə l
 peroneal	p ɛ ɹ o ʊ n iː ə l
 peronei	p ɛ ɹ ə n i a ɪ
@@ -47211,11 +47619,12 @@ personable	p ɜː ɹ s ə n ə b ə l
 personae	p ɜː ɹ s ə ʊ n a i
 personage	p ɝ s ə n ɪ d͡ʒ
 personages	p ɝ s ə n ɪ d͡ʒ ɪ z
-personal	p ɜ ɹ s n ə l
+personal	p ɝ s n ə l
 personal	p ɝ s ə n ə l
 personality	p ɝ s ə n æ l ɪ t i
 personalization	p ɝ s ə n ə l a ɪ z e ɪ ʃ ə n
-personally	p ɜː s n ə l i
+personally	p ɝ s n ə l i
+personally	p ɝ s ə n ə l i
 personator	p ɜː ɹ s ə n e ɪ t ə ɹ
 personhood	p ɝ s ə n h ʊ d
 personification	p ɚ s ɑ n ə f ə k e ɪ ʃ ə n
@@ -47314,7 +47723,7 @@ peterborough	p iː t ə ɹ b ɹ ə
 peterson	p i t ɚ s ə n
 peterview	p iː t ɚ v j uː
 pethidine	p ɛ θ ɪ d iː n
-petiole	p ɛ d i o ʊ l
+petiole	p ɛ t i o ʊ l
 petit	p ə t i
 petit	p ə t i t
 petit	p ɛ ɾ i
@@ -47345,6 +47754,7 @@ petroleum	p ə t ɹ o ʊ l i ə m
 petrology	p ə t ɹ ɑ l ə d͡ʒ i
 petronel	p ɛ t ɹ ə n ə l
 petropavl	p ɛ t ɹ ə p ɑː v ə l
+petrophilic	p ɛ t ɹ ə f ɪ l ɪ k
 petrosal	p ə t ɹ o ʊ s ə l
 pets	p ɛ t s
 petter	p ɛ t ə ɹ
@@ -47377,7 +47787,6 @@ pfeffernuss	f ɛ f ə n uː s
 pfeffernusse	p f ɛ f ə ɹ n uː s ə
 pfennig	p f ɛ n ɪ ɡ
 pff	p͡fː
-pfft	p͡ɸː t
 pfic	p iː f ɪ k
 phablet	f æ b l ɪ t
 phac	p iː h æ k
@@ -47455,6 +47864,7 @@ phatic	f æ t ɪ k
 phaëthon	f e ɪ ə t ə n
 phaëthon	f e ɪ ə θ ə n
 pheasant	f ɛ z ə n t
+pheic	f e ɪ k
 phelonion	f ə l ə ʊ n i ə n
 phelps	f ɛ l p s
 phencyclidine	f ɛ n s a ɪ k l ɪ d iː n
@@ -47694,6 +48104,7 @@ phthalic	f θ æ l ɪ k
 phthisis	f θ a ɪ s ɪ s
 phthisis	t a ɪ s ɪ s
 phthonus	θ o ʊ n ə s
+phub	f ʌ b
 phugoid	f j uː ɡ ɔ ɪ d
 phuket	p u k ɛ t
 phumdi	f u m d i
@@ -47735,6 +48146,8 @@ phytoplankton	f a ɪ t o ʊ p l æ ŋ k t ə n
 phytoplankton	f a ɪ t ə p l æ ŋ k t ə n
 pi	p a ɪ
 piaget	p j a ʒ ɛ
+pianguan	p i j ə n ɡ w ɑ n
+pianguan	p i ə n ɡ w ɑ n
 pianist	p i æ n ɪ s t
 pianist	p i ə n ɪ s t
 pianny	p a ɪ æ n i
@@ -47769,6 +48182,7 @@ piccy	p ɪ k i
 pice	p a ɪ s
 picene	p a ɪ s iː n
 piceous	p ɪ s i ə s
+picidae	p ɪ s ə d iː
 pick	p ɪ k
 pickaxe	p ɪ k æ k s
 picked	p ɪ k t
@@ -48002,7 +48416,7 @@ pinçage	p ɪ n s ɑ ʒ
 pioglitazone	p a ɪ ə ɡ l ɪ t ə z o ʊ n
 piolet	p iː ə l e ɪ
 pion	p a ɪ ɒ n
-pioneer	p a ɪ ə n ɪ ə ɹ
+pioneer	p a ɪ ə n ɪ ɹ
 pip	p ɪ p
 pipe	p a ɪ p
 piped	p a ɪ p t
@@ -48275,6 +48689,7 @@ plasterly	p l æ s t ə ɹ l i
 plasterly	p l ɑː s t ə ɹ l i
 plasterwork	p l æ s t ɚ w ɝ k
 plastic	p l æ s t ɪ k
+plastician	p l æ s t ɪ ʃ ə n
 plastron	p l æ s t ɹ ə n
 plat	p l æ t
 plate	p l e ɪ t
@@ -48362,7 +48777,7 @@ pleb	p l ɛ b
 plebe	p l i b
 plebeian	p l i b iː ə n
 plebeian	p l ɛ b iː ə n
-plebiscite	p l ɛ b ɨ s a ɪ t
+plebiscite	p l ɛ b ɪ s a ɪ t
 plebiscitum	p l i b ə s a ɪ t ə m
 plebiscitum	p l ɛ b ə s a ɪ t ə m
 plebs	p l ɛ b z
@@ -48624,6 +49039,7 @@ poison	p ɔ ɪ z ə n
 poisoned	p ɔ ɪ z n̩ d
 poisonous	p ɔ ɪ z n ə s
 poisonous	p ɔ ɪ z ə n ə s
+poissarde	p w a s ɑ ɹ d
 poisson	p w ɑː s ɒ n
 poissonier	p w ə s o ʊ n j e
 poitevinite	p ɔ ɪ t ə v ɪ n a ɪ t
@@ -48662,6 +49078,7 @@ polarize	p o ʊ l ə ɹ a ɪ z
 polary	p o ʊ l ə ɹ i
 pole	p o ʊ l
 polecat	p ə ʊ l k æ t
+polemarch	p ɑ l ə m ɑ ɹ k
 polemic	p ə l iː m ɪ k
 polemic	p ə l ɛ m ɪ k
 polemical	p ə l ɛ m ɪ k ə l
@@ -48709,6 +49126,8 @@ pollard	p ɑ l ɚ d
 polled	p o ʊ l d
 pollen	p ɑ l ə n
 pollicate	p ɒ l ɪ k e ɪ t
+pollinate	p ɒ l ɪ n e ɪ t
+pollination	p ɒ l ɪ n e ɪ ʃ ə n
 pollinator	p ɒ l ɪ n e ɪ t ə ɹ
 pollinivore	p ɑ l ɪ n ə v ɔː ɹ
 pollinosis	p ɑ l ə n o ʊ s ɪ s
@@ -48737,7 +49156,7 @@ polyadenous	p ɑ l i æ d ɪ n ə s
 polyarch	p ɑ l i ɑ ɹ k
 polyaxial	p ɑ l ɪ æ k s i ə l
 polychaete	p ɒ l ɪ k iː t
-polychoron	p ɔ l ɨ k o ʊ ɹ ɔ n
+polychoron	p ɔ l ɪ k o ʊ ɹ ɔ n
 polychrest	p ɒ l ɪ k ɹ ɛ s t
 polychromatic	p ɑ l i k ɹ ə m æ t ɪ k
 polycrisis	p ɒ l i k r a ɪ s ɪ s
@@ -48785,7 +49204,7 @@ polynya	p ɑ l ə n j ɑ
 polynya	p ə l ɪ n j ə
 polyp	p ɑ l ɪ p
 polypantheism	p ɒ l i p æ n θ i ɪ z ə m
-polyphemus	p ɒ l ɨ f iː m ə s
+polyphemus	p ɒ l ɪ f iː m ə s
 polyphiloprogenitive	p ɒ l ɪ f ɪ l ə p ɹ ə d͡ʒ ɛ n ɪ t ɪ v
 polyptoton	p ɑ l ə p t o ʊ t ɑ n
 polyptych	p ɒ l ɪ p t ɪ k
@@ -49035,6 +49454,8 @@ portugal	p ɔ ɹ t u ɡ ɑː l
 portugal	p ɔ ɹ t͡ʃ ə ɡ ə l
 portuguese	p ɔ ɹ t͡ʃ ə ɡ i z
 pory	p ɔ ɹ i
+pos	p o ʊ z
+pos	p ɑ z
 pose	p o ʊ z
 posed	p o ʊ z d
 posedown	p ə ʊ z d a ʊ n
@@ -49246,6 +49667,7 @@ prague	p ɹ ɑː ɡ
 prahok	p ɹ ə h ɑ k
 praia	p ɹ a ɪ ə
 prairial	p ɹ ɛ ɹ j ɑ l
+prairies	p ɹ ɛ ə ɹ i z
 praise	p ɹ e ɪ z
 praised	p ɹ e ɪ z d
 praiser	p ɹ e ɪ z ə ɹ
@@ -49328,7 +49750,7 @@ precedentially	p ɹ ɛ s ə d ɛ n ʃ ə l i
 preceding	p ɹ iː s iː d ɪ ŋ
 preceding	p ɹ ɪ s iː d ɪ ŋ
 precept	p ɹ iː s ɛ p t
-preceptor	p ɹ iː s ɛ p t ə ɹ
+preceptor	p ɹ i s ɛ p t ɚ
 preceptory	p ɹ ɪ s ɛ p t ə ɹ i
 precinct	p ɹ i s ɪ ŋ k t
 preciosity	p ɹ ɛ ʃ i ɑ s ə t i
@@ -49357,11 +49779,11 @@ preconsonantal	p ɹ i k ɒ n s ə n æ n t ə l
 precosmic	p ɹ ɪ k ɒ z m ɪ k
 precounsel	p ɹ iː k a ʊ n s ə l
 precrastination	p ɹ iː k ɹ æ s t ɪ n e ɪ ʃ ə n
-precurse	p ɹ ɨ k ɜ ɹ s
+precurse	p ɹ ɪ k ɜ ɹ s
 precursive	p ɹ iː k ɜː ɹ s ɪ v
 precursive	p ɹ ɪ k ɜː ɹ s ɪ v
 precursor	p ɹ iː k ɜ ɹ s ə ɹ
-precursor	p ɹ ɨ k ɜ ɹ s ə ɹ
+precursor	p ɹ ɪ k ɜ ɹ s ə ɹ
 predal	p ɹ iː d ə l
 predate	p ɹ iː d e ɪ t
 predate	p ɹ ə d e ɪ t
@@ -49406,7 +49828,7 @@ preengage	p r iː ɪ n ɡ e ɪ d͡ʒ
 preeternity	p ɹ iː ɪ t ɜː ɹ n ɪ t i
 preface	p ɹ ɛ f ə s
 preface	p ɹ ɛ f ɪ s
-prefect	p ɹ ɪ f ɛ k t
+prefect	p ɹ iː f ɛ k t
 prefecture	p ɹ i f ɛ k t͡ʃ ə ɹ
 prefer	p ɹ ɪ f ɝ
 preferable	p ɹ ɛ f ə ɹ ə b ə l
@@ -49441,6 +49863,8 @@ premalignant	p ɹ i m ə l ɪ ɡ n ə n t
 premarin	p ɹ ɛ m ə ɹ ɪ n
 premature	p ɹ i m ə t ʊ ɹ
 premature	p ɹ i m ə t͡ʃ ʊ ɹ
+prematurely	p ɹ iː m ə t j ʊ ə ɹ l i
+prematurely	p ɹ ɛ m ə t j ʊ ə ɹ l i
 premeditate	p r iː m ɛ d ɪ t e ɪ t
 premenstrual	p ɹ i m ɛ n s t ɹ ə w ə l
 premenstrual	p ɹ i m ɛ n z t ɹ ə w ə l
@@ -49477,11 +49901,9 @@ prepared	p ɹ ɪ p ɛ ɹ d
 preparing	p ɹ ɪ p ɛ ɹ ɪ ŋ
 prepend	p ɹ ɪ p ɛ n d
 prepense	p ɹ ɪ p ɛ n s
-preplied	p ɹ ɪ p l a ɪ d
-preplies	p ɹ ɪ p l a ɪ z
-preply	p ɹ iː p l a ɪ
 preponderance	p ɹ ə p ɑ n d ə ɹ ə n s
 preponderance	p ɹ ə p ɑ n d ɹ ə n s
+preported	p ɹ ɪ p ɔ ɹ t ɪ d
 prepose	p ɹ iː p ə ʊ z
 preposition	p ɹ iː p ə z ɪ ʃ ə n
 preposition	p ɹ ɛ p ə z ɪ ʃ ə n
@@ -49514,7 +49936,7 @@ presbyter	p ɹ e s b ɪ t ɚ
 presbyter	p ɹ e z b ɪ t ɚ
 presbyterian	p ɹ e z b ɪ t ɪ ɹ i ə n
 presbytery	p ɹ ɛ z b ɪ t ɛ ɹ i
-prescience	p ɹ ɛ ʃ ɨ n s
+prescience	p ɹ ɛ ʃ ɪ n s
 prescient	p ɹ iː ʃ i ə n t
 prescient	p ɹ ɛ ʃ i ə n t
 prescious	p ɹ ɛ s i ə s
@@ -49785,9 +50207,11 @@ prizings	p ɹ a ɪ z ɪ ŋ z
 prndl	p ɹ ɪ n d l̩
 pro	p ɹ o ʊ
 proa	p ɹ o ʊ ə
-proactive	p ɹ ə ʊ æ k t ɪ v
+proactive	p ɹ o ʊ æ k t ɪ v
+proactively	p ɹ o ʊ æ k t ɪ v l i
 prob'ly	p ɹ ɒ b l i
-probability	p ɹ ɑ b ə b ɪ l ɪ ɾ i
+probability	p ɹ ɑ b ə b ɪ l ə t i
+probability	p ɹ ɑ b ə b ɪ l ɪ t i
 probable	p ɹ ɑ b ə b l̩
 probably	p ɹ ɑ b l i
 probably	p ɹ ɑ b ə b l i
@@ -49932,7 +50356,7 @@ progesterone	p ɹ o ʊ d͡ʒ ɛ s t ə ɹ o ʊ n
 prognathous	p r ɑ ɡ n e ɪ θ ə s
 prognathous	p r ɑ ɡ n ə θ ə s
 prognoses	p ɹ ɑ ɡ n o ʊ s i z
-prognoses	p ɹ ɑ ɡ n o ʊ z ə s
+prognoses	p ɹ ɑ ɡ n o ʊ z ɪ z
 prognosis	p ɹ ɑ ɡ n o ʊ s i z
 prognosis	p ɹ ɑ ɡ n o ʊ s ɪ s
 prognostic	p ɹ ɒ ɡ n ɒ s t ɪ k
@@ -49997,7 +50421,7 @@ prolific	p ɹ ə l ɪ f ɪ k
 prolix	p ɹ o ʊ l ɪ k s
 prolixity	p ɹ ə l ɪ k s ɪ t i
 prolixity	p ɹ ə ʊ l ɪ k s ɪ t i
-prolly	p r ɔ l i
+prolly	p r ɑ l i
 prolly	p ɹ ɒ l i
 prologue	p ɹ o ʊ l ɑ ɡ
 prologue	p ɹ o ʊ l ɔ ɡ
@@ -50221,6 +50645,7 @@ protest	p ɹ o ʊ t ɛ s t
 protest	p ɹ ə t ɛ s t
 protestant	p ɹ ɑ t ɪ s t ə n t
 protestantism	p ɹ ɑ t ɪ s t ə n t ɪ z ə m
+protestantism	p ɹ ɑ ɾ ɪ s t ə n t ɪ z m̩
 protestation	p ɹ ɒ t ɪ s t e ɪ ʃ ə n
 protestation	p ɹ ə ʊ t ɪ s t e ɪ ʃ ə n
 protested	p ɹ ə t ɛ s t ɪ d
@@ -50292,6 +50717,7 @@ provision	p ɹ ə v ɪ ʒ ə n
 provisional	p ɹ ə v ɪ ʒ ə n ə l
 provisions	p ɹ ə v ɪ ʒ ə n z
 proviso	p ɹ ə v a ɪ z o ʊ
+provisor	p ɹ ə v a ɪ z ə ɹ
 provisory	p ɹ ə v a ɪ z ə ɹ i
 provo	p ɹ o ʊ v o ʊ
 provocate	p ɹ ə v ɑː k e ɪ t
@@ -50374,7 +50800,7 @@ pschent	s k ɛ n t
 psephism	s iː f ɪ z ə m
 psephism	s ɛ f ɪ z ə m
 psephocracy	p s i f ɑ k ɹ ə s i
-psephology	s ɨ f ɑ l ə d͡ʒ i
+psephology	s ɪ f ɑ l ə d͡ʒ i
 pseud	s uː d
 pseudepigrapha	s uː d ə p ɪ ɡ ɹ ə f ə
 pseudepigraphous	s j uː d ɪ p ɪ ɡ ɹ ə f ə s
@@ -50414,7 +50840,7 @@ psilophyte	s a ɪ l ə f a ɪ t
 psilosis	s a ɪ l o ʊ s ɪ s
 psilosopher	p s ɪ l ɑ s ə f ɚ
 psithurism	s ɪ θ j ʊ ə ɹ ɪ z ə m
-psittacosis	s i t ə k o ʊ s ɨ s
+psittacosis	s i t ə k o ʊ s ɪ s
 psoas	s o ʊ æ s
 psoas	s o ʊ ə s
 psora	s ɔː ɹ ə
@@ -50494,6 +50920,7 @@ pubby	p ʌ b i
 pube	p j uː b
 pubes	p j uː b i z
 pubes	p j uː b z
+pubescence	p j uː b ɛ s ə n s
 pubescent	p j ʊ b ɛ s ə n t
 pubic	p j uː b ɪ k
 pubikini	p j uː b ɪ k iː n i
@@ -50622,6 +51049,7 @@ pultaceous	p ʌ l t e ɪ ʃ ə s
 pulverulent	p ʌ l v ɛ ɹ j ə l ə n t
 puma	p j uː m ə
 puma	p uː m ə
+pumicate	p j uː m ɪ k e ɪ t
 pumice	p ʌ m ɪ s
 pummel	p ʌ m ə l
 pump	p ʌ m p
@@ -50697,6 +51125,7 @@ punxsutawney	p ʌ ŋ k s ə t ɔː n i
 puny	p j u n i
 pup	p ʌ p
 pupa	p j uː p ə
+pupal	p j uː p ə l
 pupe	p j u p
 pupil	p j uː p ə l
 pupils	p j uː p ə l z
@@ -50750,7 +51179,8 @@ purported	p ə ɹ p o ʊ ɹ t ɪ d
 purported	p ə ɹ p ɔ ɹ t ɪ d
 purpose	p ɝ p ə s
 purposedly	p ɜː ɹ p ə s ɪ d l i
-purposeful	p ɜː ɹ p ə s f ə l
+purposeful	p ɝ p ə s f ə l
+purposefully	p ɝ p ə s f ə l i
 purposely	p ɝ p ə s l i
 purposes	p ɝ p ə s ɪ z
 purposive	p ɚ p ə s ɪ v
@@ -50914,6 +51344,7 @@ python	p a ɪ θ ɔ n
 pythonista	p a ɪ θ ə n ɪ s t ə
 pythons	p a ɪ θ ɑ n z
 pyx	p ɪ k s
+pyxis	p ɪ k s ɪ s
 pâté	p æ t e ɪ
 pædomorphic	p iː d ə m ɔ ɹ f ɪ k
 pædomorphic	p ɛ d ə m ɔ ɹ f ɪ k
@@ -50960,6 +51391,7 @@ qingdao	t͡ʃ ɪ ŋ d a ʊ
 qinghai	t͡ʃ ɪ ŋ h a ɪ
 qinghaosu	t͡ʃ ɪ ŋ h a ʊ s uː
 qingpu	t͡ʃ ɪ ŋ p u
+qingsongite	t͡ʃ ɪ ŋ s ɒ ŋ a ɪ t
 qinpu	t͡ʃ ɪ n p uː
 qipao	t͡ʃ iː p a ʊ
 qiqihar	t͡ʃ i t͡ʃ i h ɑ ɹ
@@ -51037,8 +51469,8 @@ quahog	k w ə h ɑ ɡ
 quahog	k w ə h ɔ ɡ
 quaich	k w e ɪ k
 quaich	k w e ɪ x
-quail	k w e ɪ l
-quail	k w e ɪ ə l
+quail	kʷ e ɪ l
+quail	kʷ e ɪ ə l
 quailed	k w e ɪ l d
 quailing	k w e ɪ l ɪ ŋ
 quailings	k w e ɪ l ɪ ŋ z
@@ -51073,12 +51505,17 @@ quandary	k w ɑ n d ɹ i
 quant	k w ɒ n t
 quantal	k w ɑ n t ə l
 quantal	k w ɔ n t ə l
+quantifier	k w ɑ n t ə f a ɪ ɚ
 quantify	k w ɑː n t ə f a ɪ
 quantile	k w ɒ n t a ɪ l
 quantiles	k w ɒ n t a ɪ l z
 quantitative	k w ɑ n t ɪ t e ɪ t ɪ v
 quantities	k w ɑ n t ɪ t i z
 quantity	k w ɑ n t ɪ t i
+quantivalence	k w ɑ n t ɪ v l ə n s
+quantivalence	k w ɑ n t ɪ v ə l ə n s
+quantivalency	k w ɑ n t ɪ v l ə n s i
+quantivalency	k w ɑ n t ɪ v ə l ə n s i
 quantum	k w ɑ n t ə m
 quanzhou	t͡ʃ w ɑ n t͡s o ʊ
 quaoar	k w ɑː w ɑ ɹ
@@ -51153,7 +51590,7 @@ queendom	k w iː n d ə m
 queenly	k w iː n l i
 queensland	k w iː n z l ə n d
 queenslander	k w i n z l ə n d ɚ
-queer	k w iː ɹ
+queer	k w ɪ ɹ
 queerdar	k w i ɹ d ɑ ɹ
 quefrency	k w i f ɹ ə n s i
 quelea	k w i l i ə
@@ -51166,7 +51603,7 @@ quenya	kʷ w ɛ ɲ j a
 quercetin	k w ɜː ɹ s ɪ t ɪ n
 quercine	k w ɝ s a ɪ n
 quercine	k w ɝ s ɪ n
-quercitin	k w ɜ ɹ s ɨ t ɨ n
+quercitin	k w ɜ ɹ s ɪ t ɪ n
 querent	k w ɚ ɛ n t
 querist	k w ɪ ə ɹ ɪ s t
 quern	k w ɝ n
@@ -51274,6 +51711,7 @@ quinnat	k w ɪ n ə t
 quinoa	k i n o ʊ ə
 quinoa	k i n w ɑ
 quinolone	k w ɪ n ə l o ʊ n
+quinone	k w ɪ n ə ʊ n
 quinquagenarian	k w ɪ ŋ k w ə d͡ʒ ə n ɛ ɹ i ə n
 quinquagenary	k w ɪ ŋ k w æ d͡ʒ ə n ɛ ɹ i
 quinquagenary	k w ɪ ŋ k w ə d͡ʒ ɛ n ə ɹ i
@@ -51293,9 +51731,9 @@ quintal	k w ɪ n t l
 quinte	k w ɪ n t i
 quinte	k ɛ̃ t
 quintessence	k w ɪ n t ɛ s ə n s
-quintessence	k w ɪ n t ɛ s ɨ n s
-quintessential	k w ɪ n t ə s ɛ n ʃ ə l
-quintessentially	k w ɪ n t ɛ s ɛ n t͡ʃ ə l i
+quintessence	k w ɪ n t ɛ s ɪ n s
+quintessential	k w ɪ n t ɪ s ɛ n ʃ ə l
+quintessentially	k w ɪ n t ɪ s ɛ n ʃ ə l i
 quintet	k w ɪ n t ɛ t
 quintillion	k w ɪ n t ɪ l j ə n
 quintillionth	k w ɪ n t ɪ l i ə n θ
@@ -51306,6 +51744,7 @@ quip	k w ɪ p
 quippy	k w ɪ p i
 quipu	k i p u
 quirinus	k w ɪ ɹ a ɪ n ə s
+quirk	k w ɝ k
 quirkyalone	k w ɝ k i ə l o ʊ n
 quirl	k w ɝ l
 quirn	k w ɜː ɹ n
@@ -51331,7 +51770,7 @@ quiz	k w ɪ z
 quizzaciously	k w ɪ z e ɪ ʃ ə s l i
 quizzical	k w ɪ z ɪ k ə l
 qujing	t͡ʃ uː d͡ʒ ɪ ŋ
-qulin	k j uː l ɨ n
+qulin	k j uː l ɪ n
 qumran	k ʊ m ɹ æ n
 quo	k w o ʊ
 quoad	k w o ʊ æ d
@@ -51380,6 +51819,7 @@ rabat	ɹ ɑː b æ t
 rabat	ɹ ɑː b ɑː t
 rabat	ɹ ə b æ t
 rabato	ɹ ə b ɑː t ə ʊ
+rabaul	ɹ ə b a ʊ l
 rabbet	ɹ æ b ɪ t
 rabbi	ɹ æ b a ɪ
 rabbie	ɹ æ b i
@@ -51410,6 +51850,7 @@ racer	ɹ e ɪ s ə ɹ
 races	ɹ e ɪ s ɪ z
 racetrack	ɹ e ɪ s t ɹ æ k
 rach	ɹ e ɪ t͡ʃ
+rach	ɹ æ t ʃ
 rachel	ɹ e ɪ t͡ʃ ə l
 rachis	ɹ e ɪ k ɪ s
 rachitis	ɹ ə k ʌ ɪ t ɪ s
@@ -51620,6 +52061,7 @@ rang	ɹ æ ŋ
 range	ɹ e ɪ n d͡ʒ
 ranger	ɹ e ɪ n d͡ʒ ɚ
 ranges	ɹ e ɪ n d͡ʒ ɪ z
+rangifer	r æ n d ʒ ɪ f ə ɹ
 rangiora	ɹ a ŋ ɡ i ɔː ɹ ə
 rangle	ɹ æ ŋ ɡ l̩
 rangoon	ɹ æ ŋ ɡ uː n
@@ -51627,6 +52069,7 @@ rangy	ɹ e ɪ n d͡ʒ i
 rani	ɹ ɑː n iː
 ranitidine	ɹ ə n ɪ t ɪ d i n
 rank	ɹ æ ŋ k
+ranking	ɹ æ ŋ k ɪ ŋ
 rankism	ɹ æ ŋ k ɪ z ə m
 rankle	ɹ æ ŋ k ə l
 ranks	ɹ æ ŋ k s
@@ -51650,6 +52093,7 @@ rape	ɹ e ɪ p
 raper	ɹ e ɪ p ə ɹ
 rapey	ɹ e ɪ p i
 raphae	ɹ e ɪ f iː
+raphanus	r æ f ə n ə s
 raphe	ɹ e ɪ f i
 rapid	ɹ æ p ɪ d
 rapidity	ɹ ə p ɪ d ɪ t i
@@ -51675,7 +52119,7 @@ rapture	ɹ æ p t͡ʃ ɚ
 rapturous	ɹ æ p t͡ʃ ə ɹ ə s
 rapunzel	ɹ ə p ʌ n z ə l
 raquel	ɹ ɑː k ɛ l
-rare	ɹ ɛ ə ɹ
+rare	ɹ ɛ ɚ
 rare	ɹ ɛ ɹ
 rarely	ɹ ɛ ə ɹ l i
 rarissima	ɹ æ ɹ ɪ s ɪ m ə
@@ -51790,6 +52234,7 @@ razorback	ɹ e ɪ z ɚ b æ k
 razz	ɹ æ z
 razzmatazz	ɹ æ z m ə t æ z
 raï	ɹ a ɪ
+raï	ɹ ʌ iː
 rbar	ɹ iː b ɑ ɹ
 re	ɹ e ɪ
 re	ɹ iː
@@ -51809,7 +52254,6 @@ reactionary	ɹ i æ k ʃ ɪ n ɛ ɚ i
 reactive	ɹ iː æ k t ɪ v
 reactor	ɹ i æ k t ɚ
 read	ɹ i d
-read	ɹ iː d
 read	ɹ ɛ d
 readable	ɹ iː d ə b ə l
 reader	ɹ i d ɚ
@@ -51833,6 +52277,7 @@ reaganomics	r e ɪ ɡ ə n ɑ m ɪ k s
 reagent	ɹ i e ɪ d͡ʒ ə n t
 reak	ɹ iː k
 real	ɹ e ɪ ɑ l
+real	ɹ i ɯ
 real	ɹ iː l
 real	ɹ iː ə l
 real	ɹ ɪ ə̯ l
@@ -51881,6 +52326,8 @@ reard	ɹ ɛ ə ɹ d
 reard	ɹ ɪ ə ɹ d
 reared	ɹ ɪ ɹ d
 rearguard	ɹ ɪ ə ɹ ɡ ɑ ɹ d
+rearview	ɹ i ɹ v j uː
+rearview	ɹ ɪ ɹ v j uː
 rearward	ɹ i ɹ w ɝ d
 reason	ɹ iː z ə n
 reasonable	ɹ iː z n ə b ə l
@@ -51938,7 +52385,7 @@ recant	ɹ ə k æ n t
 recap	ɹ iː k æ p
 recapitulation	ɹ iː k ə p ɪ t͡ʃ ə l e ɪ ʃ ə n
 recce	ɹ ɛ k i
-recede	ɹ ɨ s iː d
+recede	ɹ ɪ s iː d
 receipt	ɹ ɪ s iː t
 receivability	ɹ ə s i v ɑ b ɪ l ɪ t i
 receive	ɹ ɪ s iː v
@@ -52034,6 +52481,7 @@ reconstitute	ɹ i k ɑ n s t ɪ t j u t
 reconstituting	ɹ i k ɑ n s t ɪ t j u t ɪ ŋ
 reconstructivist	ɹ iː k ə n s t ɹ ʌ k t ɪ v ɪ s t
 reconvoke	ɹ i k ə n v o ʊ k
+record	ɹ ɛ k ɔː ɹ d
 record	ɹ ɛ k ɚ d
 record	ɹ ɪ k ɔ ɹ d
 recordation	ɹ i k ɔ ɹ d e ɪ ʃ ə n
@@ -52102,14 +52550,14 @@ redder	ɹ ɛ d ɚ
 reddest	ɹ ɛ d ɪ s t
 reddish	ɹ ɛ d ɪ ʃ
 reddishness	ɹ ɛ d ɪ ʃ n ə s
-reddit	r ɛ d ɪ t
+reddit	ɹ ɛ d ɪ t
 reddition	ɹ ə d ɪ ʃ ə n
 redditor	ɹ ɛ d ɪ t ə ɹ
 rede	ɹ iː d
 redebug	ɹ iː d iː b ʌ ɡ
 redeem	ɹ ɪ d iː m
 redeliver	ɹ iː d ɪ l ɪ v ə ɹ
-redemption	ɹ ɪ d ɛ m ʃ ə n
+redemption	ɹ ɪ d ɛ m p ʃ ə n
 redemptory	ɹ ɪ d ɛ m p t ə ɹ i
 redesign	ɹ iː d ɪ z a ɪ n
 redesmouth	ɹ iː d z m ə θ
@@ -52231,6 +52679,7 @@ reflective	ɹ ɪ f l ɛ k t ɪ v
 reflet	ɹ ə f l e ɪ
 reflexible	ɹ ɪ f l ɛ k s ɪ b ə l
 reflexive	ɹ ə f l ɛ k s ɪ v
+refluent	ɹ ɛ f l u ə n t
 reflux	ɹ iː f l ʌ k s
 refold	ɹ iː f o ʊ l d
 reform	ɹ iː f ɔ ɹ m
@@ -52357,7 +52806,7 @@ regurgitate	ɹ ɪ ɡ ɝ d͡ʒ ə t e ɪ t
 rehab	ɹ iː h æ b
 rehal	ɹ e ɪ h ə l
 rehearsal	ɹ ɪ h ɝ s l̩
-rehearse	ɹ ɨ h ɝ s
+rehearse	ɹ ɪ h ɝ s
 rehome	ɹ iː h ə ʊ m
 reich	ɹ a ɪ k
 reich	ɹ a ɪ x
@@ -52389,6 +52838,7 @@ reinter	ɹ iː ɪ n t ɝ
 reird	ɹ i ɚ d
 reisz	ɹ a ɪ s
 reit	r iː t
+reit	ɹ iː t
 reiterant	ɹ i ɪ t ɝ ə n t
 reiterate	ɹ i ɪ t ə ɹ e ɪ t
 reiver	ɹ iː v ə ɹ
@@ -52570,6 +53020,7 @@ renaissance	ɹ ɛ n ə s ɑ n s
 renal	ɹ iː n ə l
 renaldo	ɹ ɪ n æ l d ə ʊ
 renaldo	ɹ ɪ n ɑ l d ə ʊ
+renarrative	ɹ iː n æ ɹ ə t ɪ v
 renascent	ɹ ɪ n e ɪ s ə n t
 renascent	ɹ ɪ n æ s ə n t
 renata	ɹ ə n ɑː t ʌ
@@ -52717,7 +53168,7 @@ represented	ɹ ɛ p ɹ ɪ z ɛ n t ɪ d
 representing	ɹ ɛ p ɹ ɪ z ɛ n t ɪ ŋ
 repress	ɹ ə p ɹ ɛ s
 repressed	ɹ i p ɹ ɛ s t
-repressed	ɹ ɨ p ɹ ɛ s t
+repressed	ɹ ɪ p ɹ ɛ s t
 reprieve	ɹ ɪ p ɹ iː v
 reprimand	ɹ ɛ p ɹ ɪ m æ n d
 reprinted	ɹ iː p ɹ ɪ n t ɪ d
@@ -52770,6 +53221,7 @@ requested	ɹ ɪ k w ɛ s t ɪ d
 requeue	ɹ iː k j uː
 requicken	r iː k w ɪ k ə n
 requiem	ɹ ɛ k w i ə m
+requiem	ɹ ɛ k w i ɛ m
 requiescat	ɹ ɛ k w i ɛ s k æ t
 requin	ɹ i k w ɪ n
 require	ɹ ɪ k w a ɪ ɹ
@@ -52792,6 +53244,7 @@ reroute	ɹ i ɹ u t
 rerun	ɹ i ɹ ʌ n
 res	ɹ e ɪ z
 res	ɹ ɛ z
+resched	ɹ i s k ɛ d͡ʒ
 reschedule	ɹ i s k ɛ d͡ʒ u l
 reschedule	ɹ i s k ɛ d͡ʒ u ə l
 reschedule	ɹ i s k ɛ d͡ʒ ə l
@@ -52802,8 +53255,8 @@ rescrutiny	ɹ iː s k ɹ uː t ɪ n i
 rescue	ɹ ɛ s k j uː
 rescued	ɹ ɛ s k j uː d
 rese	ɹ iː z
-research	ɹ i s ɚ t͡ʃ
 research	ɹ i s ɝ t͡ʃ
+research	ɹ ɪ s ɝ t͡ʃ
 researcher	ɹ i s ɚ t͡ʃ ɚ
 researches	ɹ iː s ɚ t͡ʃ ɪ z
 researches	ɹ ɪ s ɝ t͡ʃ ɪ z
@@ -52873,8 +53326,8 @@ resolved	ɹ ɪ z ɑ l v d
 resonant	ɹ ɛ z ə n ə n t
 resonate	ɹ ɛ z ə n e ɪ t
 resorbable	ɹ ɪ z ɔː ɹ b ə b ə l
+resorcinol	ɹ ə z ɔː ɹ s ɪ n ɒ l
 resort	ɹ iː s ɔ ɹ t
-resort	ɹ ɨ z ɔ ɹ t
 resound	ɹ i s a ʊ n d
 resound	ɹ ə s a ʊ n d
 resound	ɹ ə z a ʊ n d
@@ -52883,8 +53336,8 @@ resoundingly	ɹ ɪ z a ʊ n d ɪ ŋ l i
 resource	ɹ i s ɔ ɹ s
 resource	ɹ ɪ s ɔ ɹ s
 resource	ɹ ɪ z ɔ ɹ s
-resources	ɹ i s ɔ ɹ s ɨ z
-resources	ɹ ɨ z ɔ ɹ s ɨ z
+resources	ɹ i s ɔ ɹ s ɪ z
+resources	ɹ ɪ z ɔ ɹ s ɪ z
 respect	ɹ ɪ s p ɛ k t
 respectability	ɹ ɪ s p ɛ k t ə b ɪ l ɪ t i
 respected	ɹ ɪ s p ɛ k t ɪ d
@@ -52906,13 +53359,15 @@ respite	ɹ ɛ s p ɪ t
 resplendence	ɹ ɪ s p l ɛ n d ə n s
 resplendent	ɹ ɪ s p l ɛ n d ə n t
 respond	ɹ ə s p ɑ n d
+respond	ɹ ɪ s p ɑ n d
 responded	ɹ ə s p ɑ n d ɪ d
+responded	ɹ ɪ s p ɑ n d ɪ d
 respondee	ɹ ɪ s p ɒ n d iː
 responder	ɹ ə s p ɑ n d ɚ
 response	ɹ ɪ s p ɑ n s
 responseless	ɹ ɪ s p ɑ n s l ə s
 responseless	ɹ ɪ s p ɑ n s l ɪ s
-responsibility	ɹ ɪ s p ɒ n s ə b ɪ l ɪ t i
+responsibility	ɹ ɪ s p ɑ n s ə b ɪ l ə t i
 responsible	ɹ ɪ s p ɑ n s ə b l̩
 responsive	ɹ ɪ s p ɑ n s ɪ v
 responsiveness	ɹ ɪ s p ɒ n s ɪ v n ɪ s
@@ -53026,7 +53481,7 @@ retinal	ɹ ɛ t n ə l
 retinal	ɹ ɛ t ə n æ l
 retinal	ɹ ɛ t ə n ɔ l
 retinal	ɹ ɛ t ə n ə l
-retinopathy	ɹ ɛ t ɨ n ɑː p ə θ i
+retinopathy	ɹ ɛ t ɪ n ɑː p ə θ i
 retinue	ɹ ɛ t ɪ n j uː
 retire	ɹ i t a ɪ ɚ
 retire	ɹ ə t a ɪ ɹ
@@ -53125,7 +53580,7 @@ reverberate	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ t
 reverberation	ɹ i v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ə v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ ʃ ə n
-reverberative	ɹ ə v ɝ b ə ɹ ə ɪ t ɪ v
+reverberative	ɹ ə v ɝ b ə ɹ e ɪ t ɪ v
 revere	ɹ ə v iː ɹ
 revered	ɹ ɪ v ɪ ə d
 reverence	ɹ ɛ v ə ɹ ə n s
@@ -53140,13 +53595,13 @@ reversal	ɹ ɪ v ɜː ɹ s ə l
 reverse	ɹ ɪ v ɝ s
 reversible	ɹ ə v ɜː ɹ s ɪ b ə l
 reversion	ɹ ə v ɚ ʒ ə n
-reversion	ɹ ɨ v ɚ ʒ ə n
+reversion	ɹ ɪ v ɚ ʒ ə n
 reversion	ɹ ɪ v ɜː ʃ ə n̩
 reversion	ɹ ɪ v ɜː ʒ ə n̩
 reversionary	ɹ ə v ɝ ʒ ə n ɛ ɹ i
 revert	ɹ i v ɝ t
 revert	ɹ iː v ɝ t
-revert	ɹ ɨ v ɝ t
+revert	ɹ ɪ v ɝ t
 revertent	ɹ ɪ v ɜː ɹ t ə n t
 revertible	ɹ ɪ v ɝ t ɪ b l̩
 revictual	ɹ iː v ɪ t ə l
@@ -53349,7 +53804,6 @@ rictus	ɹ ɪ k t ə s
 rictus	ɹ ɪ k t ʊ s
 rid	ɹ ɪ d
 riddance	ɹ ɪ d ə n s
-ridden	ɹ ɪ d n̩
 riddle	ɹ ɪ d ə l
 riddled	ɹ ɪ d ə l d
 ride	ɹ a ɪ d
@@ -53585,8 +54039,9 @@ rochelle	ɹ o ʊ ʃ ɛ l
 rochester	ɹ ɑ t͡ʃ ɛ s t ɚ
 rock	ɹ ɑ k
 rockabilly	ɹ ɑː k ə b ɪ l i
+rockall	ɹ ɑ k ɔ l
 rocker	ɹ ɒ k ə ɹ
-rockery	ɹ ɒ k ə ɹ i
+rockery	ɹ ɑ k ɚ i
 rocket	ɹ ɑ k ɪ t
 rockfish	ɹ ɑ k f ɪ ʃ
 rocking	ɹ ɑ k ɪ ŋ
@@ -53686,7 +54141,10 @@ romanian	ɹ ə m e ɪ n i ə n
 romanichal	ɹ ɑ m ɪ n i t͡ʃ æ l
 romanization	ɹ ə ʊ m ə n a ɪ z e ɪ ʃ ə n
 romans	ɹ o ʊ m ə n z
+romansch	ɹ o ʊ m æ n ʃ
+romansch	ɹ o ʊ m ɑ n ʃ
 romantic	ɹ o ʊ m æ n t ɪ k
+romanticism	ɹ ə ʊ m æ n t ɪ s ɪ z ə m
 romaphobia	ɹ o ʊ m ə f o ʊ b i ə
 romaphobia	ɹ ə ʊ m ə f ə ʊ b i ə
 romaunt	ɹ ə m ɔː n t
@@ -53764,7 +54222,7 @@ roraima	ɹ ə ʊ ɹ a ɪ m ə
 roral	ɹ ɔː ɹ ə l
 roration	r ə r e ɪ ʃ ə n
 rore	ɹ ɔ ɹ
-rorqual	ɹ ɒ ɹ k w ə l
+rorqual	ɹ ɔ ɹ k w ə l
 rort	ɹ ɔː ɹ t
 rorty	ɹ ɔː t i
 rory	ɹ o ə ɹ i
@@ -53852,7 +54310,7 @@ roubaisian	ɹ o ʊ b e ɪ ʒ ə n
 roubaix	ɹ u b e ɪ
 rouble	ɹ uː b ə l
 rouf	ɹ ɔː f
-rouge	ɹ uː ʒ
+rouge	ɹ u ʒ
 rouged	ɹ uː ʒ d
 rough	ɹ ʌ f
 roughage	ɹ ʌ f ɪ d͡ʒ
@@ -53890,6 +54348,7 @@ roussillon	ɹ uː s iː j ə n
 roust	ɹ a ʊ s t
 rout	ɹ a ʊ t
 route	ɹ a ʊ t
+route	ɹ u t
 route	ɹ uː t
 router	ɹ a ʊ t ɚ
 router	ɹ u t ɚ
@@ -53966,6 +54425,7 @@ rubescent	ɹ uː b ɛ s ə n t
 rubicon	ɹ u b ə k ɑ n
 rubicund	ɹ u b ə k ə n d
 rubidomycin	ɹ u b ɪ d o ʊ m a ɪ s n̩
+rubigo	ɹ uː b a ɪ ɡ ə ʊ
 rubin	ɹ uː b ɪ n
 ruble	ɹ uː b ə l
 rubric	ɹ uː b ɹ ɪ k
@@ -54034,7 +54494,7 @@ rule	ɹ uː l
 ruled	ɹ uː l d
 ruler	ɹ u l ɚ
 rulership	ɹ uː l ə ɹ ʃ ɪ p
-rules	ɹ uː l z
+rules	ɹ u l z
 ruling	ɹ uː l ɪ ŋ
 rulley	ɹ ʌ l i
 ruly	ɹ uː l i
@@ -54071,7 +54531,7 @@ runned	ɹ ʌ n d
 runnel	ɹ ʌ n l
 runnel	ɹ ʌ n ə l
 runner	ɹ ʌ n ɚ
-running	ɹ ʌ n ɪ ŋ
+running	ɹ ʌ n i ŋ
 runny	ɹ ʌ n i
 runout	ɹ ʌ n a ʊ t
 runs	ɹ ʌ n z
@@ -54109,6 +54569,8 @@ russet	ɹ ʌ s ɪ t
 russia	ɹ ʌ ʃ ə
 russian	ɹ ʌ ʃ ə n
 russias	ɹ ʌ ʃ ə s
+russify	ɹ uː s ɪ f a ɪ̯
+russify	ɹ ʌ s ɪ f a ɪ̯
 russki	ɹ u s k i
 russo	ɹ u s o ʊ
 russophilia	ɹ ʌ s ə f ɪ l i ə
@@ -54158,6 +54620,7 @@ rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ɒ l ɪ t ə
 rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ə l a ɪ t ə
 rzeszów	ʒ ɛ ʃ uː f
 réaumur	ɹ e ɪ ə ʊ m j ʊ ə ɹ
+résumé	ɹ ɛ z ə m e ɪ
 röntgen	ɹ ɜː n t ɡ ə n
 rösti	ɹ ɔ s t i
 rösti	ɹ ʊ ʃ t i
@@ -54401,7 +54864,7 @@ salination	s æ l ə n e ɪ ʃ ə n
 saline	s e ɪ l iː n
 salinely	s ə l iː n l i
 salinification	s ə l ɪ n ə f ə k e ɪ ʃ ə n
-saliniform	s ə l ɪ n ɨ f ɒ ɹ m
+saliniform	s ə l ɪ n ɪ f ɒ ɹ m
 salinity	s e ɪ l ɪ n ə t i
 salipenter	s æ l ɪ p ɛ n t ɚ
 salique	s e ɪ l ɪ k
@@ -54411,7 +54874,7 @@ salish	s e ɪ l ɪ ʃ
 salishan	s e ɪ l ɪ ʃ ə n
 saliva	s ə l a ɪ v ə
 salivant	s æ l ə v ə n t
-salivarium	s æ l ɨ v ɛ ɹ iː ə m
+salivarium	s æ l ɪ v ɛ ɹ iː ə m
 salivary	s æ l ɪ v ɛ ɹ i
 salivate	s æ l ɪ v e ɪ t
 salivous	s ə l a ɪ v ə s
@@ -54507,6 +54970,10 @@ sammamish	s ə m æ m ɪ ʃ
 sammy	s æ m i
 samnite	s æ m n a ɪ t
 samoa	s ə m o ʊ ə
+samogitia	s æ m o ʊ ɡ i ʃ ə
+samogitia	s æ m ə ɡ i ʃ ə
+samogitian	s æ m o ʊ ɡ i ʃ ə n
+samogitian	s æ m ə ɡ i ʃ ə n
 samos	s e ɪ m ɒ s
 samosata	s ə m ɒ s ə t ə
 samothracian	s æ m o ʊ θ ɹ e ɪ ʃ i ə n
@@ -54632,6 +55099,7 @@ sapphic	s æ f ɪ k
 sapphire	s æ f a ɪ̯ ɚ
 sapphism	s æ f ɪ z m̩
 sappho	s æ f ə ʊ
+sappie	s æ p i
 sappy	s æ p i
 saprophyte	s æ p ɹ ə ʊ f a ɪ t
 sapsucker	s æ p s ʌ k ə ɹ
@@ -54724,7 +55192,7 @@ sat	s æ t
 sat	ɛ s e ɪ̯ t i
 sata	s e ɪ t ə
 sata	s æ t ə
-satan	s e ɪ ʔ n̩
+satan	s e ɪ t n̩
 satanic	s e ɪ t æ n ɪ k
 satanism	s e ɪ t ə n ɪ z m
 satay	s æ t e ɪ
@@ -54989,12 +55457,14 @@ sceptic	s k ɛ p t ɪ k
 sceptral	s ɛ p t ɹ ə l
 sceptre	s ɛ p t ɚ
 scetavajasse	ʃ e ɪ t ə v a ɪ ɑː s e ɪ
+schachter	ʃ æ k t ɚ
 schadenfreude	ʃ ɑː d ə n f ɹ ɔ ɪ d ə
 schaerbeek	s k ɑ ɹ b e ɪ k
 schappe	ʃ æ p
 schappe	ʃ ɑ p ə
 scharnhorst	ʃ ɑː ɹ n h ɔː ɹ s t
 schatz	ʃ æ t s
+sched	s k ɛ d͡ʒ
 schediaphilia	s k ɛ d i ə f ɪ l i ə
 schedule	s k ɛ d͡ʒ u l
 schedule	s k ɛ d͡ʒ u ə l
@@ -55059,6 +55529,7 @@ schloop	ʃ l uː p
 schloopy	ʃ l uː p i
 schlub	ʃ l ʌ b
 schlubby	ʃ l ʌ b i
+schlump	ʃ l ʌ m p
 schmaltz	ʃ m ɒ l t s
 schmaltzy	ʃ m ɒ l t s i
 schmear	ʃ m ɪ ə ɹ
@@ -55068,7 +55539,7 @@ schmidt	ʃ m ɪ t
 schmo	ʃ m ə ʊ
 schmooze	ʃ m uː z
 schmuck	ʃ m ʌ k
-schmutz	ʃ m ʌ t s
+schmutz	ʃ m ʊ t s
 schnapper	ʃ n æ p ɚ
 schnapps	ʃ n æ p s
 schnapps	ʃ n ɑ p s
@@ -55129,7 +55600,7 @@ sciatica	s a ɪ æ t ɪ k ə
 science	s a ɪ ə n s
 scientific	s a ɪ ə n t ɪ f ɪ k
 scientifiction	s a ɪ ə n t ɪ f ɪ k ʃ ə n
-scientist	s a ɪ ə n t ɪ s t
+scientist	s a ɪ ə n t ə s t
 scif	s k ɪ f
 scilicet	s ɪ l ɪ s ɛ t
 scimitar	s ɪ m ɪ t ɑː ɹ
@@ -55229,7 +55700,6 @@ scots	s k ɒ t s
 scotsman	s k ɑ t s m ə n
 scott	s k ɒ t
 scottish	s k ɑ t ɪ ʃ
-scotus	s k o ʊ t ə s
 scoundrel	s k a ʊ̯ n d ɹ ə l
 scour	s k a ʊ ɚ
 scour	s k a ʊ ɹ
@@ -55406,7 +55876,7 @@ sealocked	s i l ɑ k t
 seals	s iː l z
 seam	s iː m
 seaman	s iː m ə n
-seamen	s iː m ə n
+seamen	s iː m ɛ n
 seaming	s iː m ɪ ŋ
 seams	s iː m z
 seamus	ʃ e ɪ m ə s
@@ -55637,6 +56107,7 @@ selene	s ə l i n i
 selenium	s ə l iː n i ə m
 selenium	s ɪ l iː n i ə m
 selenolatry	s ɛ l ɪ n ɒ l ə t ɹ i
+selenophobia	s ə l i n ə f o ʊ b i ə
 seletracetam	s ɛ l ɪ t ɹ æ s ɪ t æ m
 seleucia	s ə l u ʃ i ə
 seleucia	s ə l u ʃ ə
@@ -55755,7 +56226,7 @@ senedd	s ɛ n ɛ ð
 senegal	s ɛ n ɪ ɡ ɑː l
 senegal	s ɛ n ɪ ɡ ɔː l
 senesce	s ə n ɛ s
-senescence	s ɨ n ɛ s ə n s
+senescence	s ɪ n ɛ s ə n s
 seneschal	s ɛ n ə ʃ ə l
 senex	s ɛ n ɛ k s
 senhor	s ɪ n j ɔː ɹ
@@ -55884,6 +56355,7 @@ sequester	s ɪ k w ɛ s t ɚ
 sequestrate	s iː k w ə s t ɹ e ɪ t
 sequestrator	s iː k w ə s t ɹ e ɪ t ə ɹ
 sequin	s iː k w ɪ n
+sequined	s iː k w ɪ n d
 sequitur	s ɜ k w ə t ɚ
 sequitur	s ɜ k w ə t ʊ ɹ
 sequoia	s ɪ k w ɔ ɪ ə
@@ -55920,7 +56392,6 @@ seriema	s ɛ ɹ ɪ iː m ə
 series	s i ɹ i z
 series	s ɪ ɹ i z
 serif	s ə ɹ i f
-serif	s ɛ ɹ ə f
 serif	s ɛ ɹ ɪ f
 seriocomical	s ɪ ə ɹ i ə ʊ k ɒ m ɪ k ə l
 serious	s ɪ ɚ i ə s
@@ -55934,14 +56405,13 @@ sermocinator	s ɜː ɹ m ɒ s ɪ n e ɪ t ə ɹ
 sermon	s ɝ m ə n
 sermountain	s ɝ m a ʊ n t ə n
 serodisclosure	s ɪ ə ɹ ə ʊ d ɪ s k l ə ʊ ʒ ə ɹ
-serosal	s ɨ ɹ o ʊ z ə l
+serosal	s ɪ ɹ o ʊ z ə l
 serotinal	s ə ɹ ɒ t ɪ n ə l
 serotonin	s ɛ ɹ ə t o ʊ n ɪ n
 serow	s ə ɹ o ʊ
 serpens	s ɚ p ə n z
 serpent	s ɝ p ə n t
 serpentine	s ɝ p ə n t a ɪ n
-serpentine	s ɝ p ə n t i n
 serpet	s ɜː ɹ p ɪ t
 serpette	s ɜː ɹ p ɛ t
 serrano	s ə ɹ ɑː n ə ʊ
@@ -55998,6 +56468,7 @@ setebos	s ɛ t ɛ b ʌ s
 seth	s ɛ θ
 setiferous	s iː t ɪ f ə ɹ ə s
 setiform	s iː t ə f ɔ ɹ m
+setiger	s iː t ɪ d ʒ ə ɹ
 setim	s iː t ɪ m
 setpoint	s ɛ t p ɔ ɪ n t
 setpoints	s ɛ t p ɔ ɪ n t s
@@ -56178,6 +56649,7 @@ shamefully	ʃ e ɪ m f ə l i
 shames	ʃ e ɪ m z
 shamisen	ʃ æ m ɪ s ɛ n
 shamois	ʃ æ m i
+shamone	ʃ ʌ m ə ʊ n
 shampers	ʃ æ m p ə ɹ z
 shampoo	ʃ æ m p uː
 shamrock	ʃ æ m ɹ ɑ k
@@ -56210,7 +56682,7 @@ shapeshifter	ʃ e ɪ p ʃ ɪ f t ɚ
 shapiro	ʃ ə p a ɪ ɹ o ʊ
 shapiro	ʃ ə p ɪ ɹ o ʊ
 shard	ʃ ɑ ɹ d
-share	ʃ ɛ ə ɹ
+share	ʃ ɛ ɚ
 shareable	ʃ ɛ ə ɹ ə b ə l
 sharebait	ʃ ɛ ɹ b e ɪ t
 shared	ʃ ɛ ɹ d
@@ -56281,6 +56753,7 @@ sheathbill	ʃ iː θ b ɪ l
 sheathe	ʃ i ð
 sheathed	ʃ iː ð d
 sheathed	ʃ iː θ t
+sheaths	ʃ iː ð z
 sheathy	ʃ iː θ i
 sheave	ʃ iː v
 sheba	ʃ iː b ə
@@ -56300,13 +56773,14 @@ sheepish	ʃ iː p ɪ ʃ
 sheepishly	ʃ iː p ɪ ʃ l i
 sheeple	ʃ iː p ə l
 sheepshank	ʃ i p ʃ æ ŋ k
-sheer	ʃ i ɹ
+sheer	ʃ ɪ ɹ
 sheers	ʃ ɪ ɹ z
 sheesh	ʃ iː ʃ
 sheet	ʃ i t
 sheets	ʃ i t s
 sheffield	ʃ ɛ f iː l d
 sheik	ʃ e ɪ k
+sheik	ʃ i k
 sheikdom	ʃ e ɪ k d ə m
 sheikdom	ʃ iː k d ə m
 sheila	ʃ iː l ə
@@ -56338,6 +56812,7 @@ shemagh	ʃ ə m ɑː ɣ
 shemaiah	ʃ ɛ m ɛ j ɑː
 shemale	ʃ i m e ɪ l
 shemales	ʃ i m e ɪ l z
+shen	ʃ ɛ n
 shenanigan	ʃ ə n æ n ɪ ɡ ə n
 shenanigans	ʃ ə n æ n ə ɡ ɪ n z
 shend	ʃ ɛ n d
@@ -56559,7 +57034,7 @@ shooting	ʃ uː t ɪ ŋ
 shootout	ʃ uː t a ʊ t
 shoots	ʃ uː t s
 shop	ʃ ɑ p
-shopkeeper	ʃ ɒ p k iː p ə
+shopkeeper	ʃ ɒ p k iː p ɚ
 shoplet	ʃ ɑ p l ə t
 shoplift	ʃ ɒ p l ɪ f t
 shopper	ʃ ɑ p ɚ
@@ -56638,8 +57113,8 @@ shreddy	ʃ ɹ ɛ d i
 shrek	ʃ ɹ ɛ k
 shrew	ʃ ɹ uː
 shrewd	ʃ ɹ uː d
-shrewsbury	ʃ ɹ uː z b ɹ ɪ
-shrewsbury	ʃ ɹ ə ʊ z b ɹ ɪ
+shrewsbury	ʃ ɹ o ʊ z b ə ɹ i
+shrewsbury	ʃ ɹ u z b ə ɹ i
 shriek	ʃ ɹ iː k
 shrieky	ʃ ɹ iː k i
 shrieval	ʃ ɹ iː v ə l
@@ -56704,9 +57179,9 @@ shunt	ʃ ə n t
 shunt	ʃ ʌ n t
 shuntak	ʃ ʌ n t æ k
 shunto	ʃ ʊ n t o ʊ
-shuriken	ʃ uː ɹ ɨ k ə n
-shuriken	ʃ ɝ ɨ k ə n
-shuriken	ʃ ʊ ə ɹ ɨ k ə n
+shuriken	ʃ uː ɹ ɪ k ə n
+shuriken	ʃ ɝ ɪ k ə n
+shuriken	ʃ ʊ ə ɹ ɪ k ə n
 shush	ʃ ʊ ʃ
 shush	ʃ ʌ ʃ
 shuswap	ʃ uː ʃ w ɑː p
@@ -56751,12 +57226,14 @@ sic	s ɪ k
 siccawei	s ɪː k ɑː w e ɪ
 siccawei	s ɪː k ə w e ɪ
 sice	s a ɪ s
+sicel	s ɪ k ə l
+sicel	s ɪ s ə l
 sich	s iː t͡ʃ
 sichuan	s ɛ t͡ʃ w ɑ n
 sichuan	s ɛ ʃ w ɑ n
 sichuan	s ɪ t͡ʃ w ɑ n
 sicilia	s ɪ s ɪ l j ə
-sicily	s ɪ s ɨ l i
+sicily	s ɪ s ɪ l i
 sick	s ɪ k
 sickbed	s ɪ k b ɛ d
 sicken	s ɪ k ə n
@@ -56775,6 +57252,7 @@ siddur	s ɪ d ʊ ə
 side	s a ɪ d
 sideboob	s a ɪ d b u b
 sideburns	s a ɪ d b ɚ n z
+sidecar	s a ɪ d k ɑ ɹ
 sidekick	s a ɪ d k ɪ k
 sideline	s a ɪ d l a ɪ n
 sidequest	s a ɪ d k w ɛ s t
@@ -56964,6 +57442,7 @@ simply	s ɪ m p l i
 simpson	s ɪ m p s ə n
 simul	s ɪ m ə l
 simulacrum	s i m j ə l e ɪ k ɹ ə m
+simulant	s ɪ m j ʊ l ə n t
 simular	s ɪ m j ʊ l ə ɹ
 simulate	s ɪ m j ə l e ɪ t
 simulate	s ɪ m j ə l ə t
@@ -57262,11 +57741,13 @@ skoliosexual	s k o ʊ l i o ʊ s ɛ k ʃ u ə l
 skookum	s k uː k ə m
 skoosh	s k u ʃ
 skopje	s k ɔ p j ɛ
+skopostheorie	s k ə ʊ p ə ʊ s t e ɪ ə ɹ iː
 skoracki	s k ə ɹ æ k i
 skosh	s k o ʊ ʃ
 skosh	s k ɑ ʃ
 skraeling	s k ɹ e ɪ l ɪ ŋ
 skrike	s k ɹ a ɪ k
+skrunkly	s k ɹ ʌ ŋ k l i
 sku	s k j uː
 sku	s k uː
 sku	ɛ s k e ɪ j uː
@@ -57378,6 +57859,7 @@ sleazy	s l iː z i
 sleb	s l ɛ b
 sled	s l ɛ d
 sledge	s l ɛ d͡ʒ
+sledgehammer	s l ɛ d͡ʒ h æ m ɚ
 sledger	s l ɛ d͡ʒ ə ɹ
 sleek	s l iː k
 sleekly	s l iː k l i
@@ -57480,12 +57962,14 @@ sloot	s l uː ɪ t
 slop	s l ɒ p
 slope	s l o ʊ p
 sloping	s l o ʊ p ɪ ŋ
-sloppy	s l ɒ p i
+sloppy	s l ɑ p i
 slopy	s l ə ʊ p i
+slosh	s l ɒ ʃ
 sloshed	s l ɑ ʃ t
 sloshy	s l ɒ ʃ i
 slot	s l ɑ t
 sloth	s l ɔ θ
+slothen	s l ɔ θ ə n
 sloths	s l ɑ θ s
 slouch	s l a ʊ t͡ʃ
 slough	s l a ʊ
@@ -57673,6 +58157,7 @@ snacker	s n æ k ə ɹ
 snackery	s n æ k ə ɹ iː
 snackless	s n æ k l ə s
 snacky	s n æ k i
+snaefell	s n e ɪ f ɛ l
 snaffle	s n æ f ə l
 snafu	s n æ f uː
 snag	s n æ ɡ
@@ -57725,7 +58210,7 @@ sneck	s n ɛ k
 snee	s n iː
 sneed	s n iː d
 sneep	s n iː p
-sneer	s n ɪ ə̯ ɹ
+sneer	s n ɪ ɚ̯
 sneered	s n ɪ ə̯ ɹ d
 sneered	s n ɪ ɹ d
 sneerful	s n ɪ ɹ f ə l
@@ -57887,6 +58372,7 @@ sodalite	s o ʊ d ə l a ɪ t
 sodality	s o ʊ d æ l ɪ t i
 sodar	s o ʊ d ɑ ɹ
 sodden	s ɑ d ə n
+sodiasm	s ə ʊ d ɪ ə z ə m
 sodium	s o ʊ d i ə m
 sodom	s ɑ d ə m
 sodomise	s ɒ d ə m a ɪ z
@@ -57927,9 +58413,10 @@ soho	s ɔ ʊ h ɔ ʊ
 soho	s ə ʊ h ə ʊ
 soigneur	s w ʌ n j ɝ
 soigné	s w ɑ n j e ɪ
-soil	s ɔ ɪ l
+soil	s ɔ ɪ l̩
 soilage	s ɔ ɪ l ɪ d͡ʒ
 soiree	s w ɑː ɹ e ɪ
+soja	s ə ʊ d ʒ ə
 sojourn	s o ʊ d͡ʒ ɚ n
 sojourner	s o ʊ d͡ʒ ɝ n ɚ
 soju	s o ʊ d͡ʒ uː
@@ -57963,6 +58450,7 @@ solely	s o ʊ l l i
 solemn	s ɑ l ə m
 solemnity	s ə l ɛ m n ɪ t i
 solemnly	s ɑ l ə m l i
+solen	s ə ʊ l ə n
 solent	s ə ʊ l ə n t
 soleus	s o ʊ l i ə s
 solfège	s ɒ l f e ɪ ʒ
@@ -58064,6 +58552,7 @@ songhai	s ɒ ŋ ɡ a ɪ
 songket	s ɒ ŋ k ɛ t
 songline	s ɒ ŋ l a ɪ n
 songs	s ɑ ŋ z
+songs	s ɔ ŋ z
 songster	s ɒ ŋ s t ə ɹ
 songstress	s ɑ ŋ ɡ s t ɹ ɪ s
 songy	s ɑ ŋ i
@@ -58086,7 +58575,7 @@ sooey	s uː i
 sook	s u k
 sook	s uː k
 sook	s ʊ k
-soon	s uː n
+soon	s u n
 soondae	s uː n d e ɪ
 sooner	s u n ɚ
 soopolallie	s uː p ə l æ l i
@@ -58314,7 +58803,7 @@ spankingly	s p æ ŋ k ɪ ŋ l i
 spanky	s p æ ŋ k i
 spanner	s p æ n ɚ
 spar	s p ɑ ɹ
-spare	s p ɛ ə ɹ
+spare	s p ɛ ɚ
 spared	s p ɛ ɹ d
 sparerib	s p ɛ ɚ ɹ ɪ b
 sparfloxacin	s p ɑ ɹ f l ɑ k s ə s ɪ n
@@ -58329,6 +58818,7 @@ sparring	s p ɑː ɹ ɪ ŋ
 sparrow	s p æ ɹ o ʊ
 sparrow	s p ɛ ɹ o ʊ
 sparse	s p ɑː ɹ s
+sparsentan	s p ɑː ɹ s ɛ n t æ n
 sparta	s p ɑː ɹ t ə
 spartacus	s p ɑː ɹ t ə k ə s
 spartan	s p ɑː ɹ t ə n
@@ -58339,6 +58829,8 @@ spasmodic	s p æ z m ɑ d ɪ k
 spastic	s p æ s t ɪ k
 spat	s p æ t
 spatchcock	s p æ t͡ʃ k ɑ k
+spatchcocked	s p æ t͡ʃ k ɑ k t
+spatchcocking	s p æ t͡ʃ k ɑ k ɪ ŋ
 spate	s p e ɪ t
 spathal	s p e ɪ ð ə l
 spathe	s p e ɪ ð
@@ -58457,6 +58949,7 @@ spending	s p ɛ n d ɪ ŋ
 spendthrift	s p ɛ n d θ ɹ ɪ f t
 spenser	s p ɛ n s ə ɹ
 spent	s p ɛ n t
+sperage	s p ɛ ɹ ɪ d ʒ
 sperate	s p ɪ ə ɹ ə t
 sperge	s p ɜː ɹ d͡ʒ
 sperm	s p ɜː ɹ m
@@ -58518,6 +59011,7 @@ spider	s p a ɪ̯ d ɚ
 spiderling	s p a ɪ d ɚ l ɪ ŋ
 spiderweb	s p a ɪ̯ d ə w ɛ b
 spidey	s p a ɪ d i
+spie	s p a ɪ
 spiedie	s p iː d i
 spiel	s p iː l
 spiel	ʃ p iː l
@@ -58594,15 +59088,15 @@ spiritualism	s p ɪ ɹ ɪ t͡ʃ u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ ə l ɪ z ə m
 spirituality	s p ɪ ɹ ə t͡ʃ u æ l ə t ɪ
 spirochete	s p a ɪ ɹ ə k i t
-spirocheticidal	s p a ɪ r o ʊ k i t ɨ s a ɪ d ə l
+spirocheticidal	s p a ɪ r o ʊ k i t ɪ s a ɪ d ə l
 spirochetocidal	s p a ɪ r o ʊ k i t ə s a ɪ d ə l
-spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɨ s ɨ s
-spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɨ k
-spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɨ k
+spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɪ s ɪ s
+spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɪ k
+spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɪ k
 spirometer	s p a ɪ ɹ ɑ m ə t ɚ
 spironolactone	s p a ɪ ɹ ə n o ʊ l æ k t o ʊ n
+spironolactone	s p ɪ ɚ ə n ə l æ k t o ʊ n
 spironolactone	s p ɪ ɹ o ʊ n ə l æ k t o ʊ n
-spironolactone	s p ɪ ɹ ə n ə l æ k t o ʊ n
 spirulina	s p a ɪ ɹ ə l iː n ə
 spirulina	s p ɪ ɹ j ʊ l iː n ə
 spirulina	s p ɪ ɹ ə l iː n ə
@@ -58675,6 +59169,7 @@ spondylosis	s p ɒ n d ɪ l ə ʊ s ɪ s
 sponge	s p ʌ n d͡ʒ
 sponger	s p ʌ n d͡ʒ ɚ
 spongy	s p ʌ n d͡ʒ i
+sponk	s p ɒ ŋ k
 sponsor	s p ɑ n s ə ɹ
 spontaneous	s p ɑ n t e ɪ n i ə s
 spontaneously	s p ɑ n t e ɪ n i ə s l i
@@ -58726,8 +59221,8 @@ spouge	s p uː d͡ʒ
 spousal	s p a ʊ s ə l
 spousal	s p a ʊ z ə l
 spouse	s p a ʊ s
-spouses	s p a ʊ s ɨ z
-spouses	s p a ʊ z ɨ z
+spouses	s p a ʊ s ɪ z
+spouses	s p a ʊ z ɪ z
 spout	s p a ʊ t
 spouty	s p a ʊ t i
 sprachbund	s p ɹ ɑ k b ʊ n d
@@ -58748,7 +59243,7 @@ spread	s p ɹ ɛ d
 spreadable	s p ɹ ɛ d ə b ə l
 spreader	s p ɹ ɛ d ɚ
 spreading	s p ɹ ɛ d ɪ ŋ
-spreadsheet	s p r ɛ d ʃ iː t
+spreadsheet	s p ɹ ɛ d ʃ i t
 spreath	s p ɹ iː θ
 spree	s p ɹ e ɪ
 spree	s p ɹ iː
@@ -58929,7 +59424,6 @@ stabbed	s t æ b d
 stabbing	s t æ b ɪ ŋ
 stabenow	s t æ b ɪ n a ʊ
 stabiliment	s t ə b ɪ l ɪ m ə n t
-stability	s t ə b ɪ l ɪ d i
 stability	s t ə b ɪ l ɪ t i
 stabilization	s t e ɪ b ə l a ɪ z e ɪ ʃ ə n
 stabilization	s t e ɪ b ə l ɪ z e ɪ ʃ ə n
@@ -58967,7 +59461,7 @@ staid	s t e ɪ d
 stain	s t e ɪ n
 stained	s t e ɪ n d
 stainer	s t e ɪ n ɚ
-stair	s t ɛ ə ɹ
+stair	s t ɛ ɚ
 staircase	s t ɛ ɹ k e ɪ s
 staired	s t ɛ ɹ d
 stairs	s t ɛ ɹ z
@@ -59059,7 +59553,7 @@ starbucks	s t ɑː ɹ b ʌ k s
 starch	s t ɑ ɹ t͡ʃ
 stardom	s t ɑ ɹ d ə m
 stardust	s t ɑ ɹ d ʌ s t
-stare	s t ɛ ə ɹ
+stare	s t ɛ ɚ
 stared	s t ɛ ɹ d
 starey	s t ɛ ə ɹ i
 starfish	s t ɑː ɹ f ɪ ʃ
@@ -59088,7 +59582,7 @@ starvation	s t ɑ ɹ v e ɪ ʃ ə n
 starve	s t ɑ ɹ v
 starven	s t ɑ ɹ v ə n
 starving	s t ɑ ɹ v ɪ ŋ
-stary	s t ɛ ə ɹ ɨ
+stary	s t ɛ ə ɹ ɪ
 stash	s t æ ʃ
 stasi	s t ɑː z i
 stasi	ʃ t ɑː z i
@@ -59130,6 +59624,8 @@ statler	s t æ t l ə ɹ
 statoid	s t e ɪ t ɔ ɪ d
 statuary	s t æ t͡ʃ u ɛ ə ɹ i
 statue	s t æ t͡ʃ u
+statuette	s t æ t j u ɛ t
+statuette	s t æ t ʃ u ɛ t
 statuminate	s t ə t j uː m ɪ n e ɪ t
 statuminate	s t ə t uː m ɪ n e ɪ t
 stature	s t æ t͡ʃ ɚ
@@ -59191,7 +59687,8 @@ steenbok	s t iː n b ɒ k
 steens	s t iː n z
 steep	s t iː p
 steepy	s t iː p i
-steer	s t ɪ ə ɹ
+steer	s t ɪ ɚ
+steer	s t ɪ ɹ
 steerageway	s t i ɹ ɪ d͡ʒ w e ɪ
 steerer	s t ɪ ə ɹ ə ɹ
 steerless	s t ɪ ɹ l ə s
@@ -59341,7 +59838,8 @@ stilbestrol	s t ɪ l b ɛ s t ɹ ɔ l
 stilbon	s t ɪ l b ɒ n
 stile	s t a ɪ l
 stiletto	s t ɪ l ɛ t o ʊ
-still	s t ɪ ɫ
+still	s t ɪ l
+stillborn	s t ɪ l b ɔː ɹ n
 stillicide	s t ɪ l ɪ s ʌ ɪ d
 stillness	s t ɪ l n ə s
 stilt	s t ɪ l t
@@ -59350,6 +59848,7 @@ stilton	s t ɪ l t ə n
 stilus	s t a ɪ l ə s
 stime	s t a ɪ m
 stimmy	s t ɪ m i
+stimulant	s t ɪ m j ʊ l ə n t
 stimulate	s t ɪ m j ʊ l e ɪ t
 stimulated	s t ɪ m j ʊ l e ɪ t ɪ d
 stimuli	s t ɪ m j ə l a ɪ̯
@@ -59586,7 +60085,7 @@ streel	s t ɹ iː l
 street	s t ɹ i t
 streetlet	s t ɹ iː t l ə t
 streets	s t ɹ iː t s
-strength	s t ɹ ɛ ŋ k θ
+strength	s t ɹ ɛ ŋ θ
 strengthen	s t ɹ ɛ n θ ə n
 strengthen	s t ɹ ɛ ŋ k θ ə n
 strengthen	ʃ t͡ʃ ɹ e ɪ ŋ k θ ə n
@@ -59870,7 +60369,7 @@ subglacial	s ʌ b ɡ l e ɪ ʃ i ə l
 subglacial	s ʌ b ɡ l e ɪ ʃ ə l
 subgroup	s ʌ b ɡ ɹ uː p
 subindication	s ʌ b ɪ n d ɪ k e ɪ ʃ ə n
-subitize	s ʌ b ɨ t a ɪ z
+subitize	s ʌ b ɪ t a ɪ z
 subito	s uː b ɪ t ə ʊ
 subjacency	s ə b d͡ʒ e ɪ s ə n s i
 subject	s ə b d͡ʒ ɛ k t
@@ -59921,6 +60420,7 @@ subperiosteal	s ʌ b p ɛ ɹ i ɒ s t ɪ ə l
 subpoena	s ə p iː n ə
 subpoenable	s ə p i n ə b ə l
 subprime	s ʌ b p ɹ a ɪ m
+subq	s ʌ b k j uː
 subreption	s ʌ b ɹ ɛ p ʃ ə n
 subsaltation	s ʌ b s l t e ɪ ʃ n
 subsaltation	s ʌ b s ə l t e ɪ ʃ n
@@ -59942,7 +60442,7 @@ subsidiary	s ʌ b s ɪ d i ə ɹ i
 subsidiary	s ʌ b s ɪ d ə ɹ i
 subsidiary	s ʌ b s ɪ d͡ʒ ə ɹ i
 subsidize	s ʌ b s ɪ d a ɪ z
-subsidy	s ʌ b s ɨ d i
+subsidy	s ʌ b s ɪ d i
 subsist	s ə b s ɪ s t
 subsistence	s ə b s ɪ s t ə n s
 subspecies	s ʌ b s p iː ʃ iː z
@@ -60303,7 +60803,7 @@ superinstantaneous	s uː p ɚ ɪ n s t ə n t e ɪ n i ə s
 superintend	s uː p ə ɹ ɪ n t ɛ n d
 superintendent	s j uː p ə ɹ ɪ n t ɛ n d ə n t
 superintendent	s uː p ə ɹ ɪ n t ɛ n d ə n t
-superior	s ʊ p ɪ ɹ i ə ɹ
+superior	s ʊ p ɪ ɹ i ɚ
 superirresistible	s u p ɚ ɪ ɹ ɪ z ɪ s t ə b ə l
 superkick	s uː p ɚ k ɪ k
 superlative	s u p ɝː l ə t ɪ v
@@ -60417,6 +60917,8 @@ suprasegmental	s uː p ɹ ə s ɛ ɡ m ɛ n t ə l
 suprasternal	s uː p ɹ ə s t ɜː n ə l
 supratrochlear	s u p ɹ ə t ɹ ɑ k l i ɚ
 supremacy	s u p ɹ ɛ m ə s i
+suprematism	s j uː p ɹ ɛ m ə t ɪ z ə m
+suprematist	s j uː p ɹ ɛ m ə t ɪ s t
 supreme	s u p ɹ i m
 supreme	s ə p ɹ iː m
 supremo	s uː p ɹ iː m ə ʊ
@@ -60460,6 +60962,7 @@ surimi	s ʊ ə ɹ iː m i
 surimi	s ʊ ə ɹ ɪ m i
 suriname	s ʊ ɹ ɪ n æ m
 suriname	s ʊ ɹ ɪ n ɑ m
+surinamese	s ʊ ə ɹ ɪ n ə m iː z
 surjection	s ɜː ɹ d͡ʒ ɛ k ʃ ə n
 surmise	s ɚ m a ɪ z
 surmount	s ɚ m a ʊ n t
@@ -60479,7 +60982,6 @@ surprising	s ə p ɹ a ɪ z ɪ ŋ
 surprising	s ɚ p ɹ a ɪ z ɪ ŋ
 surreal	s ə ɹ iː ə l
 surrect	s ə ɹ ɛ k t
-surrender	s ə ɹ ɛ n d ə ɹ
 surreptition	s ə ɹ ɛ p t ɪ ʃ ə n
 surreptition	s ʌ ɹ ə p t ɪ ʃ ə n
 surreptitious	s ə ɹ ɛ p t ɪ ʃ ə s
@@ -60510,6 +61012,7 @@ sus	s ʌ s
 susa	s uː z ə
 susceptibility	s ə s ɛ p t ə b ɪ l ɪ t i
 susceptible	s ə s ɛ p t ɪ b l̩
+suscitate	s ʌ s ɪ t e ɪ t
 sushen	s uː ʃ ʌ n
 sushi	s u ʃ i
 sushi	s uː ʃ i
@@ -60622,7 +61125,6 @@ swash	s w ɒ ʃ
 swastika	s w ɑ s t ə k ə
 swastika	s w ɑ s t ɪ k ə
 swat	s w ɑ t
-swat	s w ɔ t
 swatch	s w ɑ t͡ʃ
 swatch	s w ɔ t͡ʃ
 swatchel	s w ɒ t͡ʃ ə l
@@ -60788,8 +61290,8 @@ symbiotic	s ɪ m b a ɪ ɑ t ɪ k
 symbiotic	s ɪ m b i ɑ t ɪ k
 symblepharon	s ɪ m b l ɛ f ə ɹ ɑ n
 symbol	s ɪ m b ə l
-symbolically	s ɪ m b ɑː l ɪ k l ɨ
-symbolically	s ɪ m b ɒ l ɪ k l ɨ
+symbolically	s ɪ m b ɑː l ɪ k l ɪ
+symbolically	s ɪ m b ɒ l ɪ k l ɪ
 symbolism	s ɪ m b ə l ɪ z ə m
 symbolize	s ɪ m b ə l a ɪ z
 symboloid	s ɪ m b ə l ɔ ɪ d
@@ -60829,7 +61331,7 @@ synchrocyclotron	s ɪ ŋ k ɹ ə ʊ s a ɪ k l ə t ɹ ɒ n
 synchronic	s ɪ ŋ k ɹ ɑ n ɪ k
 synchronous	s ɪ ŋ k ɹ ə n ə s
 synchrotron	s ɪ ŋ k ɹ ə ʊ t ɹ ɒ n
-synchysis	s ɪ n k ə s ɨ s
+synchysis	s ɪ n k ə s ɪ s
 syncline	s ɪ n k l a ɪ n
 syncope	s ɪ ŋ k ə p i
 syncranterian	s ɪ ŋ k ɹ æ n t i ɹ i ə n
@@ -60937,6 +61439,7 @@ södertälje	s ʌ d ə r t ɛ l j ə
 t	t iː
 t'othersider	t ʌ ð ə ɹ s a ɪ d ə ɹ
 ta	t ɑː
+ta	t ə
 ta'en	t e ɪ n
 tab	t æ b
 tabard	t æ b ɑː ɹ d
@@ -61022,7 +61525,7 @@ taenifuge	t iː n ɪ f j uː d͡ʒ
 tafe	t e ɪ f
 taffaty	t æ f ə t i
 taffeta	t æ f ə t ə
-taffeta	t æ f ɨ t ə
+taffeta	t æ f ɪ t ə
 taffety	t æ f ə t i
 taffy	t æ f i
 tafsir	t æ f s ɪ ə r
@@ -61074,6 +61577,7 @@ taino	t a ɪ n o ʊ
 taint	t e ɪ n t
 tainted	t e ɪ n t ɪ d
 taipei	t a ɪ p e ɪ
+taiping	t a ɪ p ɪ ŋ
 taipingxi	t a ɪ p ɪ ŋ ʃ iː
 taiqian	t a ɪ t͡ʃ j æ n
 taiqian	t a ɪ t͡ʃ j ɛ n
@@ -61121,7 +61625,7 @@ tali	t̪ aː l i
 taliban	t æ l ɪ b æ n
 taliban	t æ l ɪ b ɑː n
 taliban	t ɑː l ɪ b ɑː n
-taliesin	t æ l i ɛ s ɨ n
+taliesin	t æ l i ɛ s ɪ n
 taligrade	t æ l ɪ ɡ ɹ e ɪ d
 talisman	t æ l ɪ s m æ n
 talisman	t æ l ɪ z m ə n
@@ -61157,8 +61661,8 @@ talmud	t æ l m ə d
 talmud	t æ l m ʊ d
 talmud	t ɑ l m ʊ d
 talmudic	t æ l m ʊ d ɪ k
-talmudic	t ɑ l m ʊ d ɪ k
 talon	t æ l ə n
+talpidae	t æ l p ɪ d iː
 talus	t e ɪ l ə s
 tam	t æ m
 tamada	t ɑ m ə d ɑ
@@ -61220,7 +61724,7 @@ tangential	t æ n d͡ʒ ɛ n t͡ʃ ə l
 tangentially	t æ n d͡ʒ ɛ n ʃ i ə l i
 tangentially	t æ n d͡ʒ ɛ n ʃ ə l i
 tangerine	t æ n d͡ʒ ə ɹ i n
-tangerine	t æ n d͡ʒ ɜ ɹ i n
+tangerine	t æ n d͡ʒ ə ɹ iː n
 tangible	t æ n d͡ʒ ə b ə l
 tangier	t æ ŋ ɪ ə
 tangle	t æ ŋ ɡ ə l
@@ -61247,6 +61751,8 @@ tannin	t æ n ɪ n
 tanning	t æ n ɪ ŋ
 tannishness	t æ n ɨ ʃ n ɨ s
 tannoy	t æ n ɔ ɪ
+tanpura	t æ m p ʊ ə ɹ ə
+tanpura	t ɑ m p ʊ ə ɹ ə
 tanru	t æ n ɹ uː
 tansy	t æ n z i
 tantalism	t æ n t ə l ɪ z ə m
@@ -61259,6 +61765,9 @@ tantara	t æ n t ə ɹ ɑː
 tante	t ɑ n t ə
 tantivy	t æ n t ɪ v i
 tanto	t ɑ n t o ʊ
+tantra	t æ n t ɹ ə
+tantra	t ɑː n t ɹ ə
+tantra	t ʌ n t ɹ ə
 tantric	t æ n t ɹ ɪ k
 tantrum	t æ n t ɹ ə m
 tanuki	t ɑ n u k i
@@ -61268,8 +61777,9 @@ tanzanian	t æ n z ə n i ə n
 tanzanite	t æ n z ə n a ɪ t
 tao	d a ʊ
 tao	t a ʊ
-taoiseach	t iː ʃ ə k
-taoiseach	t iː ʃ ə x
+taoiseach	t i ʃ i
+taoiseach	t i ʃ ə k
+taoisigh	t i ʃ i
 taotie	t a ʊ t j e ɪ
 tap	t æ p
 tapa	t ɑː p ə
@@ -61313,6 +61823,7 @@ taranto	t ə ɹ æ n t o ʊ
 taranto	t ɛ ɹ ə n t o ʊ
 tarantula	t ə ɹ æ n t͡ʃ ə l ə
 taraxacum	t ə ɹ æ k s ə k ə m
+tarboosh	t ɑ ɹ b u ʃ
 tardigrade	t ɑ ɹ d ɪ ɡ ɹ e ɪ d
 tardis	t ɑ ɹ d ɪ s
 tardlet	t ɑː ɹ d l ə t
@@ -61358,7 +61869,7 @@ tarry	t ɑː ɹ i
 tarsal	t ɑ ɹ s ə l
 tarsand	t ɑː ɹ s æ n d
 tarse	t ɑː ɹ s
-tarsier	t a ɹ s i ə ɹ
+tarsier	t ɑ ɹ s i ə ɹ
 tarsus	t ɑ ɹ s ə s
 tart	t ɑ ɹ t
 tartan	t ɑ ɹ t n̩
@@ -61439,6 +61950,7 @@ taupe	t o ʊ p
 taupo	t a ʊ p o ʊ
 taur	t ɑː r
 taur	t ɔː r
+taurida	t ɔː ɹ ɪ d ə
 taurine	t ɔː ɹ a ɪ n
 taurine	t ɔː ɹ iː n
 taurocholic	t ɔː ɹ ə k ɒ l ɪ k
@@ -61472,8 +61984,8 @@ taxis	t æ k s i z
 taxis	t æ k s ɪ s
 taxodium	t æ k s o ʊ d i ə m
 taxol	t æ k s ɒ l
-taxon	t æ k s ɑː n
-taxonomy	t æ k s ɑː n ə m i
+taxon	t æ k s ɑ n
+taxonomy	t æ k s ɑ n ə m i
 tay	t e ɪ
 tayabas	t æ j ɑ b ɑ s
 taylor	t e ɪ l ɚ
@@ -61506,6 +62018,7 @@ teachy	t iː t͡ʃ i
 teacup	t iː k ʌ p
 teade	t iː d
 teak	t iː k
+teaky	t iː k i
 teal	t iː l
 team	t iː m
 teammate	t iː m m e ɪ t
@@ -61524,8 +62037,8 @@ teared	t ɪ ə ɹ d
 teared	t ɪ ɹ d
 tearful	t ɪ ɹ f ə l
 tearful	t ɪ ɹ f ʊ l
-tearing	t ɛ ə ɹ ɪ ŋ
-tearing	t ɪ ə ɹ ɪ ŋ
+tearing	t ɛ ɹ ɪ ŋ
+tearing	t ɪ ɹ ɪ ŋ
 tears	t ɛ ɹ z
 tears	t ɪ ɹ z
 tearsheet	t ɛ ə ʃ iː t
@@ -61559,6 +62072,7 @@ technique	t ɛ k n iː k
 techno	t ɛ k n o ʊ
 technobabble	t ɛ k n o ʊ b æ b ə l
 technocracy	t ɛ k n ɒ k ɹ ə s i
+technological	t ɛ k n ə l ɑ d͡ʒ ɪ k ə l
 technologist	t ɛ k n ɑ l ə d͡ʒ ɪ s t
 technology	t ɛ k n ɑ l ə d͡ʒ i
 technopeasant	t ɛ k n ə ʊ p ɛ z ə n t
@@ -61576,6 +62090,7 @@ teddy	t ɛ d i
 tedge	t ɛ d͡ʒ
 tedious	t i d i ə s
 tedious	t i d͡ʒ ə s
+tedisome	t i d i s ə m
 tee	t iː
 teegeeack	t iː ɡ i æ k
 teek	t iː k
@@ -61585,6 +62100,7 @@ teeming	t iː m ɪ ŋ
 teen	t iː n
 teenager	t iː n e ɪ d͡ʒ ə ɹ
 teens	t iː n z
+teensy	t i n s i
 teeny	t iː n i
 teenybopper	t i n i b ɑ p ɚ
 teep	t iː p
@@ -61629,6 +62145,7 @@ telary	t iː l ə ɹ i
 tele	t ɛ l i
 telecabin	t ɛ l ɪ k æ b ɪ n
 telecine	t ɛ l ə s ɪ n e ɪ
+telega	t ɪ l e ɪ ɡ ə
 telegraphist	t ə l ɛ ɡ ɹ æ f ɪ s t
 telegraphist	t ɛ l ə ɡ ɹ æ f ɪ s t
 telegraphy	t ə l ɛ ɡ ɹ ə f i
@@ -61704,8 +62221,8 @@ temp	t ɛ m p
 tempeh	t ɛ m p e ɪ
 temper	t ɛ m p ɚ
 tempera	t ɛ m p ə ɹ ə
-temperament	t ɛ m p ə ɹ m ə n t
-temperament	t ɛ m p ə ɹ ə m ə n t
+temperament	t ɛ m p ɚ m ə n t
+temperament	t ɛ m p ɚ ə m ə n t
 temperament	t ɛ m p ɹ ə m ə n t
 temperance	t ɛ m p ə ɹ ə n s
 temperate	t ɛ m p ə ɹ ə t
@@ -61777,6 +62294,7 @@ tenet	t ɛ n ɪ t
 tenge	t ɛ ŋ ɡ e ɪ
 tengrism	t ɛ ŋ ɡ ɹ ɪ z ə m
 tengwar	t ɛ ŋ ɡ w ɑ ɹ
+teniposide	t ɛ n ɪ p ə s a ɪ d
 tenkasi	t̪ ɛ n k aː s i
 tennessee	t ɛ n ə s iː
 tennessine	t ɛ n ə s iː n
@@ -61801,7 +62319,7 @@ tensores	t ɛ n s ɔ ɹ i z
 tent	t ɛ n t
 tent	t ɪ n t
 tentacle	t ɛ n t ə k ə l
-tentacle	t ɛ n t ɨ k ə l
+tentacle	t ɛ n t ɪ k ə l
 tentacular	t ɛ n t æ k j uː l ə ɹ
 tentative	t ɛ n t ə t ɪ v
 tentatively	t ɛ n t ə t ɪ v l i
@@ -61879,7 +62397,7 @@ terminological	t ɜ ɹ m ə n ə l ɒ d͡ʒ ɪ k ə l
 terminologist	t ɛː ɹ m ɪ n ɑ l ɑ d͡ʒ ɪ s t
 terminology	t ɚ m ə n ɑ l ə d͡ʒ i
 termitarium	t ɜ ɹ m ɪ t ɛ ə ɹ i ə m
-termless	t ɝ m l ɨ s
+termless	t ɝ m l ɪ s
 terms	t ɝ m z
 tern	t ɝ n
 ternary	t ɝ n ə ɹ i
@@ -61907,6 +62425,8 @@ terrestrial	t ə ɹ ɛ s t ɹ i ə l
 terrestrious	t ə ɹ ɛ s t ɹ i ə s
 terret	t ɛ ɹ ɪ t
 terrible	t ɛ ɚ b ə l
+terrible	t ɛ ɹ ə b ə l
+terrible	t ɛ ɹ ɪ b ə l
 terrible	t ɝ b ə l
 terribler	t ɛ ɹ ɪ b ə l ə ɹ
 terribly	t ɛ ɹ ɪ b l i
@@ -62039,6 +62559,7 @@ texture	t ɛ k s t͡ʃ ə ɹ
 texture	t ɛ k ʃ t͡ʃ ə ɹ
 textured	t ɛ k s t͡ʃ ɚ d
 textured	t ɛ k ʃ t͡ʃ ɚ d
+tezosentan	t ɛ z ə ʊ s ɛ n t æ n
 th'	ð
 th'	ð ə
 th'are	ð ɑː ɹ
@@ -62082,12 +62603,14 @@ thanjavur	θ ʌ n d͡ʒ ɑ v ʊ ɹ
 thank	θ æ ŋ k
 thanked	θ æ ŋ k t
 thankful	θ æ ŋ k f ə l
+thanks	ð æ ŋ k s
 thanks	θ æ ŋ k s
 thanksgiving	θ æ ŋ k s ɡ ɪ v ɪ ŋ
 thanky	θ æ ŋ k i
 thao	θ a ʊ
 that	ð æ t
 that'd	ð æ d
+that'd	ð æ t ə d
 that're	ð ə t ɚ
 that's	ð æ t s
 that've	ð ə t ə v
@@ -62128,6 +62651,7 @@ theine	t e ɪ iː n
 theine	θ e ɪ iː n
 theine	θ iː iː n
 theinism	θ iː ɪ n ɪ z ə m
+their	ð ɚ
 their	ð ɛ ɚ
 theirs	ð ɛ ɚ z
 theirs	ð ɛ ɹ z
@@ -62147,7 +62671,7 @@ thematic	θ ɪ m æ t ɪ k
 thematise	θ iː m ə t a ɪ z
 thembo	ð ɛ m b o ʊ
 theme	θ iː m
-themis	θ iː m ɨ s
+themis	θ iː m ɪ s
 themself	ð ɛ m s ɛ l f
 themselves	ð ə m s ɛ l v z
 themselves	ð ɛ m s ɛ l v z
@@ -62174,6 +62698,7 @@ theological	θ i ə l ɑ d͡ʒ ɪ k l
 theology	θ i ɒ l ə d͡ʒ i
 theomachist	θ i ɑ m æ k ɪ s t
 theomachy	θ i ɑ m ə k i
+theophilus	θ iː ɒ f ɪ l ə s
 theophylline	θ i ɑ f ə l ɪ n
 theopneust	θ ɪ ə p n j uː s t
 theorbo	θ i ɔ ɹ b o ʊ
@@ -62212,11 +62737,11 @@ thereatop	ð ɛ ə ɹ ə t ɒ p
 therebehind	ð ɛ ə b ɪ h a ɪ n d
 thereby	ð ɛ ɹ b a ɪ
 therefor	ð ɛ ə ɹ f ɔ ɹ
-therefore	ð ɛ ə ɹ f ɔ ɹ
+therefore	ð ɛ ɚ f ɔ ɹ
 therefrom	ð e ə f ɹ ɒ m
 therein	ð e ə ɹ ɪ n
 theremin	θ ɛ ə ɹ ə m ɪ n
-theremin	θ ɛ ɹ ɨ m ɪ n
+theremin	θ ɛ ɹ ɪ m ɪ n
 thereof	ð ɛ ɹ ʌ v
 thereout	ð ɛ ə ɹ a ʊ t
 thereto	ð ɛ ɚ t uː
@@ -62389,6 +62914,7 @@ thoroughly	θ ʌ ɹ ə l i
 thoroughness	θ ɜ ɹ o ʊ n ə s
 thoroughness	θ ʌ ɹ o ʊ n ə s
 thorp	θ ɔ ɹ p
+thorpe	θ ɔ ɹ p
 those	ð o ʊ z
 those're	ð o ʊ z ɚ
 those've	ð o ʊ z ə v
@@ -62594,11 +63120,13 @@ tiberius	t ɪ b ɛ ɹ i ʊ s
 tibet	t ə b e t
 tibet	t ɪ b e t
 tibetan	t ɪ b ɛ t n̩
+tibia	t ɪ b i ə
 tibial	t ɪ b i ə l
-tibicos	t ɨ b iː k o ʊ s
+tibicos	t ɪ b iː k o ʊ s
 tic	t ɪ k
+tical	t iː k ə l
 tical	t ɪ k ɑː l
-tical	t ɪ k ə l
+tical	t ɪ k ɔː l
 ticarcillin	t a ɪ k ɑ ɹ s ɪ l ɪ n
 tice	t a ɪ s
 tich	t ɪ t͡ʃ
@@ -62616,6 +63144,7 @@ ticklishness	t ɪ k l ɪ ʃ n ɛ s
 ticks	t ɪ k s
 ticrynafen	t ɪ k ɹ ɪ n ə f ɛ n
 tics	t ɪ k s
+tid	t ɪ d
 tidal	t a ɪ d ə l
 tidbit	t ɪ d b ɪ t
 tiddly	t ɪ d l i
@@ -62874,6 +63403,7 @@ tlaloc	t l ə l o ʊ k
 tlaxcala	t l ɑː s k ɑː l ə
 tlaxcala	t l ɑː ʃ k ɑː l ə
 tlayuda	t l ɑ j u d ə
+tlemcen	t l ɛ m s ɛ n
 tlingit	k l ɪ ŋ k ɪ t
 tlingit	t l ɪ ŋ ɡ ɪ t
 tmesis	m iː s ɪ s
@@ -62958,6 +63488,7 @@ tokenize	t o ʊ k ə n a ɪ z
 toki	t o ʊ k i
 toki	t ə ʊ k i
 tokin	t ə ʊ k ɪ n
+tokkaebi	t o ʊ k e ɪ b i
 tokomaru	t ə ʊ k ə ʊ m ɑː ɹ uː
 tokophobia	t ə ʊ k ə f ə ʊ b i ə
 tokoroa	t ə ʊ k ə ʊ ɹ ə ʊ ə
@@ -62998,7 +63529,6 @@ toman	t o ʊ m ə n
 toman	t ʊ m ə n
 toman	t ʌ m ə n
 tomato	t ə m e ɪ t o ʊ
-tomato	t ə m ɑː t o ʊ
 tomb	t u m
 tombal	t uː m b ə l
 tombal	t uː m ə l
@@ -63061,7 +63591,7 @@ too	t u
 toodeloo	t uː d ə l uː
 tooele	t uː ɛ l ə
 took	t ʊ k
-tool	t uː l
+tool	t u l
 toolbox	t uː l b ɑ k s
 tools	t uː l z
 toomey	t uː m i
@@ -63097,6 +63627,7 @@ tophet	t o ʊ f ɪ t
 topi	t ə ʊ p i
 topiary	t o ʊ p i ɛ ə ɹ i
 topic	t ɑ p ɪ k
+topical	t ɑ p ɪ k ə l
 topics	t ɑ p ɪ k s
 topmost	t ɑ p m o ʊ s t
 topography	t ə p ɑ ɡ ɹ ə f i
@@ -63157,7 +63688,7 @@ torsion	t o r ʒ ə n
 torsion	t o r ʒ ɪ n
 torsk	t ɔ ɹ s k
 torso	t ɔ ɹ s o ʊ
-tort	t ɔ ɹ t
+tort	t o ɹ t
 torte	t ɔ ɹ t
 tortellini	t ɔ ɹ t ə l i n i
 tortfeasance	t ɔ ə ɹ t f iː z ə n s
@@ -63167,11 +63698,12 @@ tortile	t ɔː t a ɪ l
 tortilla	t ɔ ɹ t i j ə
 tortilla	t ɔ ɹ t i ə
 tortious	t ɔ ɹ ʃ ə s
-tortoise	t ɔː ɹ t ə s
+tortoise	t ɔ ɹ ɾ ə s
 tortoiseshell	t ɔː ɹ t ə s ʃ ɛ l
 tortoiseshell	t ɔː ɹ t ə ʃ ɛ l
 tortola	t o ɹ t o ʊ l ə
 tortoni	t ɔ ɹ t o ʊ n i
+torts	t o ɹ t s
 tortuous	t ɔ ɹ t͡ʃ u ə s
 torture	t ɔ ɹ t͡ʃ ɚ
 tortured	t ɔ ɹ t͡ʃ ɚ d
@@ -63191,7 +63723,7 @@ tossy	t ɒ s i
 tot	t ɑ t
 total	t o ʊ t ə l
 totalitarian	t o ʊ t ə l ɪ t ɛ ɹ i ə n
-totality	t o ʊ t æ l ɨ t i
+totality	t o ʊ t æ l ɪ t i
 totally	t o ʊ t ə l i
 totalness	t ə ʊ t ə l n ə s
 totchos	t ɑ t͡ʃ o ʊ z
@@ -63342,7 +63874,6 @@ trader	t ɹ e ɪ ɾ ɚ
 trades	t ɹ e ɪ d z
 tradescantia	t ɹ æ d ɪ s k æ n t i ə
 trading	t ɹ e ɪ d ɪ ŋ
-tradition	t ɹ ə d ɪ ʃ n̩
 tradition	t ɹ ə d ɪ ʃ ə n
 traditional	t ɹ ə d ɪ ʃ n ə l
 traditional	t ɹ ə d ɪ ʃ ə n ə l
@@ -63374,7 +63905,7 @@ trainees	t ɹ e ɪ n i z
 trainer	t ɹ e ɪ n ɚ
 trainiac	t ɹ e ɪ n i æ k
 training	t ɹ e ɪ n ɪ ŋ
-traino	t ɹ æ e n ə ʉ
+traino	t ɹ e ɪ n o ʊ
 trains	t ɹ e ɪ n z
 traipse	t ɹ e ɪ p s
 traipse	t͡ʃ ɹ e ɪ p s
@@ -63421,7 +63952,7 @@ tranquil	t ɹ æ ŋ k w ɪ l
 tranquility	t r æ ŋ k w ɪ l ɪ t i
 tranquilize	t ɹ æ ŋ k w ɪ l a ɪ z
 tranquilizing	t ɹ æ ŋ k w ɪ l a ɪ z ɪ ŋ
-tranquillity	t r æ ŋ k w ɪ l ɪ t i
+tranquillity	t ɹ æ ŋ k w ɪ l ɪ t i
 trans	t ɹ æ n z
 transact	t ɹ æ n z æ k t
 transaction	t ɹ æ n z æ k ʃ ə n
@@ -63652,7 +64183,7 @@ treechange	t ɹ i t͡ʃ e ɪ n d͡ʒ
 treehouse	t ɹ iː h a ʊ s
 treemapping	t ɹ iː m æ p ɪ ŋ
 treen	t ɹ iː n
-treeness	t ɹ iː n ɨ s
+treeness	t ɹ iː n ɪ s
 treenware	t ɹ iː n w ɛ ə ɹ
 trees	t ɹ iː z
 treey	t ɹ i i
@@ -63709,6 +64240,8 @@ trepidation	t ɹ ɛ p ɪ d e ɪ ʃ ə n
 trespass	t ɹ ɛ s p æ s
 tress	t ɹ ɛ s
 tressel	t ɹ ɛ s ə l
+tressure	t ɹ ɛ s j ʊ ə ɹ
+tressure	t ɹ ɛ ʃ ə ɹ
 tressy	t ɹ ɛ s i
 trestle	t ɹ ɛ s ə l
 trestolone	t ɹ ɛ s t ə l o ʊ n
@@ -63783,6 +64316,7 @@ tricks	t ɹ ɪ k s
 tricky	t ɹ ɪ k i
 triclosan	t ɹ ɪ k l ə s æ n
 tricot	t ɹ i k o ʊ
+tricrotous	t ɹ a ɪ k ɹ ə t ə s
 tricuspid	t ɹ a ɪ k ʌ s p ɪ d
 tricycle	t ɹ a ɪ s ɪ k ə l
 tridem	t ɹ a ɪ d ə m
@@ -63880,6 +64414,7 @@ triplicity	t ɹ ɪ p l ɪ s ɪ t i
 tripod	t ɹ a ɪ p ɑ d
 tripoli	t ɹ ɪ p ə l i
 tripolitan	t ɹ ɪ p ɒ l ɪ t ə n
+tripolitania	t ɹ ɪ p ə l ɪ t e ɪ n i ə
 tripped	t ɹ ɪ p t
 tripping	t ɹ ɪ p ɪ ŋ
 trippy	t ɹ ɪ p i
@@ -63989,13 +64524,13 @@ trophæal	t ɹ o ʊ f i ə l
 tropic	t ɹ ɒ p ɪ k
 tropical	t ɹ o ʊ p ɪ k ə l
 tropical	t ɹ ɑ p ɪ k ə l
-tropical	t ɹ ɒ p ɪ k ə l
 tropicalize	t ɹ ɑ p ɪ k ə l a ɪ z
 tropicamide	t ɹ ə p ɪ k ə m a ɪ d
 tropicbird	t ɹ ɒ p ɪ k b ɜ ɹ d
 tropisetron	t ɹ o ʊ p ɪ s ə t ɹ ɑ n
 tropism	t ɹ o ʊ p ɪ z ə m
 tropologize	t ɹ ə p ɒ l ə d͡ʒ a ɪ z
+tropomorphic	t ɹ o ʊ p ə m ɔ ɹ f ɪ k
 tropomyosin	t ɹ o ʊ p ə m a ɪ ə s ɪ n
 tropomyosin	t ɹ ɑ p ə m a ɪ ə s ɪ n
 troppo	t ɹ ɒ p ə ʊ
@@ -64088,7 +64623,6 @@ truthfully	t ɹ uː θ f ə l i
 truths	t ɹ uː ð z
 truths	t ɹ uː θ s
 try	t ɹ a ɪ
-try	t͡ʃ ɹ a ɪ
 tryhard	t ɹ a ɪ h ɑ ɹ d
 trying	t ɹ a ɪ ɪ ŋ
 tryke	t ɹ a ɪ k
@@ -64123,6 +64657,7 @@ tsatlee	t s æ t l iː
 tsatske	t s ɑ t s k ə
 tschinke	t͡ʃ ɪ ŋ k ə
 tse	s i
+tsenacommacah	s ɛ n ə k ɒ m ə k ə
 tsetse	s i t s i
 tsetse	t i t s i
 tsetse	t s i t s i
@@ -64154,6 +64689,8 @@ tsuridashi	t s uː ɹ i d ɑː ʃ i
 tsuriotoshi	t s uː ɹ i o ʊ t o ʊ ʃ i
 tsuris	t s uː ɹ ɪ s
 tsuris	t s ʊ ɹ ɪ s
+tsushima	s uː ʃ iː m ə
+tsushima	t s uː ʃ iː m ə
 tsutaezori	t s uː t ɑː e ɪ z ɔː ɹ i
 tsutsugamushi	t s u t s u ɡ æ m uː ʃ iː
 tsuyuharai	t s uː j uː h ɑː ɹ a ɪ
@@ -64172,6 +64709,7 @@ tubby	t ʌ b i
 tube	t j uː b
 tubelight	t j uː b l a ɪ t
 tuber	t u b ɚ
+tuberculosis	t u b ɚ k j ʊ l o ʊ s ɪ s
 tuberose	t u b ə ɹ o ʊ z
 tuberous	t j uː b ə ɹ ə s
 tubes	t uː b z
@@ -64199,6 +64737,7 @@ tufty	t ʌ f t i
 tug	t ʌ ɡ
 tugboat	t ʌ ɡ b o ʊ t
 tugged	t ʌ ɡ d
+tuggeranong	t ʌ ɡ ɹ ə n ɒ ŋ
 tugging	t ʌ ɡ ɪ ŋ
 tugs	t ʌ ɡ z
 tui	t uː i
@@ -64253,7 +64792,6 @@ tuna	t u n ə
 tundish	t ʌ n d ɪ ʃ
 tundra	t ʌ n d ɹ ə
 tune	t j u n
-tune	t u n
 tuned	t j uː n d
 tuner	t uː n ɚ
 tunes	t j uː n s
@@ -64269,7 +64807,10 @@ tunicle	t j uː n ɪ k ə l
 tuning	t j uː n ɪ ŋ
 tunis	t uː n ə s
 tunisia	t u n i ʒ ə
+tunisian	t uː n ɪ z i ə n
+tunisian	t uː n ɪ ʒ ə n
 tunnel	t ʌ n ə l
+tunny	t ʌ n i
 tunxi	t ʊ n ʃ iː
 tuoba	t w o ʊ b ɑː
 tup	t ʌ p
@@ -64296,6 +64837,7 @@ turbulence	t ɝ b j ə l ə n s
 turbulent	t ɝ b j ə l ə n t
 turd	t ɝ d
 turdetani	t ʊ ə ɹ d ɛ t ɑ n i
+turdetanian	t ɜː ɹ d ɪ t e ɪ n i ə n
 turdmuffin	t ɜː ɹ d m ʌ f ɪ n
 turducken	t ɝ d ʌ k ə n
 tureen	t j u ɹ i n
@@ -64318,9 +64860,10 @@ turkmen	t ɝ k m ə n
 turkmenistan	t ɚ k m ɛ n ɪ s t æ n
 turkwoman	t ɜ ɹ k w ʊ m ə n
 turlet	t ɝː l ɪ t
+turley	t ɤ l iː
 turmeric	t uː m ə ɹ ɪ k
 turmeric	t ɜ ɹ m ə ɹ ɪ k
-turn	t ɝ n
+turn	t ɝ ɳ
 turnaround	t ɜː ɹ n ə ɹ a ʊ n d
 turncoat	t ɝ n k o ʊ t
 turned	t ɝ n d
@@ -64345,6 +64888,7 @@ turret	t ʌ ɹ ɪ t
 turribant	t ɜː ɹ ɪ b ə n t
 turribant	t ʌ ɹ ɪ b ə n t
 turriff	t ɜ ɹ ɪ f
+turritella	t ʌ ɹ ɪ t ɛ l ə
 turron	t ə ɹ ɒ n
 turtle	t ɝ t l̩
 tuscaloosa	t ʌ s k ə l uː s ə
@@ -64461,6 +65005,7 @@ twincest	t w ɪ n s ɛ s t
 twine	t w a ɪ n
 twinge	t w ɪ n d͡ʒ
 twink	t w ɪ ŋ k
+twinkhon	t w ɪ ŋ k h ʌ n
 twinkle	t w ɪ ŋ k ə l
 twinkling	t w ɪ ŋ k l ɪ ŋ
 twins	t w ɪ n z
@@ -64499,6 +65044,7 @@ tyebble	t͡ʃ ɛ b ə l
 tyek	t j ɛ k
 tying	t a ɪ ɪ ŋ
 tyke	t a ɪ k
+tykhana	t a ɪ k ɑː n ə
 tylenol	t a ɪ l ə n ɑ l
 tyler	t a ɪ l ɚ
 tympan	t ɪ m p ə n
@@ -64660,7 +65206,7 @@ ulster	ʌ l s t ɚ
 ulsterette	ʌ l s t ə ɹ ɛ t
 ulterior	ʌ l t ɪ ɚ i ɚ
 ultimate	ʌ l t ə m ɪ t
-ultimately	ʌ l t ɪ m ə t l i
+ultimately	ʌ l t ə m ə t l i
 ultimation	ʌ l t ɪ m e ɪ ʃ ə n
 ultimatum	ʌ l t ɪ m e ɪ t ə m
 ultra	ʌ l t ɹ ə
@@ -64718,6 +65264,7 @@ umich	j u m ɪ ʃ
 umlaut	u m l a ʊ t
 umlaut	ʊ m l a ʊ t
 ummah	ʊ m ə
+umno	ʌ m n o ʊ
 ump	ʌ m p
 umpteenth	ʌ m p t iː n θ
 umwelt	ʊ m v ɛ l t
@@ -64839,7 +65386,7 @@ unclutch	ʌ n k l ʌ t͡ʃ
 uncoif	ʌ n k w ɑː f
 uncoif	ʌ n k ɔ ɪ f
 uncoil	ʌ n k ɔ ɪ ə l
-uncollectible	ʌ n k ə l ɛ k t ɨ b l̩
+uncollectible	ʌ n k ə l ɛ k t ɪ b l̩
 uncomfortable	ʌ n k ʌ m f t ɚ b ə l
 uncomfortable	ʌ n k ʌ m f ɚ t ə b ə l
 uncommon	ʌ n k ɒ m ə n
@@ -64870,8 +65417,8 @@ uncrook	ʌ n k ɹ ʊ k
 unction	ʌ ŋ k ʃ ə n
 unctional	ʌ ŋ k t͡ʃ n ə l
 unctional	ʌ ŋ k t͡ʃ ə n ə l
-unctuous	ʌ n k t j u ə s
-unctuous	ʌ n k t͡ʃ u ə s
+unctuous	ʌ ŋ k t ʃ ə s
+unctuous	ʌ ŋ k t ʃ ə w ə s
 unctuousness	ʌ ŋ k t͡ʃ u ə s n ə s
 und	ʌ n d
 undead	ʌ n d ɛ d
@@ -64894,9 +65441,9 @@ undercarriage	ʌ n d ɚ k ɛ ɹ ɪ d͡ʒ
 undercook	ʌ n d ɚ k ʊ k
 undercover	ʌ n d ə ɹ k ʌ v ə ɹ
 undercurrent	ʌ n d ɚ k ʌ ɹ ə n t
-underestimate	ʌ n d ɚ ɛ s t ɨ m e ɪ t
-underestimate	ʌ n d ɚ ɛ s t ɨ m ə t
-underestimate	ʌ n d ɚ ɛ s t ɨ m ɨ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m e ɪ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ə t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ɪ t
 underfire	ʌ n d ɚ f a ɪ ə ɹ
 underfired	ʌ n d ɚ f a ɪ ə ɹ d
 underfiring	ʌ n d ɚ f a ɪ ə ɹ ɪ ŋ
@@ -64918,6 +65465,7 @@ underlip	ʌ n d ɚ l ɪ p
 underlook	ʌ n d ɚ l ʊ k
 underly	ʌ n d ə ɹ l a ɪ
 underly	ʌ n d ə ɹ l i
+undermine	ʌ n d ɚ m a ɪ n
 underneath	ʌ n d ɚ n i ð
 underneath	ʌ n d ɚ n i θ
 underpants	ʌ n d ə ɹ p æ n t s
@@ -64943,7 +65491,7 @@ undertime	ʌ n d ə ɹ t a ɪ̯ m
 undertime	ʌ n d ɚ t a ɪ̯ m
 undertone	ʌ n d ə ɹ t ə ʊ n
 undertook	ʌ n d ə ɹ t ʊ k
-underutilize	ʌ n d ɚ j uː t ɨ l a ɪ z
+underutilize	ʌ n d ɚ j uː t ɪ l a ɪ z
 undervalue	ʌ n d ə ɹ v æ l j u
 underverse	ʌ n d ə ɹ v ɜː ɹ s
 underwater	ʌ n d ɚ w ɔ t ə ɹ
@@ -65004,7 +65552,7 @@ unenthusiastic	ʌ n ɛ n θ j uː z i æ s t ɪ k
 unequal	ʌ n iː k w ə l
 unequivocable	ʌ n ɪ̈ k w ɪ v ə k b ə b ə l
 unequivocably	ʌ n ɪ̈ k w ɪ v ə k ə b l i
-unequivocal	ʌ n ɪ̈ k w ɪ v ə k ə l
+unequivocal	ʌ n ɪ k w ɪ v ə k ə l
 unequivocally	ʌ n ɪ̈ k w ɪ v ə k ə l i
 unergative	ʌ n ɝ ɡ ə t ɪ v
 unergatives	ʌ n ɜː ɹ ɡ ə t ɪ v z
@@ -65078,7 +65626,7 @@ uniat	j uː n iː ɪ t
 uniate	j u n i e ɪ t
 uniate	j u n i ɪ t
 unible	j uː n ɪ b ə l
-unicameral	j u n ɨ k æ m ə ɹ ə l
+unicameral	j u n ɪ k æ m ə ɹ ə l
 unicate	j uː n ɪ k ə t
 unicef	j u n ə s ɛ f
 unicellular	j uː n ɪ s ɛ l j ʊ l ə ɹ
@@ -65106,7 +65654,7 @@ uninformed	ʌ n ɪ n f ɔ ɹ m d
 uninspired	ʌ n ɪ n s p a ɪ ə d
 uninspiring	ʌ n ɪ n s p a ɪ ɹ ɪ ŋ
 unintelligent	ʌ n ə n t ɛ l ə d͡ʒ ə n t
-unintelligible	ʌ n ɪ n t ɛ l ɨ d͡ʒ ɨ b ə l
+unintelligible	ʌ n ɪ n t ɛ l ɪ d͡ʒ ɪ b ə l
 unintended	ʌ n ɪ n t ɛ n d ɪ d
 unintentional	ʌ n ɪ n t ɛ n ʃ ə n ə l
 uninvite	ʌ n ɪ n v a ɪ t
@@ -65123,8 +65671,8 @@ unique	j uː n iː k
 unique	j ə n iː k
 uniquity	j u n ɪ k w ɪ t i
 unisex	j u n ə s ɛ k s
-unison	j u n ɨ s ə n
-unison	j u n ɨ z ə n
+unison	j u n ɪ s ə n
+unison	j u n ɪ z ə n
 unit	j uː n ɪ t
 unite	j u n a ɪ t
 unite	j ʊ n a ɪ t
@@ -65145,6 +65693,7 @@ univocal	j uː n ɪ v o ʊ k ə l
 univocal	j uː n ɪ v ə k ə l
 univocity	j uː n ɪ v ɒ s ɪ t i
 unix	j uː n ɪ k s
+unjam	ʌ n d͡ʒ æ m
 unjust	ʌ n d͡ʒ ʌ s t
 unjustly	ʌ n d͡ʒ ʌ s t l i
 unked	ʌ n k ɛ d
@@ -65160,6 +65709,8 @@ unknown	ʌ n n o ʊ n
 unlaid	ʌ n l e ɪ d
 unlead	ʌ n l ɛ d
 unlearn	ʌ n l ɝ n
+unlearned	ʌ n l ɝ n d
+unlearned	ʌ n l ɝ n ɪ d
 unleash	ʌ n l i ʃ
 unless	ə n l ɛ s
 unless	ɪ n l ɛ s
@@ -65212,6 +65763,7 @@ unnoticed	ʌ n n o ʊ t ɪ s t
 unnun	ʌ n n ʌ n
 unoared	ʌ n ɔː ɹ d
 unobtainium	ʌ n ə b t e ɪ n i ə m
+unobtrusive	ʌ n ə b t ɹ u s ɪ v
 unobtrusively	ʌ n ə b t ɹ uː s ɪ v l i
 unorthodox	ʌ n ɔ ɹ θ ə d ɑ k s
 unoverridden	ʌ n o ʊ v ɚ ɹ ɪ d ə n
@@ -65252,6 +65804,7 @@ unrecognizable	ʌ n ɹ ɛ k ə n a ɪ z ə b ə l
 unrecognizable	ʌ n ɹ ɛ k ə ɡ n a ɪ z ə b ə l
 unrecuring	ʌ n ɹ ɪ k j ʊ ə ɹ ɪ ŋ
 unredressable	ʌ n ɹ ɪ d ɹ ɛ s ə b ə l
+unreliable	ʌ n ɹ ə l a ɪ ə b ə l
 unreluctant	ʌ n ɹ ɪ l ʌ k t ə n t
 unremitting	ʌ n ɹ ɪ m ɪ ɾ ɪ ŋ
 unrequited	ʌ n ɹ ə k w a ɪ t ɪ d
@@ -65371,13 +65924,15 @@ unwittingly	ʌ n w ɪ t ɪ ŋ l i
 unwonted	ʌ n w ɑ n t ɪ d
 unwontedly	ʊ n w o ʊ n t ɪ d l i
 unworthy	ʌ n w ɝ ð i
-unwound	ʌ n w ɑ ʊ n d
+unwound	ʌ n w a ʊ̯ n d
+unwound	ʌ n w uː n d
 unwrap	ʌ n ɹ æ p
 unwroken	ʌ n ɹ ə ʊ k ə n
 unyoke	ʌ n j o ʊ k
 uotsuri	uː o ʊ t s ʊ ə ɹ i
 up	ʌ p
 upanayana	uː p ə n ɑː j ə n ə
+upazila	uː p ɒ d͡ʒ ɪ l ə
 upbar	ʌ p b ɑː ɹ
 upbind	ʌ p b a ɪ n d
 upbraid	ʌ p b ɹ e ɪ d
@@ -65598,13 +66153,14 @@ uterus	j uː t ə ɹ ə s
 uther	j uː θ ə ɹ
 uther	uː θ ə ɹ
 utica	j uː t ɪ k ə
+util	j uː t ɪ l
 utilitarian	j u t ɪ l ə t ɛ ɹ i ə n
 utilitarianist	j u t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianist	j ʊ t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianly	j u t ɪ l ɪ t e ɪ ɹ i ə n l i
 utility	j uː t ɪ l ɪ t i
 utility	j ə t ɪ l ɪ t i
-utilize	j uː t ɨ l a ɪ z
+utilize	j uː t ɪ l a ɪ z
 utmost	ʌ t m o ʊ̯ s t
 utonian	j uː t o ʊ n i ə n
 utopia	j u t o ʊ p i ə
@@ -65732,6 +66288,7 @@ valency	v e ɪ l ə n s i
 valent	v e ɪ l ə n t
 valentine	v a l ə n t a ɪ n
 valentine	v æ l ə n t a ɪ n
+valeria	v ə l ɪ ə ɹ i ə
 valet	v æ l e ɪ
 valet	v æ l ɪ t
 valetudinarian	v æ l ə t uː d ə n ɛ ɹ i ə n
@@ -65744,6 +66301,7 @@ valid	v æ l ɪ d
 validate	v æ l ɪ d e ɪ t
 validation	v æ l ə d e ɪ ʃ ə n
 validify	v ə l ɪ d ɪ f a ɪ
+valinemia	v e ɪ l ɪ n iː m i ə
 valise	v ə l iː z
 valium	v æ l i ə m
 valium	v æ l j ə m
@@ -65760,10 +66318,12 @@ vallejo	v ə l e ɪ ə ʊ
 valletta	v ə l ɛ t ə
 valley	v æ l i
 valleys	v æ l i z
+vallum	v æ l ə m
 valnemulin	v æ l n ɛ m j ʊ l ɪ n
 valor	v æ l ɚ
 valorize	v æ l ə r a ɪ z
 valour	v æ l ɚ
+valparaíso	v ɑ l p ɑ ɹ a ɪ iː s o ʊ
 valproate	v æ l p ɹ o ʊ e ɪ t
 valsartan	v æ l s ɑ ɹ t æ n
 valsartan	v æ l s ɑ ɹ t ə n
@@ -65921,6 +66481,7 @@ vaxxer	v æ k s ɚ
 ve	v i
 veal	v iː l
 vector	v ɛ k t ɚ
+vectorize	v ɛ k t ə ɹ a ɪ z
 vecuronium	v ɛ k j ə ɹ o ʊ n i ə m
 veda	v e ɪ d ə
 vedette	v ə d ɛ t
@@ -65942,7 +66503,6 @@ vegas	v e ɪ ɡ ə z
 vegeburger	v ɛ d͡ʒ iː b ɜː ɹ ɡ ə ɹ
 vegetable	v ɛ d͡ʒ ə t ə b ə l
 vegetable	v ɛ t͡ʃ t ə b ə l
-vegetables	v ɛ d͡ʒ t ə b ə l z
 vegetables	v ɛ d͡ʒ ə t ə b ə l z
 vegetables	v ɛ t͡ʃ t ə b ə l z
 vegetal	v ɛ d͡ʒ ɪ̈ t l̩
@@ -66030,6 +66590,7 @@ venezuela	v ɛ n ɛ z w e ɪ l ə
 venezuela	v ɛ n ɪ z w e ɪ l ə
 vengeance	v ɛ n d͡ʒ ə n s
 vengeful	v e n ʒ f ə l
+vengence	v iː n iː n s
 venial	v iː n i ə l
 venice	v ɛ n ɪ s
 venicia	v ə n iː ʃ ə
@@ -66120,6 +66681,7 @@ verlan	v ɛ ə ɹ l ɑː n
 vermeer	v ɚ m ɛ ə ɹ
 vermeer	v ɚ m ɪ ə ɹ
 vermeil	v ɜ ˞ m ɪ l
+vermetid	v ɜː ɹ m ə t ɪ d
 vermiculate	v ɚ m ɪ k j ə l e ɪ t
 vermiculate	v ɚ m ɪ k j ə l ə t
 vermiculation	v ɚ m ɪ k j u l e ɪ ʃ ə n
@@ -66190,7 +66752,8 @@ vertiginous	v ɜː ɹ t ɪ d͡ʒ ɪ n ə s
 vertigo	v ɝ t ɪ ɡ o ʊ
 verts	v ɜː ɹ t s
 vertu	v əː t uː
-vervaeke	v ɝ v iː k i
+vervaeke	v ɚ v iː k i
+vervaeke	v ɝ v e ɪ k i
 vervain	v ɚ v e ɪ n
 verve	v ɝ v
 vervelle	v ɜ ɹ v ɛ l
@@ -66202,8 +66765,8 @@ vesical	v iː s ɪ k ə l
 vesical	v ɛ s ɪ k ə l
 vesicle	v iː s ɪ k ə l
 vesicle	v ɛ s ɪ k ə l
-vesicobullous	v ɛ s ɨ k o ʊ b ʊ l ə s
-vesicocele	v ɛ s ɨ k o ʊ s i l
+vesicobullous	v ɛ s ɪ k o ʊ b ʊ l ə s
+vesicocele	v ɛ s ɪ k o ʊ s i l
 vespasian	v ɛ s p e ɪ z i ə n
 vespasian	v ɛ s p e ɪ ʒ i ə n
 vesper	v ɛ s p ɚ
@@ -66241,14 +66804,15 @@ veterinarian	v ɛ ʔ n̩ ɛ ɹ i j ə n
 veterinary	v ɛ t ə ɹ ɪ n ɛ ɹ i
 veterinary	v ɛ t ɪ n ɛ ɹ i
 veterinary	v ɛ t ɹ ɪ n ɛ ɹ i
-vetiver	v ɛ t ɪ v ə
+vetiver	v ɛ t ə v ɚ
+vetiver	v ɛ t ɪ v ɚ
 vetkousie	f e ɪ t k o ʊ s i
 vetkousie	f ɛ t k o ʊ s i
 veto	v iː t o ʊ
 vetoed	v iː t ə ʊ d
 vets	v ɛ t s
 vetter	v ɛ t ɚ
-vetustity	v ə t u s t ɨ t i
+vetustity	v ə t u s t ɪ t i
 veuglaire	v ə ɡ l ɛ ə ɹ
 veurne	v ɜː ɹ n ə
 vevay	v iː v iː
@@ -66479,7 +67043,9 @@ viognier	v i o ʊ n j e ɪ
 viol	v a ɪ ə l
 viola	v a ɪ o ʊ l ə
 viola	v a ɪ ə l ə
+viola	v a ɪ ə ʊ l ə
 viola	v i o ʊ l ə
+viola	v i ə ʊ l ə
 viola	v ɪ o ʊ l ə
 violate	v a ɪ ə l e ɪ t
 violated	v a ɪ ə l e ɪ t ɪ d
@@ -66502,8 +67068,8 @@ viossa	v i ɒ s ə
 viossa	v ɪ j o ʊ̯ s ə
 vip	v ɪ p
 viper	v a ɪ p ɚ
-viraginous	v ɨ ɹ æ d͡ʒ ə n ə s
-viraginous	v ɨ ɹ æ d͡ʒ ɪ n ə s
+viraginous	v ɪ ɹ æ d͡ʒ ə n ə s
+viraginous	v ɪ ɹ æ d͡ʒ ɪ n ə s
 virago	v ɪ ɹ ɑː ɡ ə ʊ
 viral	v a ɪ ɹ ə l
 virally	v a ɪ ɹ ə l i
@@ -66541,6 +67107,7 @@ virtualize	v ɜː ɹ t j u ə l a ɪ z
 virtualize	v ɜː ɹ t͡ʃ u ə l a ɪ z
 virtue	v ɝ t͡ʃ u
 virtues	v əː t͡ʃ uː s
+virtuosity	v ɜː ɹ t j u ɒ s ɪ t i
 virtuoso	v ɝ t͡ʃ u o ʊ s o ʊ
 virtuous	v ɝ t͡ʃ u ə s
 virulence	v ɪ ɹ j ə l ə n s
@@ -66559,7 +67126,7 @@ visard	v ɪ z ə ɹ d
 visayas	v ɪ s a ɪ ə z
 viscacha	v ɪ s k ɑ t͡ʃ ə
 viscachera	v ɪ s k ɑ t͡ʃ ɛ ɹ ə
-visceral	v ɪ s ə ɹ ə l
+visceral	v ɪ s ɚ ə l
 viscerotonic	v ɪ s ə ɹ ə ʊ t ɒ n ɪ k
 viscose	v ɪ s k ə ʊ s
 viscosity	v ɪ s k ɑ s ɪ t i
@@ -66572,6 +67139,7 @@ visibility	v ɪ z ə b ɪ l ə t i
 visibility	v ɪ z ə b ɪ l ɪ t i
 visibility	v ɪ z ɪ b ɪ l ɪ t i
 visible	v ɪ z ə b ə l
+visibly	v ɪ z ə b l i
 visibly	v ɪ z ɪ b l i
 vision	v ɪ ʒ ə n
 visionary	v ɪ ʒ ə n ɛ ɹ i
@@ -66613,6 +67181,7 @@ vitrify	v ɪ t ɹ ɪ f a ɪ
 vitrine	v ə t ɹ iː n
 vitrine	v ɪ t ɹ iː n
 vitriol	v ɪ t ɹ i ə l
+vitrophyre	v ɪ t ɹ ə f a ɪ ə ɹ
 vituperate	v ə t j u p ə ɹ e ɪ t
 vituperate	v ə t j u p ə ɹ ə t
 vituperation	v a ɪ t j u p ə ɹ e ɪ ʃ ə n
@@ -66964,6 +67533,7 @@ wallis	w ɒ l ɪ s
 wallonia	w ə l ə ʊ n ɪ ə
 wallop	w ɑ l ə p
 walls	w ɔ l z
+walm	w ɑː m
 walm	w ɔː m
 walmartian	w ɔː l m ɑː ɹ ʃ ə n
 walnut	w ɑ l n ə t
@@ -67038,6 +67608,7 @@ want	w ɒ n t
 want	w ɔ n t
 want	w ʌ n t
 wantcha	w ʌ n t͡ʃ ə
+wanted	w ɑ n t ɪ d
 wanting	w ɑ n t ɪ ŋ
 wantok	w ɑ n t ɑ k
 wantokism	w ɑ n t ɒ k ɪ z ə m
@@ -67058,7 +67629,6 @@ waragi	w a ɹ ə d͡ʒ i
 waragi	w a ɹ ə ɡ i
 warble	w ɔ ɹ b l̩
 warbler	w ɔː ɹ b l ə ɹ
-warburg	v aː ɐ̯ b ʊ ʁ k
 warcraft	w ɔ ɹ k ɹ æ f t
 ward	w ɔ ɹ d
 warden	w ɔ ɹ d ə n
@@ -67126,7 +67696,6 @@ was	w ʌ z
 was't	w ɒ z t
 wasabi	w ə s ɑː b i
 wase	w e ɪ s
-wash	w ɑ ʃ
 wash	w ɔ ɹ ʃ
 wash	w ɔ ʃ
 washcloth	w ɔ ʃ k l ɔ θ
@@ -67178,6 +67747,7 @@ waterily	w ɔː t ɹ ɪ l i
 waterloo	w ɑ t ɚ l uː
 waterloo	w ɔ t ɚ l uː
 waterlooville	w ɔː t ə ɹ l uː v ɪ l
+watermelon	w ɑ t ə ɹ m ɛ l ə n
 watermelon	w ɔ t ə ɹ m ɛ l ə n
 waters	w ɔ t ɚ z
 watershed	w ɔ t ɚ ʃ ɛ d
@@ -67247,7 +67817,6 @@ weak	w iː k
 weaken	w i k ə n
 weakened	w i k ə n d
 weaker	w i k ɚ
-weakling	w iː k l ɨ ŋ ɡ
 weakling	w iː k l ɪ ŋ ɡ
 weakly	w iː k l i
 weakness	w iː k n ə s
@@ -67361,6 +67930,7 @@ weimar	v a ɪ m ɑ ɹ
 weimar	w a ɪ m ɑ ɹ
 weimaraner	v a ɪ m ə ɹ ɑː n ə ɹ
 weimarization	v a ɪ m ɑ ɹ a ɪ z e ɪ ʃ ə n
+weiqi	w e ɪ t ʃ iː
 weir	w ɪ ɹ
 weird	w i ɚ d
 weird	w ɪ ɚ d
@@ -67432,8 +68002,7 @@ wereleopard	w ɛ ɹ l ɛ p ɚ d
 wereleopard	w ɪ ɹ l ɛ p ɚ d
 werelion	w ɛ ɹ l a ɪ ə n
 werelion	w ɪ ɹ l a ɪ ə n
-weren't	w ɝ n t
-weren't	w ɝ ə n t
+weren't	w ɝ n̩ t
 wererat	w ɛ ɹ æ t
 wererat	w ɪ ɹ æ t
 weretiger	w ɛ ɹ t a ɪ ɡ ɚ
@@ -67441,6 +68010,8 @@ weretiger	w ɪ ɹ t a ɪ ɡ ɚ
 werewolf	w ɛ ə ɹ w ʊ l f
 werewolf	w ɜ ɹ w ʊ l f
 werewolf	w ɪ ə ɹ w ʊ l f
+wergeld	w ɛ ə ɹ ɡ ɛ l d
+wergeld	w ɜː ɹ ɡ ɛ l d
 wert	w ɝ t
 wes	w ɛ s
 wes	w ɛ z
@@ -67523,7 +68094,7 @@ what	w ʌ t
 what	ʍ ʌ t
 what'd	w ʌ d
 what'd	w ʌ t ə d
-what'd	w ʌ t ɨ d
+what'd	w ʌ t ɪ d
 what'll	h w ɒ t ə l
 what'll	h w ʌ t ə l
 what's	w ɑ t s
@@ -67531,6 +68102,7 @@ what's	w ʌ t s
 what's	ʍ ɑ t s
 what's	ʍ ʌ t s
 whataboutery	w ɒ t ə b a ʊ t ə ɹ i
+whataboutism	w ə t ə b a ʊ t ɪ z ə m
 whatcha	w ʌ t͡ʃ j ə
 whatcha	w ʌ t͡ʃ ə
 whatchamacallit	w ʌ t͡ʃ m ə k ɑ l ɪ t
@@ -67541,7 +68113,6 @@ whatever	w ʌ t ɛ v ɚ
 whatever's	w ʌ t ɛ v ɚ z
 whatnot	w ʌ t n ɑ t
 whatnot	ʍ ʌ t n ɑ t
-whatsapps	v ɔ t͡s ʔ ɛ p s
 whatsoever	h w ʌ t s o ʊ ɛ v ɚ
 whatten	w ɑ t ə n
 whatten	w ɒ t ə n
@@ -67733,6 +68304,8 @@ whitebeam	w a ɪ t b i m
 whiteboard	w a ɪ t b ɔː d
 whitechurch	w a ɪ t t͡ʃ ɜː ɹ t͡ʃ
 whitechurch	ʍ a ɪ t t͡ʃ ɜː ɹ t͡ʃ
+whitehall	w a ɪ t h ɔː l
+whitehall	ʍ a ɪ t h ɔː l
 whitelash	h w a ɪ t l æ ʃ
 whiten	h w a ɪ t n̩
 whiteness	w a ɪ t n ə s
@@ -67770,7 +68343,7 @@ whitwick	ʍ ɪ t w ɪ k
 whitworth	w ɪ t w ɜː r θ
 whitworth	w ɪ t ɜː r θ
 whiz	w ɪ z
-who	h uː
+who	h u
 who'da	h uː d ə
 who's	h uː z
 who's	ʍ uː z
@@ -67924,10 +68497,10 @@ wiktionary	w ɪ k t͡ʃ ə n ɛ ə ɹ i
 wiktionary	w ɪ k ʃ ə n ɛ ə ɹ i
 wilco	w ɪ l k o ʊ
 wild	w a ɪ l d
-wild	w a ɪ ə l d
 wildcat	w a ɪ ə l d k æ t
 wilde	w a ɪ l d
 wildebeest	w ɪ l d ə b i s t
+wilden	w a ɪ l d ə n
 wilder	w a ɪ l d ɚ
 wilder	w ɪ l d ɚ
 wilderness	w ɪ l d ɚ n ə s
@@ -68060,7 +68633,7 @@ winne	w ɪ n
 winner	w ɪ n ɚ
 winnie	w ɪ n i
 winning	w ɪ n ɪ ŋ
-winningest	w ɪ n ɪ ŋ ɨ s t
+winningest	w ɪ n ɪ ŋ ɪ s t
 winnings	w ɪ n ɪ ŋ z
 winnipeg	w ɪ n ə p ɛ ɡ
 winnipegger	w ɪ n ə p ɛ ɡ ə ɹ
@@ -68140,6 +68713,7 @@ with't	w ɪ θ t
 withal	w ɪ ð ɑ l
 withdraught	w ɪ θ d ɹ æ f t
 withdraw	w ɪ ð d ɹ ɔ
+withdraw	w ɪ θ d ɹ ɔ
 withdrawal	w ɪ ð d ɹ ɔː ə l
 withdrawal	w ɪ θ d ɹ ɔː ə l
 withdrawn	w ɪ ð d ɹ ɔː n
@@ -68161,8 +68735,9 @@ withheld	w ɪ ð h ɛ l d
 withheld	w ɪ θ h ɛ l d
 withhold	w ɪ ð h o ʊ l d
 withhold	w ɪ θ h o ʊ l d
-withholding	w ɪ ð h o ʊ l d i ŋ
-withholding	w ɪ θ h o ʊ l d i ŋ
+withholding	w ɪ ð h o ʊ l d ɪ ŋ
+withholding	w ɪ θ h o ʊ l d ɪ ŋ
+withiel	w ɪ ð j ə l
 withies	w ɪ ð i z
 withies	w ɪ θ i z
 within	w ɪ ð ɪ n
@@ -68201,6 +68776,9 @@ wizardly	w ɪ z ɚ d l i
 wizen	w ɪ z ə n
 wizened	w i z ə n d
 wizened	w ɪ z ə n d
+wlan	d ʌ b ə l j u l æ n
+wlan	w a ɪ j ə ɹ l ə s l æ n
+wlan	w a ɪ ɹ l ə s l æ n
 wo	w o
 wo	w ɔː
 woad	w o ʊ d
@@ -68209,6 +68787,7 @@ woah	w o ʊ
 woak	w o ʊ k
 wobbegong	w ɒ b ɪ ɡ ɒ ŋ
 wobble	w ɑ b l̩
+wobbly	w ɑ b ə l i
 woburn	w ə ʊ b ə ɹ n
 wodehouse	w ʊ d h a ʊ s
 wodehousian	w ʊ d h a ʊ s i ə n
@@ -68357,24 +68936,25 @@ wop	w ɒ p
 worcester	w ʊ s t ɚ
 worcesterberry	w ʊ s t ə ɹ b ɛ ɹ i
 worcestershire	w ɪ s t ɚ ʃ a ɪ ɚ
-worcestershire	w ɪ s t ɚ ʃ i ɹ
+worcestershire	w ɪ s t ɚ ʃ ɪ ɹ
 worcestershire	w ʊ s t ɚ ʃ a ɪ ɚ
-worcestershire	w ʊ s t ɚ ʃ i ɹ
 worcestershire	w ʊ s t ɚ ʃ ɚ
+worcestershire	w ʊ s t ɚ ʃ ɪ ɹ
 word	w ɝ d
 wordbook	w ɝ d b ʊ k
 wordform	w ɝ d f ɔ ɹ m
 wordforms	w ɝ d f ɔ ɹ m z
 words	w ɝ d z
 wordsmith	w ɝ d s m ɪ θ
+wordsmithing	w ɝ d s m ɪ θ ɪ ŋ
 wordster	w ɝ d s t ɚ
 wordy	w ɝ d i
 wore	w ɔ ɹ
 work	w øː k
-work	w ɔ ɪ̯ k
-work	w ɜ ɹ k
+work	w ɜ ɪ̯ k
 work	w ɜː k
 work	w ɜː ɹ k
+work	w ɝ k
 work	w ɵː k
 workaday	w ɜː ɹ k ə d e ɪ
 workamping	w ɝ k k æ m p ɪ ŋ
@@ -68383,6 +68963,7 @@ worked	w ɝ k t
 worker	w ɝ k ɚ
 workers	w ɝ k ɚ z
 workflow	w ɝ k f l o ʊ
+workforce	w ɝ k f o ɹ s
 working	w ɝ k ɪ ŋ
 workington	w ɜː ɹ k ɪ ŋ t ə n
 workiversary	w ɝ k ə v ɝ s ə ɹ i
@@ -68417,8 +68998,8 @@ worrisome	w ʌ ɹ i s ə m
 worry	w ə ʊ ɹ i
 worry	w ɝ i
 worry	w ʌ ɹ i
-worrywart	w ɝ i w ɔ ɹ t
-worrywart	w ʌ ɹ i w ɔ ɹ t
+worrywart	w ɚ i w o ɹ t
+worrywart	w ʌ ɹ i w o ɹ t
 worsbrough	w ɜː ɹ z b ɹ ə
 worse	w ɝ s
 worsen	w ɝ s n̩
@@ -68431,7 +69012,7 @@ worsley	w ɜː ɹ z l i
 worst	w ɝ s t
 worsted	w ɝ s t ɪ d
 worsted	w ʊ s t ɪ d
-wort	w ɔ r t
+wort	w o ɹ t
 wort	w ɝ t
 wortcunning	w ɝ t k ʌ n ɪ ŋ
 worth	w ɝ θ
@@ -68440,6 +69021,8 @@ worthless	w ɝ θ l ə s
 worthwhileness	w ɜː ɹ θ w a ɪ l n ə s
 worthwhileness	w ɜː ɹ θ ʍ a ɪ l n ə s
 worthy	w ɝ ð i
+worts	w o ɹ t s
+worts	w ɝ t s
 worty	w ɝ t i
 wot	w ɑ t
 wotcher	w ɒ t͡ʃ ə
@@ -68513,7 +69096,7 @@ wrestling	ɹ ɛ s l ɪ ŋ
 wrestling	ɹ ɛ s l̩ ɪ ŋ
 wrests	ɹ ɛ s t s
 wretch	ɹ ɛ t͡ʃ
-wretched	ɹ ɛ t͡ʃ ɪ d
+wretched	ɹ ɛ t͡ʃ ə d
 wretchedness	ɹ ɛ t͡ʃ ɪ d n ə s
 wrexham	ɹ ɛ k s ə m
 wrig	ɹ ɪ ɡ
@@ -68529,6 +69112,10 @@ wrinkled	ɹ ɪ ŋ k l̩ d
 wrinkledness	ɹ ɪ ŋ k ə l d n ə s
 wrinkliness	ɹ ɪ ŋ k ə l i n ə s
 wrinkly	ɹ ɪ ŋ k ə l i
+wriothesley	r a ɪ z l i
+wriothesley	r a ɪ ə θ s l i
+wriothesley	r ɒ t s l i
+wriothesley	r ɛ z l i
 wrist	ɹ ɪ s t
 wristband	ɹ ɪ s t b æ n d
 wristlet	ɹ ɪ s t l ə t
@@ -68546,7 +69133,6 @@ writhle	ɹ ɪ ð ə l
 writhled	ɹ ɪ ð ə l d
 writing	ɹ a ɪ t ɪ ŋ
 writings	ɹ a ɪ t ɪ ŋ z
-written	ɹ ɪ t ə n
 wrizled	ɹ ɪ z ə l d
 wrizzled	ɹ ɪ z ə l d
 wroclaw	v ɹ ɔ t s l ɑ f
@@ -68585,6 +69171,8 @@ wug	w ʌ ɡ
 wuhan	uː h ɑː n
 wuhan	w uː h ɑː n
 wuhu	w uː h uː
+wujiang	w u d͡ʒ j æ ŋ
+wujiang	w u d͡ʒ j ɑ ŋ
 wujiaqu	w uː d͡ʒ i ɑː t͡ʃ uː
 wulumuqi	w uː l uː m uː t͡ʃ iː
 wumao	w uː m a ʊ
@@ -68744,6 +69332,7 @@ xerocracy	z iː ɹ ɑ k ɹ ə s i
 xeromorphic	z ɪ ə ɹ ə m ɔ ɹ f ɪ k
 xerophyte	z ɪ ə ɹ ə ʊ f a ɪ t
 xerox	z iː ə ɹ ɑ k s
+xertz	z ɝ t s
 xerxes	z ɝ k s iː z
 xhosa	k o ʊ s ə
 xhosa	k ɔ s ə
@@ -68790,6 +69379,7 @@ xizang	ʃ iː z ɑː ŋ
 xmas	k ɹ ɪ s m ə s
 xmas	ɛ k s m ə s
 xoanon	z o ʊ ə n ɑ n
+xography	ɛ k s ɒ ɡ ɹ ə f i
 xoloitzcuintle	ʃ o ʊ l o ʊ iː t s k w iː n t l e ɪ
 xoloitzcuintli	ʃ o ʊ l o ʊ ɪ t s k w ɪ n t l i
 xor	k s o ɹ
@@ -68831,7 +69421,7 @@ y'ad	j æ d
 y'all	j ɔ l
 y'all'd	j ɔ l d
 y'all'd've	j ɔ l d ə v
-y'all'dn't've	j ɔ ɫᵈ n̩ t ɘ̆ v
+y'all'dn't've	j ɔ ɫᵈ n̩ t ə v
 y'are	j ɑː ɹ
 y'ave	j æ v
 y'ave	j ə v
@@ -68971,6 +69561,7 @@ yaws	j ɔː z
 yay	j e ɪ
 yayan	j ɑː j ɑː n
 yayo	j e ɪ o ʊ
+yclad	ɪ k l æ d
 yclept	ɪ k l ɛ p t
 ye	j e ɪ
 ye	j iː
@@ -69040,6 +69631,7 @@ yes	j ɛ s
 yes'm	j ɛ s ə m
 yeses	j ɛ s ɪ z
 yeshiva	j ə ʃ iː v ə
+yesn't	j ɛ s ə n t
 yesses	j ɛ s ɪ z
 yessir	j ɛ s s ɝ
 yessir	j ɛ sː ɝ
@@ -69169,7 +69761,6 @@ youngest	j ʌ ŋ ɡ ə s t
 youngin	j ʌ ŋ ɪ n
 youngling	j ʌ ŋ l ɪ ŋ
 youngster	j ʌ ŋ s t ɚ
-youngun	j ʌ ŋ ə n
 your	j ɔ ɹ
 your	j ɚ
 your	j ɝ
@@ -69266,6 +69857,7 @@ zach	z æ k
 zachary	z æ k ə ɹ i
 zack	z æ k
 zacks	z æ k s
+zaddy	z æ d i
 zadruga	z æ d ɹ uː ɡ ə
 zaffre	z æ f ə ɹ
 zafirlukast	z æ f ɪ ɹ l uː k æ s t
@@ -69295,14 +69887,14 @@ zamindar	z æ m ɪ n d ɑː ɹ
 zamindar	z ə m iː n d ɑː ɹ
 zamora	z ə m ɔ ɹ ə
 zamrock	z æ m ɹ ɑ k
-zamzummim	z a m z ʌ m m ɨ m
+zamzummim	z a m z ʌ m m ɪ m
 zanamivir	z ə n æ m ɪ v ɪ ɹ
 zander	z æ n d ə ɹ
 zandra	z æ n d ɹ ə
 zangi	z æ ŋ ɡ iː
 zangid	z æ ŋ ɡ ɪ d
 zante	z æ n t i
-zantedeschia	z æ n t ɨ d ɛ s k i ə
+zantedeschia	z æ n t ɪ d ɛ s k i ə
 zany	z e ɪ n i
 zanzibar	z æ n z ɪ b ɑː ɹ
 zap	z æ p
@@ -69354,6 +69946,7 @@ zelina	z ɛ l i n ə
 zellige	z ɛ l iː d͡ʒ
 zelophehad	z ɪ l ɒ f ɪ h æ d
 zelus	z iː l ə s
+zemlyanka	z ɛ m l i ɑ ŋ k ə
 zenana	z ə n ɑː n ə
 zenith	z i n ɪ θ
 zenithal	z i n ɪ θ ə l
@@ -69372,7 +69965,7 @@ zerahiah	z ɛ ɹ ə h a ɪ ə
 zerbert	z ɜː ɹ b ə ɹ t
 zerg	z ɜː ɹ ɡ
 zerk	z ɝ k
-zermatt	z ɚ m ɑ t
+zermatt	z ɝ m ɑ t
 zero	z i ɹ o ʊ
 zero	z ɪ ɚ o ʊ
 zeroth	z i ɹ o ʊ θ
@@ -69524,8 +70117,8 @@ zomedy	z ɑ m ə d i
 zonal	z ə ʊ n ə l
 zone	z o ʊ n
 zongdu	d z ʊ ŋ d uː
-zongzi	t s ʊ ŋ t s ɨ
-zongzi	z ʊ ŋ z ɨ
+zongzi	t s ʊ ŋ t s ɪ
+zongzi	z ʊ ŋ z ɪ
 zonie	z o ʊ n i
 zonisamide	z o ʊ n ɪ s ə m a ɪ d
 zony	z o ʊ n i
@@ -69615,6 +70208,8 @@ zun	z ʊ n
 zunyi	d z uː n j iː
 zuojhen	d z w o ʊ d͡ʒ ʌ n
 zuoyun	d z w o ʊ j uː n
+zuppa	t s uː p ə
+zuppa	z uː p ə
 zurich	z ɜ ɹ ɪ k
 zurich	z ʊ ɹ ɪ k
 zwingli	s w ɪ ŋ ɡ l i
@@ -69659,7 +70254,9 @@ zzzs	z iː z
 æsir	e ɪ z ɪ ɹ
 éclair	ɪ k l ɛ ɹ
 éclat	e ɪ k l ɑː
+élan	e ɪ l æ n
 élan	e ɪ l ɑː n
+émigré	ɛ m ɪ ɡ ɹ e ɪ
 étatisme	e ɪ t ɑː t iː z m
 étatisme	ɛ t ɑ t ɪ z m
 étatisme	ɛ t ɑː t ɪ z ə m

--- a/data/scrape/tsv/eng_latn_us_broad_filtered.tsv
+++ b/data/scrape/tsv/eng_latn_us_broad_filtered.tsv
@@ -506,7 +506,7 @@ abidjan	æ b ɪ d͡ʒ ɑ n
 abience	æ b i n̩ s
 abience	æ b i n̩ t s
 abient	æ b i n̩ t
-abier	ə b ɪ ə ɹ
+abier	ə b ɪ ɚ
 abies	e ɪ b i i z
 abies	æ b i i z
 abietate	æ b i ə t e ɪ t
@@ -1524,6 +1524,7 @@ accentuate	ə k s e n t͡ʃ u e ɪ t
 accentuation	æ k s ɛ n t͡ʃ ə w e ɪ ʃ ə n
 accentuation	ɪ k s ɛ n t͡ʃ ə w e ɪ ʃ ə n
 accept	ə k s ɛ p t
+accept	ɪ k s ɛ p t
 acceptability	æ k s ɛ p t ə b ɪ l ə t i
 acceptable	æ k s ɛ p t ə b ə l
 acceptable	ə k s ɛ p t ə b ə l
@@ -1533,6 +1534,8 @@ acceptance	ə k s ɛ p t ə n s
 acceptant	æ k s ɛ p t ə n t
 acceptation	æ k s ɛ p t e ɪ ʃ ə n
 accepted	æ k s ɛ p t ɪ d
+accepted	ə k s ɛ p t ɪ d
+accepted	ɪ k s ɛ p t ɪ d
 accepter	æ k s ɛ p t ɚ
 accepting	ə k s ɛ p t ɪ ŋ
 accepting	ɪ k s ɛ p t ɪ ŋ
@@ -1729,7 +1732,7 @@ acebutolol	æ s ə b j u t ə l ɔ l
 aced	e ɪ s t
 acedia	ə s iː d ɪ ə
 acela	ə s ɛ l ə
-aceldama	ə k e l d ə m ə
+aceldama	ə k ɛ l d ə m ə
 aceldama	ə s ɛ l d ə m ə
 acephalan	e ɪ s ɛ f ə l ə n
 acephalocyst	ɑ s ɛ f ə l o ʊ s ɪ s t
@@ -1768,7 +1771,7 @@ acetaminophen	ə s i t ə m ɪ n ə f ə n
 acetarious	ɑ s ɪ t ɛ ɚ i ə s
 acetary	ə s iː t ə ɹ i
 acetate	æ s ɪ t e ɪ̯ t
-acetator	æ s ɪ t e ɪ t ə ɹ
+acetator	æ s ɪ t e ɪ t ɚ
 acetazolamide	æ s ə t ə z o ʊ l ə m a ɪ d
 acetazolamide	æ s ə t ə z o ʊ l ə m ɪ d
 acetazolamide	æ s ə t ə z ɑ l ə m a ɪ d
@@ -1804,6 +1807,7 @@ ache	e ɪ k
 ache	e ɪ t͡ʃ
 achean	ə k i ə n
 ached	e ɪ k t
+achelous	æ k ɪ l o ʊ ə s
 acheron	æ k ə ɹ ɔ n
 acheron	æ k ə ɹ ə n
 aches	e ɪ k s
@@ -1814,7 +1818,7 @@ achieved	ə t͡ʃ iː v d
 achievement	ə t͡ʃ iː v m ə n t
 achievement	ə t͡ʃ iː v m ɪ n t
 achievements	ə t͡ʃ iː v m ə n t s
-achiever	ə t͡ʃ iː v ə ɹ
+achiever	ə t͡ʃ iː v ɚ
 achieves	ə t͡ʃ iː v z
 achieving	ə t͡ʃ iː v ɪ ŋ
 achievings	ə t͡ʃ iː v ɪ ŋ z
@@ -1884,7 +1888,7 @@ acquaintant	ə k w e ɪ n t ə n t
 acquainted	ə k w e ɪ n t ɪ d
 acquest	ə k w ɛ s t
 acquiesce	æ k w i ɛ s
-acquire	ə k w a ɪ ə ɹ
+acquire	ə k w a ɪ ɚ
 acquired	ə k w a ɪ ɹ d
 acquirement	ə k w a ɪ ə ɹ m ə n t
 acquiring	ə k w a ɪ ə ɹ ɪ ŋ
@@ -1898,7 +1902,6 @@ acquittal	ə k w ɪ d ə l
 acquittance	ə k w ɪ t ə n s
 acquitted	ə k w ɪ t ɪ d
 acrasia	ə k ɹ e ɪ z i ə
-acre	e ɪ k ə ɹ
 acre	e ɪ k ɚ
 acres	e ɪ k ɚ z
 acrid	æ k ɹ ɪ d
@@ -1908,6 +1911,7 @@ acrobatic	æ k ɹ ə b æ t ɪ k
 acrocephalic	æ k ɹ o ʊ s ə f æ l ɪ k
 acrocephalic	æ k ɹ ə s ə f æ l ɪ k
 acrocyanosis	æ k ɹ o ʊ s a ɪ ə n o ʊ s ɪ s
+acrogynous	ə k ɹ ɑ d͡ʒ ɪ n ə s
 acrolect	æ k ɹ ə l ɛ k t
 acrolein	æ k ɹ ə l i n
 acrolein	ə k ɹ o ʊ l i ɪ n
@@ -1922,6 +1926,8 @@ acropoleis	æ k ɹ ɒ p ɒ l ɛ ɪ z
 acropolises	æ k ɹ ɒ p ɒ l ɪ s ɪ z
 across	ə k ɹ ɔ s
 acrostic	ə k ɹ ɔ s t ɪ k
+acroter	æ k ɹ ə t ə ɹ
+acroterium	æ k ɹ ə t ɪ ə ɹ i ə m
 acrylamide	ə k ɹ ɪ l ə m a ɪ d
 acrylate	æ k ɹ ɪ l e ɪ t
 acrylic	ə k ɹ ɪ l ɪ k
@@ -1970,6 +1976,7 @@ actual	æ k ʃ u ə l
 actual	æ k ʃ ə l
 actuality	æ k t͡ʃ u æ l ɪ t i
 actually	æ k t͡ʃ u ə l i
+actually	æ k ʃ u ə l i
 actuate	æ k t͡ʃ u e ɪ t
 acuity	ə k j uː ɪ t i
 acumen	æ k j u m ə n
@@ -1982,6 +1989,7 @@ acushla	ə k ʊ ʃ l ə
 acute	ə k j u t
 acutely	ə k j uː t l i
 acyclic	e ɪ s a ɪ k l ɪ k
+acyclic	e ɪ s ɪ k l ɪ k
 acyl	æ s ɪ l
 acyrologia	ə s ɪ ɹ ə l ɒ d͡ʒ i ə
 acyrology	æ s ɪ ɹ ɒ l ə d͡ʒ i
@@ -2052,7 +2060,7 @@ adduce	ə d j uː s
 adduct	æ d ʌ k t
 adduct	ə d ʌ k t
 adduction	ə d ʌ k ʃ n̩
-adductor	ə d ʌ k t ə ɹ
+adductor	ə d ʌ k t ɚ
 ade	e ɪ d
 adela	æ d ə l ə
 adela	ə d ɛ l ə
@@ -2060,6 +2068,7 @@ adelaide	æ d ə l e ɪ d
 adele	ə d ɛ l
 adeling	æ d ə l ɪ ŋ
 adelings	æ d ə l ɪ ŋ z
+adelopod	ə d ɛ l ə p ɒ d
 adenine	æ d ə n iː n
 adenine	æ d ɪ n ɪ n
 adenines	æ d ɪ n ɪ n z
@@ -2081,9 +2090,9 @@ adermatoglyphia	e ɪ d ɝ m ə t ə ɡ l ɪ f i ə
 adespota	ə d ɛ s p ə t ə
 adhan	ɑː ð ɑː n
 adhan	ə ð ɑː n
-adhere	æ d h i ɹ
-adherence	ə d h ɪ ə ɹ ə n s
-adherent	æ d h ɪ ə ɹ ə n t
+adhere	æ d h ɪ ɹ
+adherence	ə d h ɪ ɹ ə n s
+adherent	æ d h ɪ ɹ ə n t
 adhesive	æ d h i s ɪ v
 adhibit	ə d h ɪ b ɪ t
 adhibition	æ d h ɪ b ɪ ʃ ə n
@@ -2106,12 +2115,13 @@ adieux	ə d j u z
 adios	ɑ d i o ʊ s
 adios	ɑ d i ɔ s
 adipate	æ d ɪ p e ɪ t
-adipocere	æ d ə p o ʊ s i ə ɹ
-adipocere	æ d ɪ p o ʊ s i ə ɹ
+adipocere	æ d ə p o ʊ s i ɚ
+adipocere	æ d ɪ p o ʊ s i ɚ
 adipocytokine	æ d ɪ p ə ʊ s a ɪ t ə ʊ k a ɪ n
 adipose	æ d ɪ p o ʊ s
 adirondack	æ d ɪ ɹ ɑ n d æ k
 adiru	æ d ə ɹ u
+adit	a d ɪ t
 adit	æ d ɪ t
 adits	æ d ɪ t s
 adjacent	ə d͡ʒ e ɪ s ə n t
@@ -2158,6 +2168,7 @@ admin	ə d m ɪ n
 administer	ə d m ɪ n ɪ s t ɚ
 administrate	ə d m ɪ n ɪ s t ɹ e ɪ t
 administration	ə d m ɪ n ə s t ɹ e ɪ ʃ ə n
+administrative	ə d m ɪ n ə s t ɹ e ɪ t ɪ v
 administrator	ə d m ɪ n ɪ s t ɹ e ɪ t ɚ
 administratorship	æ d m ɪ n ə s t ɹ e ɪ t ɚ ʃ ɪ p
 administratrix	æ d m ɪ n ɪ s t ɹ e ɪ t ɹ ɪ k s
@@ -2184,8 +2195,8 @@ admits	ə d m ɪ t s
 admittance	ə d m ɪ t n̩ s
 admitted	ə d m ɪ t ɪ d
 admitting	ə d m ɪ t ɪ ŋ
-admixture	æ d m ɪ k s t͡ʃ ə ɹ
-admixture	ə d m ɪ k s t͡ʃ ə ɹ
+admixture	æ d m ɪ k s t͡ʃ ɚ
+admixture	ə d m ɪ k s t͡ʃ ɚ
 admonish	æ d m ɑ n ɪ ʃ
 admonition	æ d m ə n ɪ ʃ ə n
 ado	ə d uː
@@ -2304,7 +2315,7 @@ advert	ə d v ɜː ɹ t
 advertise	æ d v ɚ t a ɪ z
 advertisement	æ d v ɚ t a ɪ z m ə n t
 advertisement	ə d v ɝ t ɪ z m ə n t
-advertiser	æ d v ə ɹ t a ɪ z ə ɹ
+advertiser	æ d v ɚ t a ɪ z ɚ
 advertising	æ d v ɚ t a ɪ z ɪ ŋ
 advertorial	æ d v ɚ t ɔ ɹ i ə l
 advesperate	æ d v ɛ s p ə ɹ e ɪ t
@@ -2404,7 +2415,9 @@ aesthete	ɛ s θ iː t
 aesthetic	e ɪ s θ ɛ t ɪ k
 aesthetic	ə s θ e t ɪ k
 aesthetic	ɛ s θ ɛ t ɪ k
+aesthetician	ɛ s θ ɪ t ɪ ʃ ə n
 aestivation	iː s t ɪ v e ɪ ʃ ə n
+aether	e ɪ θ ɚ
 aether	i θ ɚ
 aetiology	i t i ɑ l ə d͡ʒ i
 aetites	i t a ɪ d i z
@@ -2414,19 +2427,20 @@ aeviternity	i v ə t ɝ n ə t i
 aevum	i v ə m
 af	e ɪ̯ ɛ f
 af	æ f
+afab	e ɪ f æ b
 aface	ə f e ɪ s
 afam	a f a m
 afanc	æ v æ ŋ k
 afanc	ɑ v ɑ ŋ k
 afar	ʌ f a ɹ
-afare	ə f ɛ ə ɹ
+afare	ə f ɛ ɚ
 afeared	ə f ɪ ə ɹ d
 afelimomab	æ f ɛ l ɪ m ə m æ b
 affable	æ f ə b ə l
 affably	æ f ə b l i
 affabrous	æ f ə b ɹ ə s
 affabrous	ə f æ b ɹ ə s
-affair	ə f ɛ ə ɹ
+affair	ə f ɛ ɚ
 affair	ə f ɛ ɹ
 affairs	ə f ɛ ɹ z
 affamish	ə f æ m ɪ ʃ
@@ -2495,7 +2509,6 @@ afghani	æ f ɡ ɑː n i
 afghanistan	æ f ɡ æ n ɪ s t æ n
 afghanistan	æ f ɡ æ n ɪ s t ɑː n
 afghanistan	æ f ɡ ɑː n ɪ s t ɑː n
-afgod	æ f ɡ ɒ d
 aficionado	ɑ f i s j ɔ n ɑ ð ɔ
 aficionado	ɑ f i θ j ɔ n ɑ ð ɔ
 aficionado	ə f i s i ə n ɑ d o ʊ
@@ -2505,9 +2518,9 @@ aficionado	ə f ɪ s j ə n ɑ d o ʊ
 aficionado	ə f ɪ ʃ i ə n ɑ d o ʊ
 aficionado	ə f ɪ ʃ j ə n ɑ d o ʊ
 afield	ə f iː l d
-afire	ə f a ɪ ə ɹ
+afire	ə f a ɪ ɚ
 aflame	ə f l e ɪ m
-aflare	ə f l ɛ ə ɹ
+aflare	ə f l ɛ ɚ
 aflash	ə f l æ ʃ
 aflat	ə f l æ t
 aflaunt	ə f l ɔː n t
@@ -2516,7 +2529,7 @@ aflight	ə f l a ɪ t
 afloat	ə f l o ʊ t
 aflop	ə f l ɒ p
 aflow	ə f l o ʊ
-aflower	ə f l a ʊ ə ɹ
+aflower	ə f l a ʊ ɚ
 aflush	ə f l ʌ ʃ
 aflutter	ə f l ʌ t ɚ
 afoam	ə f o ʊ m
@@ -2542,7 +2555,7 @@ africana	æ f ɹ ɪ k ɑ n ə
 africo	æ f ɹ ɪ k ə ʊ
 africom	æ f ɹ ɪ k ɑ m
 afrikaans	ɑː f ɹ ɪ k ɑː n z
-afrikaner	æ f ɹ ɪ k ɑː n ə ɹ
+afrikaner	æ f ɹ ɪ k ɑː n ɚ
 afro	æ f ɹ o ʊ
 afroed	æ f ɹ o ʊ d
 afros	æ f ɹ o ʊ z
@@ -2577,7 +2590,7 @@ agape	æ ɡ ə p i
 agape	ə ɡ e ɪ p
 agape	ə ɡ ɑː p e ɪ
 agar	e ɪ ɡ ɑ ɹ
-agar	æ ɡ ə ɹ
+agar	æ ɡ ɚ
 agar	ɑ ɡ ɑ ɹ
 agaric	æ ɡ ə ɹ ɪ k
 agaric	ə ɡ æ ɹ ɪ k
@@ -2588,7 +2601,7 @@ agassi	æ ɡ ə s i
 agate	æ ɡ ə t
 agate	ə ɡ æ t
 agateophobia	ə ɡ e ɪ t i ə ʊ f ə ʊ b i ə
-agateware	æ ɡ ə t w ɛ ə ɹ
+agateware	æ ɡ ə t w ɛ ɚ
 agatha	æ ɡ ə θ ə
 agave	ə ɡ e ɪ v iː
 agave	ə ɡ ɑː v e ɪ
@@ -2631,6 +2644,7 @@ aggrace	ə ɡ ɹ e ɪ s
 aggrandize	ə ɡ ɹ æ n d a ɪ̯ z
 aggravate	æ ɡ ɹ ə v e ɪ̯ t
 aggravated	æ ɡ ɹ ə v e ɪ̯ t ɪ d
+aggravation	æ ɡ ɹ ə v e ɪ ʃ ə n
 aggregate	æ ɡ ɹ ɪ ɡ e ɪ t
 aggregate	æ ɡ ɹ ɪ ɡ ə t
 aggregation	æ ɡ ɹ ə ɡ e ɪ ʃ ə n
@@ -2652,7 +2666,7 @@ agility	ə d͡ʒ ɪ l ɪ t i
 agin	ə ɡ ɪ n
 aging	e ɪ d͡ʒ ɪ ŋ
 agings	e ɪ d͡ʒ ɪ ŋ z
-aginner	ə ɡ ɪ n ə ɹ
+aginner	ə ɡ ɪ n ɚ
 agio	æ d͡ʒ i o ʊ
 agio	æ d͡ʒ o ʊ
 agio	ɑː d͡ʒ o ʊ
@@ -2666,13 +2680,13 @@ agitolalia	æ d͡ʒ ɪ t o ʊ l e ɪ l i ə
 agitophasia	æ d͡ʒ ɪ t o ʊ f e ɪ ʒ ə
 agitprop	æ d͡ʒ ə t p ɹ ɑ p
 agitpropping	æ d͡ʒ ə t p ɹ ɑ p ɪ ŋ
-aglare	ə ɡ l ɛ ə ɹ
+aglare	ə ɡ l ɛ ɚ
 agleam	ə ɡ l iː m
 agley	ə ɡ l e ɪ
 agley	ə ɡ l iː
-aglimmer	ə ɡ l ɪ m ə ɹ
+aglimmer	ə ɡ l ɪ m ɚ
 aglint	ə ɡ l ɪ n t
-aglitter	ə ɡ l ɪ t ə ɹ
+aglitter	ə ɡ l ɪ t ɚ
 aglow	ə ɡ l o ʊ
 agnate	æ ɡ n e ɪ t
 agnath	æ ɡ n ə θ
@@ -2714,6 +2728,7 @@ agrarian	ə ɡ ɹ ɛ ə ɹ i ə n
 agree	ə ɡ ɹ i
 agree	ə ɡ ɹ iː
 agreeable	ə ɡ ɹ iː ə b l
+agreeably	ə ɡ ɹ iː ə b l i
 agreed	ə ɡ ɹ i d
 agreed	ə ɡ ɹ iː d
 agreement	ə ɡ ɹ iː m ə n t
@@ -2833,12 +2848,12 @@ airling	ɛ ə ɹ l ɪ ŋ
 airmail	ɛ ə m e ɪ l
 airmails	ɛ ə m e ɪ l z
 airman	ɛ ɹ m ə n
-airplane	ɛ ə ɹ p l e ɪ̯ n
+airplane	ɛ ɚ p l e ɪ̯ n
 airport	ɛ ɹ p ɔ ɹ t
 airports	ɛ ɹ p o ɹ t s
 airports	ɛ ɹ p ɔ ɹ t s
 airprox	ɛ ə ɹ p ɹ ɒ k s
-airs	ɛ ɹ z
+airs	ɛ ə ɹ z
 airy	ɛ ə ɹ i
 aisha	a ɪ iː ʃ ə
 aisle	a ɪ̯ l
@@ -2899,6 +2914,7 @@ akroposthion	æ k ɹ ə ʊ p ɒ s θ ɪ ə n
 aks	æ k s
 aks	ɑː k s
 aktau	ɑ k t a ʊ
+akwesasne	æ k w ə s æ s n e ɪ
 al	æ l
 al	ɑː l
 ala	e ɪ l ə
@@ -2962,7 +2978,7 @@ album	æ l b ə m
 albumen	æ l b j uː m ə n
 albumen	æ l b j ʊ m ə n
 albumin	æ l b j uː m ə n
-albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ə ɹ
+albuminimeter	æ l b j ʊ m ɪ n ɪ m ɪ t ɚ
 albuminous	æ l b j uː m ɪ n ə s
 albuquerque	æ l b ə k ɝ k i
 albury	ɔː l b ə ɹ i
@@ -2974,7 +2990,8 @@ alcatraz	æ l k ə t ɹ æ z
 alcazar	æ l k ɑ z ɚ
 alcazar	æ l k ə z ɑ ɹ
 alcedine	æ l s ə d ʌ ɪ n
-alcester	ɒ l s t ə ɹ
+alces	æ l s iː z
+alcester	ɒ l s t ɚ
 alchemist	æ l k ə m ɪ s t
 alchemistic	æ l k ə m ɪ s t ə k
 alchemistical	æ l k ə m ɪ s t ɪ k ə l
@@ -2998,6 +3015,8 @@ alcove	æ l k ə ʊ v
 alcyone	æ l s a ɪ ə n i
 aldcliffe	ɔː k l ɪ f
 aldcliffe	ɔː l d k l ɪ f
+aldehyde	æ l d ɪ h a ɪ d
+aldehydes	æ l d ɪ h a ɪ d z
 alderliefest	ɔː l d ə ɹ l iː f ɪ s t
 aldermanic	ɔː l d ə ɹ m æ n ɪ k
 aldermaston	ɔː l d ə m ɑː s t ə n
@@ -3039,6 +3058,12 @@ aleutian	ə l uː ʃ ə n
 alevin	æ l ə v ə n
 alewife	e ɪ l w a ɪ f
 alex	æ l ɪ k s
+alexander	æ l ɪ ɡ z æ n d ə ɹ
+alexander	æ l ɪ ɡ z æ n d ɚ
+alexanders	æ l i ɡ z æ n d ɚ z
+alexanders	æ l ɪ ɡ z æ n d ɚ z
+alexandra	æ l ɪ ɡ z æ n d ɹ ə
+alexandra	æ l ɪ ɡ z ɑ n d ɹ ə
 alexandria	æ l ə k z æ n d ɹ i ə
 alexandria	æ l ə ɡ z æ n d ɹ i ə
 alexandrian	æ l ɛ k s z æ n d ɹ i ə n
@@ -3049,6 +3074,7 @@ alexipharmac	ə l ɛ k s ə f ɑ ɹ m æ k
 alexipharmic	ə l ɛ k s ə f ɑ ɹ m ɪ k
 alexithymia	e ɪ l ɛ k s ə θ a ɪ m i ə
 alexithymic	ə l ɛ k s ɪ θ a ɪ m ɪ k
+alexondra	æ l ɪ ɡ z ɑ n d ɹ ə
 alf	æ l f
 alfacalcidol	æ l f ə k æ l s ɪ d ɔ l
 alfalfa	æ l f æ l f ə
@@ -3203,7 +3229,7 @@ allocate	æ l ə k e ɪ t
 allocated	æ l ə k e ɪ t ɪ d
 allocation	æ l ə k e ɪ ʃ ə n
 allocentric	æ l o ʊ s ɛ n t ɹ ɪ k
-allocher	æ l ə k ɛ ə ɹ
+allocher	æ l ə k ɛ ɚ
 allochthon	ə l ɒ k θ ɒ n
 allochthon	ə l ɒ k θ ə n
 allodial	ə l ə ʊ d i ə l
@@ -3309,7 +3335,6 @@ aloin	æ l o ʊ ɪ n
 alone	ə l o ʊ n
 along	ə l ɑ ŋ
 along	ə l ɔ ŋ
-alongside	ə l ɑ ŋ s a ɪ d
 alongside	ə l ɔ ŋ s a ɪ d
 alongsides	ə l ɑ ŋ s a ɪ d z
 alongsides	ə l ɔ ŋ s a ɪ d z
@@ -3349,12 +3374,13 @@ alright	ɔː l ɹ a ɪ t
 alsace	æ l s e ɪ s
 alsace	æ l s æ s
 alsatian	æ l s e ɪ ʃ ə n
+also	ɑ l s o ʊ
 also	ɔ l s o ʊ
+alstroemeria	æ l s t ɹ i m iː ɹ ɪ ə
+alt	ɑ l t
 alt	ɔ l t
-alt	ɔː l t
 alta	ɑː l t ə
 altaic	æ l t e ɪ ɪ k
-altar	ɑ l t ɚ
 altar	ɔ l t ɚ
 alteplase	æ l t ə p l e ɪ s
 alter	ɔ l t ɚ
@@ -3381,6 +3407,7 @@ altman	ɔː l t m ə n
 alto	æ l t o ʊ
 altogether	ɑ l t ə ɡ ɛ ð ɚ
 altogether	ɔ l t u ɡ ɛ ð ɚ
+altogether	ɔ l t ə ɡ ɛ ð ɚ
 alton	ɒ l t ə n
 alton	ɔː l t ə n
 altricial	ə l t ɹ ɪ ʃ ə l
@@ -3420,7 +3447,7 @@ alvinolagnia	æ l v ɪ n ə l a ɡ n i ə
 alvinophilia	æ l v a ɪ n ə f ɪ l i ə
 alvinophilia	æ l v ɪ n ə f i l j ə
 alvocidib	æ l v ɒ s ɪ d ɪ b
-always	ɑ ɫ w e ɪ z
+always	ɑ l w e ɪ z
 always	ɔ l w e ɪ z
 always	ɔ l w i z
 always	ɔ l w ə z
@@ -3428,7 +3455,9 @@ alxa	ɑ l ʃ ɑː
 alytarch	æ l ə t ɑ ɹ k
 alytus	ə l iː t ə s
 ama	ɑː m ə
+amab	e ɪ m æ b
 amacrine	æ m ə k ɹ ɪ n
+amadeus	æ m ə d e ɪ ə s
 amadou	æ m ə d uː
 amah	ɑː m ə
 amahs	ɑː m ə z
@@ -3470,9 +3499,11 @@ amati	ɑ m ɑ t i
 amatory	æ m ə t ɔː ɹ i
 amatory	ɑ m ə t ə ɹ i
 amaurosis	æ m ɔ ɹ o ʊ s ə s
+amaze	ə m e ɪ z
 amazed	ə m e ɪ z d
 amazement	ə m e ɪ z m ə n t
 amazes	ə m e ɪ z ɪ z
+amazigh	æ m ə z ɪ ɡ
 amazing	ə m e ɪ z ɪ ŋ
 amazingly	ə m e ɪ z ɪ ŋ l i
 amazon	æ m ə z ɑ n
@@ -3516,6 +3547,7 @@ ambles	æ m b ə l z
 amblyopia	æ m b l ɪ ə ʊ p ɪ ə
 amblyopic	æ m b l iː o ʊ p ɪ k
 amblyopic	æ m b l iː ɒ p ɪ k
+ambrisentan	æ m b ɹ ɪ s ɛ n t æ n
 ambrose	æ m b ɹ o ʊ z
 ambrose	æ m b ɹ ə ʊ z
 ambrosia	æ m b ɹ o ʊ ʒ ə
@@ -3585,6 +3617,7 @@ amharic	æ m h æ ɹ ɪ k
 amiability	e ɪ m i ʌ b ɪ l ə t i
 amiable	e ɪ m i ə b ə l
 amiable	æ m i ə b ə l
+amicable	æ m ɪ k ə b ə l
 amici	æ m ɪ k i
 amici	ə m i k i
 amicide	æ m ɪ s a ɪ d
@@ -3649,7 +3682,6 @@ amoeba	ə m iː b ə
 amoebal	ə m iː b ə l
 amoebic	ə m iː b ɪ k
 amogus	ə m o ʊ ɡ ə s
-amogus	ə m o ʊ ɡ ɪ s
 amok	ə m ɒ k
 amok	ə m ʌ k
 amole	ə m o ʊ l e ɪ
@@ -3661,7 +3693,7 @@ amongst	ə m ʌ ŋ s t
 amoral	e ɪ m ɔ ɹ ə l
 amorally	e ɪ m ɔ ɹ ə l i
 amorally	æ m ɔ ɹ ə l i
-amorce	ə m ɔ ɹ s
+amorce	ə m o ɹ s
 amoret	æ m ə ɹ ɪ t
 amorevolous	æ m ə ɹ ɛ v ə l ə s
 amorous	æ m ə ɹ ə s
@@ -3694,6 +3726,7 @@ ampersat	æ m p ɚ s æ t
 ampersat	æ m p ɚ z æ t
 amphetamine	æ m f ɛ t ə m iː n
 amphetamine	æ m f ɛ t ə m ɪ n
+amphibial	æ m f ɪ b i ə l
 amphibian	æ m f ɪ b ɪ ə n
 amphibole	æ m f ɪ b o ʊ l
 amphibolite	æ m f ɪ b ə l a ɪ t
@@ -3703,7 +3736,7 @@ amphid	æ m f ɪ d
 amphigory	æ m f ɪ ɡ ɔ ɹ i
 amphipathic	æ m f ə p æ θ ɪ k
 amphipod	a m f ɪ p ɑ d
-amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ə ɹ
+amphiprostylar	æ m f ɪ p ɹ ə ʊ s t a ɪ l ɚ
 amphisbaena	æ m f ɪ s b iː n ə
 amphisbæna	æ m f ɪ s b iː n ə
 amphitheatre	æ m f ə θ i j ə t ɚ
@@ -3718,7 +3751,7 @@ amping	æ m p ɪ ŋ
 ample	æ m p ə l
 amplificate	æ m p l ɪ f ɪ k e ɪ̯ t
 amplification	æ m p l ɪ f ɪ k e ɪ ʃ ə n
-amplifier	æ m p l ə f a ɪ ə ɹ
+amplifier	æ m p l ə f a ɪ ɚ
 amplifier	æ m p l ə f a ɪ ɹ
 amplifiers	æ m p l ə f a ɪ ə ɹ z
 amplifiers	æ m p l ə f a ɪ ɹ z
@@ -3750,7 +3783,7 @@ amusement	ə m j u z m ə n t
 amuses	ə m j uː z ɪ z
 amusing	ə m j uː z ɪ ŋ
 amusingly	ə m j u z ɪ ŋ l i
-amutter	ə m ʌ t ə ɹ
+amutter	ə m ʌ t ɚ
 amy	e ɪ m i
 amygdala	ə m ɪ ɡ d ə l ə
 amygdalae	ə m ɪ ɡ d ə l a ɪ
@@ -3779,6 +3812,7 @@ anacoluthon	æ n ə k ə l uː θ ɒ n
 anaconda	æ n ə k ɒ n d ə
 anacreon	ə n æ k ɹ i ə n
 anacreontic	ə n æ k ɹ i ɑ n t ɪ k
+anacrogynous	æ n ə k ɹ ɑ d͡ʒ ɪ n ə s
 anacronym	ə n æ k ɹ ə n ɪ m
 anadrome	æ n ə d ɹ o ʊ m
 anadromes	æ n ə d ɹ o ʊ m z
@@ -3786,10 +3820,12 @@ anadromous	ə n æ d ɹ ə m ə s
 anaerobe	æ n ə ɹ o ʊ b
 anaerobic	æ n ə ɹ o ʊ b i k
 anaerophyte	ə n e ɪ ə ɹ ə ʊ f a ɪ t
+anagoge	æ n ə ɡ o ʊ d͡ʒ i
+anagoge	æ n ə ɡ ɑ d͡ʒ i
 anagogy	æ n ə ɡ o ʊ d͡ʒ i
 anagogy	æ n ə ɡ ɒ d͡ʒ i
 anagram	æ n ə ɡ ɹ æ m
-anagrammer	æ n ə ɡ ɹ æ m ə ɹ
+anagrammer	æ n ə ɡ ɹ æ m ɚ
 anagrams	æ n ə ɡ ɹ æ m s
 anagrind	æ n ə ɡ ɹ ɪ n d
 anaheim	æ n ə h a ɪ m
@@ -3815,7 +3851,6 @@ analogous	ə n æ l ə ɡ ə s
 analogously	ə n æ l ə ɡ ə s l i
 analogy	ə n æ l ə d͡ʒ i
 analphabet	æ n æ l f ə b ɛ t
-analyse	æ n ə l a ɪ z
 analyses	æ n ə l a ɪ z ə z
 analyses	æ n ə l a ɪ z ɪ z
 analyses	ə n æ l ə s iː z
@@ -3828,6 +3863,7 @@ analytic	æ n ə l ɪ t ɪ k
 analytical	æ n ə l ɪ t ə k ə l
 analytically	æ n ə l ɪ t ɪ k ə l l i
 analytics	æ n ə l ɪ t ɪ k s
+analyze	æ n ə l a ɪ z
 analyzed	æ n ə l a ɪ z d
 anamnesis	æ n æ m n iː s ɪ s
 anamorphic	æ n ə m ɔ ɹ f ɪ k
@@ -3882,6 +3918,7 @@ anatase	æ n ə t e ɪ z
 anataxis	æ n ə t æ k s ə s
 anathema	ə n æ θ ə m ə
 anathematize	ə n æ θ ə m ə t a ɪ z
+anatidae	ə n æ t ɪ d iː
 anatole	æ n ə t o ʊ l
 anatoli	æ n ə t o ʊ l i
 anatoli	æ n ə t ɑ l i
@@ -3933,7 +3970,7 @@ andorra	æ n d o ɹ ə
 andorran	æ n d ɔː ɹ ə n
 andouille	æ n d u i
 andouilles	ɑ n d uː ɪ z
-andover	æ n d o ʊ v ə ɹ
+andover	æ n d o ʊ v ɚ
 andre	ɑː n d ɹ e ɪ
 andre	ɑː n d ɹ ə
 andre	ɑː n d ɹ ɪ
@@ -4041,11 +4078,12 @@ angulus	æ ŋ ɡ j ə l ə s
 angust	æ ŋ ɡ ʌ s t
 anhedonia	æ n h i d o ʊ n i ə
 anhedonic	æ n h i d ɑ n ɪ k
+anhedonic	æ n h ɪ d ɑ n ɪ k
 anhelation	æ n h ə l e ɪ ʃ ə n
 anhele	ə n h iː l
 anhele	ə n iː l
 anhui	ɑː n h w e ɪ
-anhur	ɑː n h ʊ ə ɹ
+anhur	ɑː n h ʊ ɚ
 anhypostasia	æ n h a ɪ p ə s t e ɪ ʒ i ə
 anhypostasis	æ n h a ɪ p ə s t e ɪ s ɪ s
 ani	e ɪ n a ɪ
@@ -4065,8 +4103,6 @@ animalcule	æ n ə m æ l k j u l
 animals	æ n ɪ m ə l z
 animate	æ n ə m e ɪ t
 animate	æ n ə m ə t
-animate	æ n ɪ m e ɪ t
-animate	æ n ɪ m ə t
 animated	æ n ɪ m e ɪ t ɪ d
 animatedly	æ n ɪ m e ɪ t ɪ d l i
 animatic	æ n ɪ m æ t ɪ k
@@ -4092,6 +4128,7 @@ anisocytosis	ə n a ɪ s ə ʊ s a ɪ t ə ʊ s ɪ s
 anisogamy	æ n a ɪ s ɒ ɡ ə m i
 anisomorphic	æ n a ɪ s o ʊ m ɔː ɹ f ɪ k
 anisopoikilocytosis	ə n a ɪ s o ʊ p ɔ ɪ k ə l o ʊ s a ɪ t o ʊ s ɪ s
+anisotropous	æ n a ɪ s ɒ t ɹ ə p ə s
 anita	ə n iː t ə
 aniṭ	ʌ n ɪ t
 ankang	ɑː n k ɑ ŋ
@@ -4115,6 +4152,7 @@ annal	æ n ə l
 annalist	æ n ə l ɪ s t
 annals	æ n ə l z
 annan	æ n ə n
+annapolis	ə n æ p ə l ɪ s
 anne	æ n
 anneal	ə n iː l
 annette	ə n ɛ t
@@ -4133,7 +4171,7 @@ annish	æ n ɪ ʃ
 anniversary	æ n ə v ɝ s ə ɹ i
 anniversary	æ n ɪ v ɝ s ə ɹ i
 annotate	a n ə t e ɪ t
-announce	ə n a ʊ n s
+announce	ə n a ʊ n t s
 announcement	ə n a ʊ n s m ɛ n t
 announcer	ə n a ʊ n s ɚ
 annoy	ə n ɔ ɪ
@@ -4195,11 +4233,12 @@ ans	æ n z
 ansa	æ n s ə
 ansai	ɑː n s a ɪ
 anselm	æ n s ɛ l m
+anser	æ n s ə r
 ansi	æ n s iː
 answer	æ n s ɚ
 answerable	æ n s ə ɹ ə b l
 answered	æ n s ɚ d
-answerer	æ n s ə ɹ ə ɹ
+answerer	æ n s ə ɹ ɚ
 answering	æ n s ɚ ɪ ŋ
 answers	æ n s ɚ z
 ant	æ n t
@@ -4220,6 +4259,7 @@ ante	æ n t i
 anteater	æ n t i t ɚ
 antebellum	æ n t i b ɛ l ə m
 antecedaneous	æ n t ɪ s ɪ d e ɪ n i ə s
+antecedence	æ n t ɛ s ɪ d ə n s
 antecedent	æ n t ɪ s iː d ə n t
 antechamber	æ n t i t͡ʃ e ɪ m b ɚ
 antediluvian	a n t ə d ɪ l uː v ɪ j ɪ n
@@ -4273,7 +4313,7 @@ anthroposophic	æ n θ ɹ ə p ə s ɑ f ɪ k
 anthroposophical	æ n θ ɹ ə p ə s ɑ f ɪ k ə l
 anthroposophist	æ n θ ɹ ə p ɑ s ə f ɪ s t
 anthroposophy	æ n θ ɹ ə p ɑ s ə f i
-anthroposphere	a n θ ɹ ɒ p ə s f ɪ ə ɹ
+anthroposphere	a n θ ɹ ɒ p ə s f ɪ ɚ
 anthypophora	æ n θ ə p ə f ɔ ɹ ə
 antialiasing	æ n t i e ɪ l i ə s ɪ ŋ
 antialiasing	æ n t ɑ ɪ̯ e ɪ l i ə s ɪ ŋ
@@ -4390,7 +4430,7 @@ antiviral	æ n t i v a ɪ ɹ ə l
 antler	æ n t l ɚ
 antler	æ n ʔ l ɚ
 antler	æ n ʔ ɫ ɚ
-antmire	a n t m a ɪ ə ɹ
+antmire	a n t m a ɪ ɚ
 antonia	æ n t ə ʊ n i ə
 antonia	æ n t ə ʊ n j ə
 antonio	æ n t o ʊ n i o ʊ
@@ -4409,6 +4449,7 @@ antumbra	æ n t ʌ m b ɹ ə
 antwacky	æ n t w æ k i
 antwerp	æ n t w ɝ p
 anubandha	ə n ʊ b ʌ n d ə
+anura	ə n j ʊ ə r ə
 anuran	ə n j ʊ ɹ ə n
 anus	e ɪ n ə s
 anvil	æ n v ə l
@@ -4418,7 +4459,7 @@ anxin	ɑː n ʃ iː n
 anxiolytic	æ ŋ k s i ə l ɪ t ɪ k
 anxious	e ɪ ŋ k ʃ ə s
 anxious	æ ŋ k ʃ ə s
-anxiouser	æ ŋ k ʃ ə s ə ɹ
+anxiouser	æ ŋ k ʃ ə s ɚ
 anxiously	æ ŋ k ʃ ə s l i
 any	ɛ n i
 any	ɪ n i
@@ -4473,7 +4514,7 @@ aped	e ɪ p t
 apeiron	ə p a ɪ ə ɹ ɒ n
 apennine	æ p ə n a ɪ n
 apennines	æ p ə n a ɪ n z
-aper	e ɪ p ə ɹ
+aper	e ɪ p ɚ
 apert	ə p ɜː ɹ t
 aperture	æ p ɚ t j ʊ ɹ
 aperture	æ p ɚ t ʊ ɹ
@@ -4491,6 +4532,18 @@ aphantasia	e ɪ f æ n t e ɪ ʒ ə
 aphasia	ə f e ɪ z ɪ ə
 aphasia	ə f e ɪ ʒ ə
 aphasic	ə f e ɪ z ə k
+aphelia	æ p h i l i ə
+aphelia	æ p h i l j ə
+aphelia	ə f i l i ə
+aphelia	ə f i l j ə
+aphelion	æ p h i l i ə
+aphelion	æ p h i l i ə n
+aphelion	æ p h i l j ə
+aphelion	æ p h i l j ə n
+aphelion	ə f i l i ə
+aphelion	ə f i l i ə n
+aphelion	ə f i l j ə
+aphelion	ə f i l j ə n
 apheresis	æ f ə ɹ i s ɪ s
 apheresis	ə f ɛ ɹ ə s ɪ s
 apheses	æ f ə s iː z
@@ -4499,7 +4552,7 @@ aphetic	ə f ɛ t ɪ k
 aphetism	æ f ə t ɪ z ə m
 aphetize	æ f ə t a ɪ z
 aphid	e ɪ f ɪ d
-aphorism	æ f ə ɹ ɪ z m̩
+aphorism	æ f ə ɹ ɪ z ə m
 aphoristic	æ f ə ɹ ɪ s t ɪ k
 aphotic	e ɪ f o ʊ t ɪ k
 aphrodisiac	æ f ɹ o ʊ d i z i æ k
@@ -4545,6 +4598,7 @@ apodictic	æ p ə d ɪ k t ɪ k
 apodioxis	æ p ə ʊ d a ɪ ɒ k s ɪ s
 apodixis	æ p ə ʊ d a ɪ k s ɪ s
 apodixis	æ p ə ʊ d ɪ k s ɪ s
+apodosis	ə p ɒ d ə s ɪ s
 apogamy	ə p ɒ ɡ ə m ɪ
 apogeal	æ p o ʊ d͡ʒ iː ə l
 apogeal	æ p ə d͡ʒ iː ə l
@@ -4586,7 +4640,7 @@ apostatical	æ p ə s t æ t ɪ k ə l
 apostle	ə p ɑ s l̩
 apostolic	æ p ə s t ɑː l ɪ k
 apostolos	ə p ɒ s t ə l ɪ s
-apostrophe	ə p ɑː s t ɹ ə f i
+apostrophe	ə p ɑ s t ɹ ə f i
 apostrophed	ə p ɒ s t ɹ ə f iː d
 apothecary	ə p ɑ θ ə k ɛ ə ɹ i
 apothegm	æ p ə θ ɛ m
@@ -4610,9 +4664,10 @@ apparel	ə p æ ɹ ə l
 apparel	ə p ɛ ɹ ə l
 apparent	ə p æ ɹ ə n t
 apparent	ə p ɛ ɚ ə n t
+apparently	ə p æ ɹ ə n t l iː
 apparition	æ p ɚ ɪ ʃ n̩
 apparition	æ p ɚ ɪ ʃ ə n
-apparitor	ə p æ ɹ i t ə ɹ
+apparitor	ə p æ ɹ i t ɚ
 appeal	ə p i l
 appealed	ə p iː l d
 appealing	ə p i l ɪ ŋ
@@ -4713,7 +4768,7 @@ appropry	ə p ɹ o ʊ p ɹ i
 approval	ə p ɹ u v ə l
 approve	ə p ɹ uː v
 approved	ə p ɹ uː v d
-approver	ə p ɹ uː v ə ɹ
+approver	ə p ɹ uː v ɚ
 approves	ə p ɹ uː v z
 approving	ə p ɹ uː v ɪ ŋ
 approximal	ə p ɹ ɒ k s ɪ m ə l
@@ -4734,11 +4789,12 @@ aprepitant	ə p ɹ ɛ p ɪ t ə n t
 apricate	æ p ɹ i k e ɪ t
 aprication	æ p ɹ i k e ɪ ʃ ə n
 apricitabine	æ p ɹ ɪ s a ɪ t ə b i n
-apricot	e ɪ p ɹ ɪ k ɒ t
-apricot	æ p ɹ ɪ k ɒ t
+apricot	e ɪ p ɹ ɪ k ɑ t
+apricot	æ p ɹ ɪ k ɑ t
 april	e ɪ p ɹ ə l
 aprils	e ɪ p ɹ ə l z
 aprium	e ɪ p ɹ i ə m
+aprocitentan	æ p ɹ ə s ɪ t ɛ n t æ n
 apron	e ɪ p ɹ ə n
 aprons	e ɪ p ɹ ə n z
 apronym	æ p ɹ ə n ɪ m
@@ -4803,7 +4859,7 @@ aquila	ɑː k w ə l ə
 aquiline	æ k w ɪ l a ɪ n
 aquinas	ə k w a ɪ n ə s
 aquitaine	æ k w ɪ t e ɪ n
-aquiver	ə k w ɪ v ə ɹ
+aquiver	ə k w ɪ v ɚ
 ar	ɑ ɹ
 ara	e ɪ ɹ ə
 ara	ɛ ɹ ə
@@ -4835,6 +4891,7 @@ arachnophobia	æ ɹ æ k n ə f ə ʊ b ɪ ə
 aragon	ɛ ɹ ə ɡ ɑ n
 aragonese	æ r ə ɡ ɒ n iː z
 arak	ə ɹ æ k
+arak	ɛ ɹ ɪ k
 aral	ɛ ɹ ə l
 aralia	ə ɹ e ɪ l i ə
 aralia	ə ɹ e ɪ l j ə
@@ -4845,7 +4902,7 @@ aran	æ ɹ ə n
 arancino	ɑ ɹ ə n t͡ʃ i n o ʊ
 arango	ə ɹ æ ŋ ɡ ə ʊ
 arans	æ ɹ ə n z
-arapaho	ə ɹ æ p ə h o ʊ
+arapaho	ə ɹ e ɪ p ə h o ʊ
 arapaima	ɑː ɹ ə p a ɪ m ə
 araphostic	æ ɹ ə f ɑ s t ɪ k
 ararat	æ ɹ ə ɹ æ t
@@ -4863,6 +4920,7 @@ arbor	ɑ ɹ b ɚ
 arboreal	ɑ ɹ b ɔ ɹ i ə l
 arborescent	ɑː ɹ b ə ɹ ɛ s ə n t
 arboretum	ɑː ɹ b ə ɹ iː t ə m
+arboriculture	ɑː ɹ b ɔː ɹ ɪ k ʌ l t͡ʃ ɚ
 arborio	ɑ ɹ b ɔ ɹ i o ʊ
 arborolatry	ɑ ɹ b ɚ ɑ l ə t ɹ i
 arborvitae	ɑ ɹ b ɚ v a ɪ t ə
@@ -4948,12 +5006,12 @@ archivist	ɑː ɹ k ə v ɪ s t
 archivist	ɑː ɹ k ɪ v ɪ s t
 archking	ɑ ɹ t͡ʃ k ɪ ŋ
 archleader	ɑ ɹ t͡ʃ l i d ɚ
-archleader	ɑ ɹ t͡ʃ l iː d ə ɹ
+archleader	ɑ ɹ t͡ʃ l iː d ɚ
 archmage	ɑː r t͡ʃ m e ɪ d͡ʒ
 archology	ɑː k ɒ l ə d͡ʒ ɪ
 archon	ɑː ɹ k ə n
 archpaladin	ɑ ɹ t͡ʃ p æ l ə d ɪ n
-archpractitioner	ɑ ɹ t͡ʃ p ɹ æ k t ɪ ʃ ə n ə ɹ
+archpractitioner	ɑ ɹ t͡ʃ p ɹ æ k t ɪ ʃ ə n ɚ
 archy	ɑ ɹ k i
 archy	ɑ ɹ t͡ʃ i
 arcing	ɑ ɹ k ɪ ŋ
@@ -4972,7 +5030,7 @@ arcturus	ɑ ɹ k t j ʊ ə ɹ ə s
 arcweld	ɑ ɹ k w ɛ l d
 ard	ɑ ɹ d
 ardent	ɑ ɹ d ə n t
-ardor	ɑː ɹ d ə ɹ
+ardor	ɑː ɹ d ɚ
 arduous	ɑː ɹ d͡ʒ u ə s
 are	ɑ ɹ
 are	ɚ
@@ -4997,16 +5055,18 @@ areopagitic	ɛ ə ɹ i ə ʊ p ə d͡ʒ ɪ t ɪ k
 areopagus	æ r i ɒ p ə ɡ ə s
 ares	e ə ɹ iː z
 arete	æ ɹ ɪ t iː
+arethusa	æ ɹ ɪ θ j uː z ə
 arew	ə ɹ ə ʊ
 argal	ɑː ɹ ɡ ə l
 argaman	ɑː ɹ ɡ ə m ə n
 argan	ɑː ɹ ɡ ə n
 argent	ɑ ɹ d͡ʒ ə n t
 argentina	ɑ ɹ d͡ʒ ə n t i n ə
+argentinan	ɑ ɹ d͡ʒ ɪ n t iː n ə n
 argentine	ɑː ɹ d͡ʒ ə n t a ɪ n
 argentine	ɑː ɹ d͡ʒ ə n t iː n
-argentinian	ɑ ɹ d͡ʒ ə n t i n i ə n
-argentinian	ɑ ɹ d͡ʒ ə n t iː n i ə n
+argentinian	ɑ ɹ d͡ʒ ə n t i n ɪ ə n
+argentinian	ɑ ɹ d͡ʒ ə n t iː n ɪ ə n
 argentry	ɑː ɹ d͡ʒ ə n t ɹ i
 argh	ɑ ɹ ɡ
 argillaceous	ɑː d͡ʒ ɪ l e ɪ ʃ ə s
@@ -5068,6 +5128,7 @@ aristocrat	ə ɹ ɪ s t ə k ɹ æ t
 aristocratic	æ ɹ ɪ s t ə k ɹ æ t ɪ k
 aristolochic	ə ɹ ɪ s t ə l o ʊ k ɪ k
 aristophanes	ɛ ɹ ɪ s t ɑ f ə n i z
+aristotelian	æ ɹ ɪ s t ə t iː l i ə n
 aristotle	æ ɹ ɪ s t ɑ t ə l
 aristotle	ɛ ɹ ɪ s t ɑ t ə l
 arithmetic	æ ɹ ɪ θ m ɛ t ɪ k
@@ -5105,12 +5166,12 @@ armature	ɑ ɹ m ə t͡ʃ ʊ ɚ
 armchair	ɑ ɹ m t͡ʃ ɛ ɚ
 armed	ɑ ɹ m d
 armenia	ɑ ɹ m i n i ə
-armenian	ɑː ɹ m iː n i ə n
+armenian	ɑ ɹ m i n i ə n
 armet	ɑ ɹ m ɛ t
 armful	ɑ ɹ m f ʊ l
 armhole	ɑ ɹ m h o ʊ l
 armies	ɑ ɹ m i z
-armiger	ɑː ɹ m ɪ d͡ʒ ə ɹ
+armiger	ɑː ɹ m ɪ d͡ʒ ɚ
 armigerous	ɑ ɹ m ɪ d͡ʒ ɚ ə s
 armill	ɑ ɹ m ə l
 armill	ɑ ɹ m ɪ l
@@ -5149,8 +5210,11 @@ arpa	ɑ ɹ p ə
 arpanet	ɑ ɹ p ə n ɛ t
 arpeggio	ɑ ɹ p ɛ d͡ʒ i o ʊ
 arpitan	ɑ ɹ p ɪ t ə n
+arquebus	ɑ ɹ k w ɪ b ə s
+arquebus	ɑ ɹ k ɪ b ə s
 arrabbiata	ɑ ɹ ə b i ɑː t ə
 arrack	ə ɹ æ k
+arrack	ɛ ɹ ɪ k
 arraign	ə ɹ e ɪ n
 arraigned	ə ɹ e ɪ n d
 arraigning	ə ɹ e ɪ n ɪ ŋ
@@ -5196,7 +5260,8 @@ arrogant	æ ɹ ə ɡ ə n t
 arrogate	æ ɹ ə ɡ e ɪ t
 arrondissement	ə ɹ ɒ n d ɪ s m ə n t
 arrove	ə ɹ o ʊ v
-arrowmaker	æ ɹ ə ʊ m e ɪ k ə ɹ
+arrowcide	æ ɹ o ʊ s a ɪ d
+arrowmaker	æ ɹ ə ʊ m e ɪ k ɚ
 arrowroot	ɛ ɹ o ʊ ɹ u t
 arrows	ɛ ɹ o ʊ z
 arroyo	ə ɹ ɔ ɪ o ʊ
@@ -5262,8 +5327,8 @@ articulation	ɑ ɹ t ɪ k j ə l e ɪ ʃ ə n
 articulatory	ɑː ɹ t ɪ k j ə l ə t ɔ ɹ i
 artifact	ɑ ɹ t ɪ f æ k t
 artifice	ɑː ɹ t ɪ f ɪ s
-artificer	ɑ ɹ t ɪ f ə s ə ɹ
-artificer	ɑ ɹ t ɪ f ɪ s ə ɹ
+artificer	ɑ ɹ t ɪ f ə s ɚ
+artificer	ɑ ɹ t ɪ f ɪ s ɚ
 artificial	ɑː ɹ t ə f ɪ ʃ ə l
 artillery	ɑ ɹ t ɪ l ə ɹ i
 artina	ɑ ɹ t i n ə
@@ -5360,14 +5425,13 @@ ashamed	ə ʃ e ɪ m d
 ashanti	ə ʃ æ n t iː
 ashanti	ə ʃ ɑː n t iː
 ashed	æ ʃ t
-ashen	æ ʃ ɪ n
-asher	æ ʃ ə ɹ
+ashen	æ ʃ ə n
 asher	æ ʃ ɚ
 asherah	ə ʃ i ɹ ə
 ashes	æ ʃ ɪ z
 ashfield	æ ʃ f iː l d
 ashine	ə ʃ a ɪ n
-ashiver	ə ʃ ɪ v ə ɹ
+ashiver	ə ʃ ɪ v ɚ
 ashkelon	æ ʃ k ə l ɒ n
 ashkenazi	ɑː ʃ k ɪ n ɑː z i
 ashkenazi	ɑː ʃ k ɪ n ə z iː
@@ -5408,7 +5472,7 @@ aslant	ə s l ɑː n t
 asleep	ə s l iː p
 aslope	ə s l ə ʊ p
 asmara	æ s m ɑː ɹ ə
-asmear	ə s m ɪ ə ɹ
+asmear	ə s m ɪ ɚ
 asmodeus	æ z m ə d iː ə s
 asmrtist	e ɪ ɛ s ɛ m ɑ ɹ t ɪ s t
 asnarl	ə s n ɑː ɹ l
@@ -5432,11 +5496,11 @@ aspectable	æ s p ɛ k t ə b ə l
 aspects	æ s p ɛ k t s
 aspectual	æ s p ɛ k t j ʊ ə l
 aspen	æ s p ə n
-asper	æ s p ə ɹ
+asper	æ s p ɚ
 asperate	æ s p ə ɹ e ɪ t
 asperate	æ s p ə ɹ ə t
 asperge	ə s p ɜː ɹ d͡ʒ
-asperger	æ s p ɜː ɹ ɡ ə ɹ
+asperger	æ s p ɜː ɹ ɡ ɚ
 aspergilloma	æ s p ə ɹ d͡ʒ ɪ l o ʊ m ə
 aspergilloses	æ s p ə ɹ d͡ʒ ɪ l o ʊ s i s
 aspergillosis	æ s p ə ɹ d͡ʒ ɪ l o ʊ s ɪ s
@@ -5589,13 +5653,13 @@ assyrogenous	æ s ɪ ɹ ɑ d͡ʒ ɪ n ə s
 assythment	ə s a ɪ ð m ə n t
 astana	æ s t ɑː n ə
 astand	ə s t æ n d
-astare	ə s t ɛ ə ɹ
+astare	ə s t ɛ ɚ
 astart	ə s t ɑː ɹ t
 astasia	ə s t e ɪ z i ə
 astasia	ə s t e ɪ ʒ ə
 astatine	æ s t ə t i n
 astay	ə s t e ɪ
-aster	æ s t ə ɹ
+aster	æ s t ɚ
 asterisk	æ s t ə ɹ ɪ k s
 asterisk	æ s t ə ɹ ɪ s k
 asterism	æ s t ə ɹ ɪ z ə m
@@ -5648,7 +5712,7 @@ astrogeometry	æ s t ɹ ə d͡ʒ iː ɑ m ɛ t ɹ i
 astrohistory	æ s t ɹ ə h ɪ s t ə ɹ i
 astrolabe	æ s t ɹ ə l e ɪ b
 astrolinguistics	æ s t ɹ ə l ɪ ŋ ɡ w ɪ s t ɪ k s
-astrologer	ə s t r ɒ l ə d͡ʒ ə ɹ
+astrologer	ə s t r ɒ l ə d͡ʒ ɚ
 astrological	æ s t ɹ ə l ɒ d͡ʒ ɪ k ə l
 astronaut	æ s t ɹ ə n ɔ t
 astronomer	ə s t ɹ ɑ n ə m ɚ
@@ -5741,8 +5805,8 @@ atherine	æ θ ə ɹ a ɪ n
 atherine	æ θ ə ɹ ɪ n
 athermic	e ɪ θ ɜ ɹ m ɪ k
 athetesis	æ θ ɪ t iː s ɪ s
-athleisure	æ θ l iː ʒ ə ɹ
-athleisure	æ θ l ɛ ʒ ə ɹ
+athleisure	æ θ l iː ʒ ɚ
+athleisure	æ θ l ɛ ʒ ɚ
 athlete	æ θ l i t
 athletics	æ θ l ɛ t ɪ k s
 athos	æ θ ɒ s
@@ -5777,6 +5841,7 @@ atoll	ə t ɑ l
 atoltivimab	æ t ɒ l t ɪ v ɪ m æ b
 atom	æ t ə m
 atomic	ə t ɑː m ɪ k
+atomicity	æ t ə m ɪ s ɪ t i
 atomist	æ t ə m ɪ s t
 atompunk	æ t ə m p ʌ ŋ k
 atoms	a t ə m z
@@ -5807,6 +5872,7 @@ atrium	e ɪ t ɹ i ə m
 atrocious	ə t ɹ o ʊ ʃ ə s
 atrocity	ə t ɹ ɒ s ɪ t i
 atrophy	æ t ɹ ə f i
+atropia	ə t ɹ ə ʊ p i ə
 atropine	æ t ɹ ə p i n
 atropos	æ t ɹ ə p ɒ s
 atrous	e ɪ t ɹ ə s
@@ -5866,7 +5932,7 @@ attesting	ə t ɛ s t ɪ ŋ
 attests	ə t ɛ s t s
 attic	æ t ɪ k
 attinge	ə t ɪ n d͡ʒ
-attire	ə t a ɪ ə ɹ
+attire	ə t a ɪ ɚ
 attitude	æ t ɪ t u d
 attitudinize	æ t ɪ t j uː d ɪ n a ɪ z
 attitudinize	æ t ɪ t uː d ɪ n a ɪ z
@@ -5897,7 +5963,7 @@ atwinkle	ə t w ɪ ŋ k ə l
 atwirl	ə t w ɜː ɹ l
 atwist	ə t w ɪ s t
 atwitch	ə t w ɪ t͡ʃ
-atwitter	ə t w ɪ t ə ɹ
+atwitter	ə t w ɪ t ɚ
 atyrau	ɑ t ɪ ɹ a ʊ
 aubade	o ʊ b ɑ d
 aube	ɔː b
@@ -5906,7 +5972,8 @@ aubrey	ɔː b ɹ i
 auburn	ɔ b ɚ n
 auburn	ɔː b ə ɹ n
 auckland	ɔː k l ə n d
-auction	ɔː k ʃ ə n
+auction	ɑ k ʃ ə n
+auction	ɔ k ʃ ə n
 audacious	ɔ d e ɪ ʃ ə s
 audaciously	ɔ d e ɪ ʃ ə s l i
 audaciousness	ɔ d e ɪ ʃ ə s n ə s
@@ -5923,9 +5990,10 @@ audio	ɔ d i o ʊ
 audiology	ɔː d i ɒ l ə d͡ʒ i
 audiovisual	ɑ d i o ʊ v ɪ ʒ u ə l
 audiovisual	ɔ d i o ʊ v ɪ ʒ u ə l
+audit	ɑ d ɪ t
 audit	ɔ d ɪ t
 audition	ɔː d ɪ ʃ ə n
-auditor	ɔː d ɪ t ə ɹ
+auditor	ɔː d ɪ t ɚ
 auditorium	ɔ d ə t ɔ ɹ i ə m
 auditory	ɑː d ɪ t ɔ ɹ i
 auditory	ɔː d ɪ t ɔ ɹ i
@@ -6019,9 +6087,9 @@ austenesque	ɔ s t ə n ɛ s k
 austenian	ɔ s t i n i ə n
 austenite	ɔ s t ɪ n a ɪ t
 auster	ɒ s t ə
-auster	ɒ s t ə ɹ
+auster	ɒ s t ɚ
 auster	ɔː s t ə
-auster	ɔː s t ə ɹ
+auster	ɔː s t ɚ
 austere	ɔ s t i ɹ
 austerely	ɔ s t i ə ɹ l i
 austerity	ɔ s t ɛ ɹ ɪ t i
@@ -6042,14 +6110,14 @@ australiana	ɔ s t ɹ e ɪ l i ɑ n ə
 australianise	ɒ s t ɹ e ɪ l j ə n a ɪ z
 australianize	ɒ s t ɹ e ɪ l j ə n a ɪ z
 austria	ɔ s t ɹ i ə
-austrian	ɔː s t ɹ i ə n
+austrian	ɔ s t ɹ i ə n
 austrians	ɔː s t ɹ i ə n s
 austronesia	ɒ s t ɹ ə n iː ʒ ə
 austronesian	ɔː s t ɹ o ʊ n iː ʒ ə n
 austronesians	ɔː s t ɹ o ʊ n iː ʒ ə n z
-autarchy	ɔː t ɑː ɹ k i
+autarchy	ɔ t ɑ ɹ k i
+autarky	ɔ t ɑ ɹ k i
 auteur	o ʊ t ɝ
-authentic	ɒ θ ɛ n t ɪ k
 authentic	ɔ θ ɛ n t ɪ k
 authenticate	ɔ θ ɛ n t ɪ k e ɪ t
 authenticity	ɑ θ ə n t ɪ s ɪ t i
@@ -6172,7 +6240,7 @@ avenge	ə v ɛ n d͡ʒ
 avens	æ v ɪ n z
 aventail	æ v ə n t e ɪ l
 aventine	æ v ə n t a ɪ n
-aventre	ə v ɛ n t ə ɹ
+aventre	ə v ɛ n t ɚ
 aventurine	ə v ɛ n t͡ʃ ə ɹ i n
 aventurine	ə v ɛ n t͡ʃ ə ɹ ɪ n
 avenue	æ v ə n j u
@@ -6222,6 +6290,7 @@ avoirdupois	æ v ɚ d ə p ɔ ɪ z
 avolition	e ɪ v ə l ɪ ʃ ə n
 avondale	e ɪ v ə n d e ɪ l
 avonmouth	e ɪ v ə n m ə θ
+avosentan	æ v ə s ɛ n t æ n
 avouch	ə v a ʊ t͡ʃ
 avourneen	ə v ɝ n iː n
 avourneen	ə v ʊ ɹ n iː n
@@ -6255,7 +6324,7 @@ awaze	ɑ w ɑ z e ɪ
 awaze	ɑ w ɑ z i
 awe	ɔ
 aweary	ə w ɪ ə ɹ i
-aweather	ə w ɛ ð ə ɹ
+aweather	ə w ɛ ð ɚ
 awed	ɔː d
 aweigh	ə w e ɪ
 aweless	ɔ l ɪ s
@@ -6281,7 +6350,7 @@ awkwards	ɔ k w ɚ d z
 awl	ɔ l
 awlwort	ɔː l w ɜː ɹ t
 awn	ɔː n
-awner	ɔː n ə ɹ
+awner	ɔː n ɚ
 awning	ɔ n ɪ ŋ
 awnry	ɔː n ɹ i
 awoke	ə w ə ʊ k
@@ -6346,7 +6415,7 @@ ayn	a ɪ n
 ayo	e ɪ j o ʊ
 ayoo	e ɪ o ʊ
 ayoo	e ɪ uː
-ayr	ɛ ə ɹ
+ayr	ɛ ɚ
 ayr	ɛ ɹ
 ayrab	e ɪ ɹ æ b
 ayrshire	ɛ ɚ ʃ ɪ ɚ
@@ -6371,14 +6440,14 @@ azinomycin	æ z i n o ʊ m a ɪ s ɪ n
 azinomycin	æ z ɪ n o ʊ m a ɪ s ɪ n
 aziridine	ə z ɪ ɹ ɪ d iː n
 azithromycin	ə z ɪ θ ɹ o ʊ m a ɪ s n̩
-aznavour	ɑː z n ə v ʊ ə ɹ
+aznavour	ɑː z n ə v ʊ ɚ
 azole	æ z o ʊ l
 azole	ə z o ʊ l
 azores	e ɪ z ɔː ɹ z
 azote	æ z ə ʊ t
 azotemia	æ z o ʊ t i m i ə
 azoth	æ z ɔ θ
-azotometer	e ɪ z ə ʊ t ɒ m ɪ t ə ɹ
+azotometer	e ɪ z ə ʊ t ɒ m ɪ t ɚ
 azov	e ɪ z ɑ v
 azov	e ɪ z ɔ f
 azov	æ z ɔ f
@@ -6424,7 +6493,7 @@ babblery	b æ b ə l ɹ i
 babby	b æ b i
 babe	b e ɪ b
 babel	b æ b l̩
-babergh	b e ɪ b ə ɹ
+babergh	b e ɪ b ɚ
 babes	b e ɪ b z
 babiche	b æ b iː ʃ
 babiche	b ə b iː ʃ
@@ -6477,7 +6546,7 @@ backcountry	b æ k k ʌ n t r i
 backdam	b æ k d æ m
 backdrop	b æ k d ɹ ɒ p
 backed	b æ k t
-backer	b æ k ə ɹ
+backer	b æ k ɚ
 backfield	b æ k f i l d
 backfisch	b æ k f ɪ ʃ
 backflip	b æ k f l ɪ p
@@ -6506,7 +6575,7 @@ backseaters	b æ k s i t ɚ z
 backside	b æ k s a ɪ d
 backslang	b æ k s l æ ŋ
 backslash	b æ k s l æ ʃ
-backslider	b æ k s l a ɪ d ə ɹ
+backslider	b æ k s l a ɪ d ɚ
 backspace	b æ k s p e ɪ s
 backspin	b æ k s p ɪ n
 backstab	b æ k s t æ b
@@ -6555,7 +6624,6 @@ badass	b æ d æ s
 badassery	b æ d æ s ə ɹ i
 baddams	b æ d ə m z
 baddeck	b ə d ɛ k
-badder	b æ d ə ɹ
 baddie	b æ d i
 bade	b e ɪ d
 bade	b æ d
@@ -6565,6 +6633,7 @@ baden	b ɑː d ə n
 badge	b æ d͡ʒ
 badger	b æ d ʒ ɚ
 badger	b æ d͡ʒ ɚ
+badigeon	b ə d ɪ d ʒ ə n
 badinage	b ɑ d ɪ n ɑ ʒ
 badine	b ə d iː n
 badinerie	b æ d ɪ n ɹ i
@@ -6577,7 +6646,7 @@ badness	b æ d n ə s
 badong	b ə d ɔ ŋ
 badonkadonk	b ə d ɔ ŋ k ə d ɔ ŋ k
 bae	b e ɪ
-baenomere	b iː n ə m ɪ ə ɹ
+baenomere	b iː n ə m ɪ ɚ
 baenopod	b iː n ə p ɒ d
 baetyl	b iː t a ɪ ɫ
 baff	b æ f
@@ -6638,7 +6707,7 @@ baihe	b a ɪ h ə
 baiji	b a ɪ d͡ʒ i
 baijiu	b a ɪ d͡ʒ uː
 baikal	b a ɪ k ɑː l
-baikonur	b a ɪ k ə n ɪ ə ɹ
+baikonur	b a ɪ k ə n ɪ ɚ
 bail	b e ɪ̯ l
 baile	b a ɪ l i
 baile	b e ɪ l
@@ -6700,7 +6769,8 @@ balaclava	b ɑː l ə k l ɑː v ə
 balalaika	b æ l ə l a ɪ k ə
 balance	b æ l ə n s
 balanced	b æ l ə n s t
-balancer	b æ l ə n s ə ɹ
+balancer	b æ l ə n s ɚ
+balanic	b ə l æ n ɪ k
 balanitis	b æ l ə n a ɪ t ɪ s
 balas	b a l ə s
 balaton	b æ l ə t ɒ n
@@ -6727,6 +6797,7 @@ baled	b e ɪ l d
 baleen	b e ɪ l iː n
 baleen	b ə l iː n
 baleful	b e ɪ l f ə l
+balenciaga	b ə l ɛ n s i ɑː ɡ ə
 bales	b e ɪ l z
 bali	b ɑː l i
 baling	b e ɪ l ɪ ŋ
@@ -6746,7 +6817,7 @@ balladry	b æ l ə d ɹ i
 ballarat	b æ l ə ɹ æ t
 ballast	b æ l ə s t
 ballcock	b ɔː l k ɒ k
-baller	b ɔː l ə ɹ
+baller	b ɔː l ɚ
 ballerina	b æ l ə ɹ iː n ə
 ballerino	b æ l ə ɹ iː n o ʊ
 ballet	b æ l e ɪ
@@ -6763,7 +6834,7 @@ ballistic	b ə l ɪ s t ɪ k
 ballistics	b ə l ɪ s t ɪ k s
 balloon	b ə l u n
 ballooned	b ə l uː n d
-ballooner	b ə l uː n ə ɹ
+ballooner	b ə l uː n ɚ
 ballooning	b ə l uː n ɪ ŋ
 balloonings	b ə l uː n ɪ ŋ z
 balloons	b ə l uː n z
@@ -6789,7 +6860,7 @@ balmily	b ɔ l m ə l i
 balmoral	b æ l m ɒ ɹ ə l
 balmy	b ɑː m i
 baloney	b ə l o ʊ n i
-balquhidder	b æ l k w ɪ d ə ɹ
+balquhidder	b æ l k w ɪ d ɚ
 balrog	b æ l ɹ ɑ ɡ
 balrog	b ɑ l ɹ ɑ ɡ
 balrog	b ɔ l ɹ ɑ ɡ
@@ -6797,7 +6868,7 @@ balsa	b ɑ l s ə
 balsamic	b ɔː l s æ m ɪ k
 balsamous	b ɔː l s ə m ə s
 balsamy	b ɑ l s ə m iː
-balthazar	b æ l θ e ɪ z ə ɹ
+balthazar	b æ l θ e ɪ z ɚ
 balthazar	b æ l θ ə z ɔ ɹ
 baltic	b ɑ l t ɪ k
 baltic	b ɔ l t ɪ k
@@ -6818,13 +6889,16 @@ bamboozle	b æ m b uː z l̩
 bambuterol	b æ m b j uː t ə ɹ ɒ l
 bamf	b æ m f
 bamma	b æ m ə
-bammer	b æ m ə ɹ
+bammer	b æ m ɚ
 bamp	b æ m p
 bampot	b æ m p ɒ t
 ban	b æ n
+banaba	b ə n ɑː b ə
 banal	b e ɪ n ə l
 banal	b ə n æ l
 banal	b ə n ɑː l
+banality	b e ɪ n æ l ɪ t i
+banality	b ə n æ l ɪ t i
 banana	b ə n æ n ə
 bananas	b ə n æ n ə z
 banausic	b ə n ɔ z ɪ k
@@ -6844,8 +6918,9 @@ bandings	b æ n d ɪ ŋ z
 bandit	b æ n d ɪ t
 bandmate	b æ n d m e ɪ t
 bandolero	b æ n d ə l e ə ɹ ə ʊ
-bandolier	b æ n d ə l ɪ ə ɹ
+bandolier	b æ n d ə l ɪ ɚ
 bandolierwise	b æ n d ə l ɪ ə ɹ w a ɪ z
+bandra	b æ n d ɹ ə
 bands	b æ n d z
 bandung	b ɑ n d ʊ ŋ
 bandura	b æ n d u ɹ ə
@@ -6861,14 +6936,14 @@ bangable	b æ ŋ ɡ ə b ə ɫ
 bangalore	b æ ŋ ɡ ə l o ɹ
 bangarang	b æ ŋ ə ɹ æ ŋ
 bangel	b e ɪ n d͡ʒ ə l
-banger	b æ ŋ ə ɹ
+banger	b æ ŋ ɚ
 banging	b æ ŋ ɪ ŋ
 bangiophyte	b æ n d͡ʒ ɪ ɔ f a ɪ t
 bangkok	b æ ŋ k ɒ k
 bangladesh	b æ ŋ ɡ l ə d ɛ ʃ
 bangladesh	b ɑː ŋ ɡ l ə d ɛ ʃ
 bangle	b æ ŋ ɡ ə l
-bangor	b æ ŋ ɡ ə ɹ
+bangor	b æ ŋ ɡ ɚ
 bangui	b ɑː ŋ ɡ i
 bangui	b ɑː ŋ ɡ iː
 baning	b e ɪ n ɪ ŋ
@@ -6878,7 +6953,7 @@ banishes	b æ n ɪ ʃ ɪ z
 banishing	b æ n ɪ ʃ ɪ ŋ
 banishings	b æ n ɪ ʃ ɪ ŋ z
 banishment	b æ n ɪ ʃ m ə n t
-banister	b æ n ɪ s t ə ɹ
+banister	b æ n ɪ s t ɚ
 banjax	b æ n d͡ʒ æ k s
 banjo	b æ n d͡ʒ o ʊ
 banjouke	b æ n d͡ʒ ə ʊ j uː k
@@ -7026,6 +7101,7 @@ bargello	b ɑ ɹ d͡ʒ ɛ l o ʊ
 bargello	b ɑ ɹ ʒ ɛ l o ʊ
 bari	b æ ɹ i
 baria	b ɛ ə ɹ i ə
+bariatric	b æ ɹ i æ t ɹ ɪ k
 bariatrician	b ɛ ɹ i ə t ɹ ɪ ʃ ə n
 barin	b ɑ ɹ ɪ n
 baring	b ɛ ɹ ɪ ŋ
@@ -7040,7 +7116,7 @@ bark	b ɑ ɹ k
 barken	b ɑː ɹ k ə n
 barker	b ɑ ɹ k ɚ
 barker	b ɑː r k ə r
-barker	b ɑː ɹ k ə ɹ
+barker	b ɑː ɹ k ɚ
 barking	b ɑ ɹ k ɪ ŋ
 barkley	b ɑ ɹ k l i
 barksian	b ɑ ɹ k s i ə n
@@ -7072,17 +7148,16 @@ barramundi	b æ ɹ ə m ʌ n d i
 barranca	b ə ɹ æ ŋ k ə
 barrasso	b ə ɹ æ s o ʊ
 barrasso	b ə ɹ ɑ s o ʊ
-barrator	b æ ɹ ə t ə ɹ
+barrator	b æ ɹ ə t ɚ
 barrators	b æ ɹ ə t ə ɹ z
 barratry	b æ ɹ ə t ɹ i
 barrel	b æ ɹ ə l
-barrel	b ɛ ɚ ɹ ə l
+barrel	b ɛ ɚ ə l
 barrett	b æ ɹ ɪ t
 barrette	b ə ɹ ɛ t
-barrier	b æ ɹ i ə ɹ
-barrier	b ɛ ɹ i ə ɹ
+barrier	b æ ɹ i ɚ
+barrier	b ɛ ɹ i ɚ
 barrow	b æ ɹ o ʊ
-barry	b æ ɹ i
 barry	b ɑ ɹ i
 barse	b ɑː ɹ s
 barside	b ɑ ɹ s a ɪ d
@@ -7096,9 +7171,6 @@ bartholow	b ɑː ɹ θ ə l ə ʊ
 bartisan	b ɑː t ɪ z æ n
 bartitsu	b ɑː t ɪ t s uː
 bartizan	b ɑː t ɪ z æ n
-baruch	b ɑ r u k
-baruch	b ə r u k
-baruch	b ɛ r ə k
 baryon	b æ ɹ i ɒ n
 baryon	b ɛ ə ɹ i ɒ n
 baryta	b ə ɹ a ɪ t ə
@@ -7135,7 +7207,7 @@ bashes	b æ ʃ ɪ z
 bashing	b æ ʃ ɪ ŋ
 bashings	b æ ʃ ɪ ŋ z
 bashir	b ə ʃ i ɹ
-bashkir	b ɑː ʃ k ɪ ə ɹ
+bashkir	b ɑː ʃ k ɪ ɚ
 bashlyk	b æ ʃ l ɪ k
 basic	b e ɪ s ɪ k
 basically	b e ɪ s ɪ k ə l i
@@ -7160,9 +7232,10 @@ basis	b e ɪ s ɪ s
 bask	b æ s k
 baskerville	b æ s k ɚ v ɪ l
 basket	b æ s k ɪ t
-basketball	b æ s k ɪ t b ɔː l
-basler	b æ z l ə ɹ
-basler	b ɑː z l ə ɹ
+basketball	b æ s k ɪ t b ɑ l
+basketball	b æ s k ɪ t b ɔ l
+basler	b æ z l ɚ
+basler	b ɑː z l ɚ
 basophil	b e ɪ s ə f ɪ l
 basque	b æ s k
 basque	b ɑː s k
@@ -7170,13 +7243,14 @@ bass	b e ɪ s
 bass	b æ s
 bassaleg	b æ s æ l ɛ ɡ
 bassein	b ə s e ɪ n
+basseterre	b æ s t ɛ ə ɹ
 bassinet	b æ s ɪ n ɛ t
 bassist	b e ɪ s ɪ s t
 bassline	b e ɪ s l a ɪ n
 basslines	b e ɪ s l a ɪ n z
 bassoon	b ə s u n
 bassooned	b ə s uː n d
-bassooner	b ə s uː n ə ɹ
+bassooner	b ə s uː n ɚ
 bassooning	b ə s uː n ɪ ŋ
 bassoons	b ə s uː n z
 basswood	b æ s w ʊ d
@@ -7296,6 +7370,7 @@ bawson	b ɔː s ə n
 bawtry	b ɔː t ɹ i
 baxter	b æ k s t ɚ
 bay	b e ɪ
+baybayin	b a ɪ b a j i n
 bayed	b e ɪ d
 bayesian	b e ɪ z i ə n
 bayesian	b e ɪ ʒ ə n
@@ -7348,6 +7423,7 @@ beadings	b iː d ɪ ŋ z
 beads	b iː d z
 beadsman	b iː d z m ə n
 beady	b i d i
+beagle	b iː ɡ ə l
 beaked	b iː k t
 beaker	b iː k ɚ
 beaking	b iː k ɪ ŋ
@@ -7423,7 +7499,7 @@ beaus	b o ʊ z
 beaut	b j uː t
 beauties	b j uː t i z
 beautifies	b j u t ə f a ɪ z
-beautiful	b j uː t ɪ f ə l
+beautiful	b j u t ɪ f ə l
 beautifully	b j uː t ɪ f ə l i
 beautify	b j uː t ɪ f a ɪ
 beautility	b j uː t ɪ l ə t i
@@ -7463,6 +7539,7 @@ beckonings	b ɛ k ə n ɪ ŋ z
 beckons	b ɛ k ə n z
 becky	b ɛ k i
 becloud	b ɪ k l a ʊ d
+become	b i k ʌ m
 become	b ə k ʌ m
 become	b ɪ k ʌ m
 becomes	b ə k ʌ m z
@@ -7535,7 +7612,6 @@ beeping	b iː p ɪ ŋ
 beepings	b iː p ɪ ŋ z
 beeps	b iː p s
 beer	b i ɚ
-beer	b ɪ ə ɹ
 beer	b ɪ ɚ
 beer	b ɪ ɹ
 beers	b i ɹ z
@@ -7629,13 +7705,17 @@ behelp	b ɪ h ɛ l p
 behemoth	b iː ə m ə θ
 behemoth	b ə h iː m ə θ
 behest	b i h ɛ s t
+behest	b ɪ h ɛ s t
 behind	b iː h a ɪ n d
 behind	b ə h a ɪ n d
 behind	b ɪ h a ɪ n d
 behl	b e ɪ l
 behold	b ɪ h o ʊ l d
+beholden	b ɪ h o ʊ l d ə n
 beholder	b ɪ h o ʊ l d ɚ
+behoove	b ɪ h uː v
 behove	b i h o ʊ v
+behoven	b i h o ʊ v ə n
 beibei	b e ɪ b e ɪ
 beida	b e ɪ d a
 beige	b e ɪ d͡ʒ
@@ -7643,6 +7723,7 @@ beige	b e ɪ ʒ
 beigey	b e ɪ ʒ i
 beignet	b ɛ n j e ɪ
 beijing	b e ɪ d͡ʒ ɪ ŋ
+beijinger	b e ɪ d ʒ ɪ ŋ ə ɹ
 bein	b iː n
 being	b i ŋ
 being	b i ɪ ŋ
@@ -7700,6 +7781,7 @@ belief	b ɪ l iː f
 believe	b ɪ l i v
 believer	b ɪ l i v ɚ
 belinda	b ə l ɪ n d ə
+belittle	b ɪ l ɪ t ə l
 belive	b ə l a ɪ v
 beliven	b ə l ɪ v ə n
 belize	b e ɪ l iː z
@@ -7752,7 +7834,7 @@ beloved	b ɪ l ʌ v d
 beloved	b ɪ l ʌ v ɪ d
 below	b ɪ l o ʊ
 belphegor	b ɛ l f ə ɡ ɔ ɹ
-belswagger	b ɛ l s w æ ɡ ə ɹ
+belswagger	b ɛ l s w æ ɡ ɚ
 belt	b ɛ l t
 belted	b ɛ l t ɪ d
 belter	b ɛ l t ɚ
@@ -7767,7 +7849,7 @@ bema	b iː m ə
 bemean	b ɪ m iː n
 bemidji	b ə m ɪ d͡ʒ i
 bemingle	b ɪ m ɪ ŋ ɡ ə l
-bemire	b ə m a ɪ ə ɹ
+bemire	b ə m a ɪ ɚ
 bemoan	b ɪ m o ʊ n
 bemol	b iː m ɒ l
 bemuse	b ə m j uː z
@@ -7779,7 +7861,7 @@ benatoprazole	b ɛ n ə t ɒ p ɹ ə z o ʊ l
 benbecula	b ɛ n b ɛ k j ʊ l ə
 bench	b ɛ n t͡ʃ
 benched	b ɛ n t͡ʃ t
-bencher	b ɛ n t͡ʃ ə ɹ
+bencher	b ɛ n t͡ʃ ɚ
 benches	b ɛ n t͡ʃ ɪ z
 benching	b ɛ n t͡ʃ ɪ ŋ
 benchings	b ɛ n t͡ʃ ɪ ŋ z
@@ -7800,6 +7882,7 @@ beneficence	b ə n ɛ f ɪ s ə n s
 beneficent	b ə n ɛ f ə s ə n t
 beneficial	b ɛ n ə f ɪ ʃ ə l
 beneficiary	b ɛ n ə f ɪ ʃ i ɚ i
+beneficiary	b ɛ n ɪ f ɪ ʃ ɚ i
 beneficient	b ɛ n ə f ɪ ʃ ə n t
 benefit	b ɛ n ə f ɪ t
 benegro	b ɪ n iː ɡ ɹ ə ʊ
@@ -7846,6 +7929,7 @@ benzathine	b ɛ n z ə θ i n
 benzatropine	b ɛ n z æ t ɹ ə p i n
 benzene	b ɛ n z iː n
 benzocaine	b ɛ n z ə k e ɪ n
+benzodiazepine	b ɛ n z o ʊ d a ɪ æ z ɪ p iː n
 benzonatate	b ɛ n z o ʊ n ə t e ɪ t
 benzopyrazine	b ɛ n z ə ʊ p a ɪ ɹ ə z iː n
 benzoyl	b ɛ n z ə ʊ a ɪ l
@@ -7887,7 +7971,7 @@ bere	b ɪ ə
 bereave	b ɪ ɹ iː v
 bereaved	b ɪ r iː v d
 bereft	b ə ɹ ɛ f t
-berengar	b ɛ ɹ ɪ ŋ ɡ ə ɹ
+berengar	b ɛ ɹ ɪ ŋ ɡ ɚ
 berenice	b ɛ r ə n a ɪ s i
 berenice	b ɛ r ə n iː s
 berenice	b ɛ r ə n iː s i
@@ -7926,6 +8010,7 @@ berserker	b ɚ s ɚ k ɚ
 berserker	b ɚ z ɚ k ɚ
 bert	b ɝ t
 berth	b ɝ θ
+bertha	b ɜː ɹ θ ə
 bertha	b ɝ θ ə
 berwick	b ɝ w ɪ k
 beryl	b ɛ ɹ ə l
@@ -7985,6 +8070,7 @@ bestiary	b ɛ s t i ɛ r i
 bestie	b ɛ s t i
 besting	b ɛ s t ɪ ŋ
 bestir	b i s t ɝ
+bestir	b ə s t ɝ
 bestir	b ɪ s t ɝ
 bestow	b ɪ s t o ʊ
 bestowal	b ɪ s t o ʊ ə l
@@ -8000,8 +8086,8 @@ betamethasone	b e ɪ t ə m ɛ θ ə s o ʊ n
 betaxolol	b ə t æ k s ə l ɔ l
 betcha	b ɛ t͡ʃ ə
 betcho	b ɛ t͡ʃ o ʊ
-betear	b ɪ t ɛ ə ɹ
-betear	b ɪ t ɪ ə ɹ
+betear	b ɪ t ɛ ɚ
+betear	b ɪ t ɪ ɚ
 betelgeuse	b i d l d ʒ u s
 betelgeuse	b i d l d ʒ u z
 betelgeuse	b ɛ d l d ʒ u s
@@ -8064,11 +8150,11 @@ bevor	b i v ɚ
 bevvy	b ɛ v i
 bevy	b ɛ v i
 bewail	b ɪ w e ɪ l
-beware	b i w ɛ ə ɹ
-beware	b ə w ɛ ə ɹ
-beware	b ɪ w ɛ ə ɹ
-bewater	b ɪ w ɔː t ə ɹ
-bewelter	b ɪ w ɛ l t ə ɹ
+beware	b i w ɛ ɚ
+beware	b ə w ɛ ɚ
+beware	b ɪ w ɛ ɚ
+bewater	b ɪ w ɔː t ɚ
+bewelter	b ɪ w ɛ l t ɚ
 bewhape	b ɪ w e ɪ p
 bewhape	b ɪ ʍ e ɪ p
 bewhore	b ɪ h ɔː ɹ
@@ -8118,7 +8204,7 @@ bhaji	b ɑː d͡ʒ i
 bhang	b a ŋ
 bhang	b æ ŋ
 bhangra	b ɑː ŋ ɡ ɹ ə
-bheer	b ɪ ə ɹ
+bheer	b ɪ ɚ
 bhikkhu	b ɪ k uː
 bhojpuri	b o ʊ d͡ʒ p ʊ ə r i
 bhopal	b ə ʊ p ɑː l
@@ -8150,6 +8236,7 @@ bibliometrist	b ɪ b l i ɒ m ə t ɹ ɪ s t
 bibliopoly	b ɪ b l i ɑ p ə l i
 bibliotheca	b ɪ b l i ə θ iː k ə
 bibliothecal	b ɪ b l i ə θ iː k ə l
+bibliotheque	b ɪ b l i ə θ iː k
 bibliotic	b ɪ b l i ɒ t ɪ k
 biblist	b ɪ b l ɪ s t
 bibs	b ɪ b z
@@ -8164,9 +8251,9 @@ bicep	b a ɪ s ɛ p
 bicephaly	b a ɪ s ɛ f ə l i
 biceps	b a ɪ s ɛ p s
 bicester	b ɪ s t ɚ
-bichir	b iː ʃ ə ɹ
+bichir	b iː ʃ ɚ
 bichir	b ɪ ʃ iː ɹ
-bichir	b ɪ ʃ ə ɹ
+bichir	b ɪ ʃ ɚ
 bichon	b i ʃ ɔ n
 bicipital	b a ɪ s ɪ p ə t ə l
 bicipital	b a ɪ s ɪ p ɪ t ə l
@@ -8192,7 +8279,7 @@ bide	b a ɪ d
 bided	b a ɪ d ɪ d
 bideford	b ɪ d ɪ f ə r d
 biden	b a ɪ d ə n
-bidencare	b a ɪ d ə n k ɛ ə ɹ
+bidencare	b a ɪ d ə n k ɛ ɚ
 bidenomics	b a ɪ d ə n ɒ m ɪ k s
 bides	b a ɪ d z
 bidet	b ɪ d e ɪ
@@ -8204,7 +8291,8 @@ bids	b ɪ d z
 bieber	b i b ɚ
 biennial	b a ɪ ɛ n i ə l
 biennium	b a ɪ ɛ n i ə m
-bier	b i ɚ
+bier	b ɪ ɚ
+bifarious	b a ɪ f ɛ ə ɹ i ə s
 bifenthrin	b a ɪ f ɛ n θ ɹ ɪ n
 bifeprunox	b ɪ f ɛ p ɹ ə n ɒ k s
 biff	b ɪ f
@@ -8250,7 +8338,7 @@ bikini	b ɪ k iː n i
 bikini	b ɪ k ɪ n i
 bilabial	b a ɪ l e ɪ b i ə l
 bilali	b ɪ l ɑː l i
-bilander	b ɪ l ə n d ə ɹ
+bilander	b ɪ l ə n d ɚ
 bilateral	b a ɪ l æ t ə ɹ ə l
 bilbao	b ɪ l b a ʊ
 bilberry	b ɪ l b ə ɹ ɪ
@@ -8297,7 +8385,6 @@ bimetallic	b a ɪ m ɪ t æ l ɪ k
 bimillennial	b a ɪ m ɪ l ɛ n i ə l
 bimini	b ɪ m ɪ n i
 bimini	b ɪ m ɪ n iː
-bin	b iː n
 bin	b ɪ n
 binal	b a ɪ n ə l
 binarseniate	b a ɪ n ɑː ɹ s iː n i e ɪ t
@@ -8312,7 +8399,11 @@ bine	b a ɪ n
 bines	b a ɪ n z
 bing	b ɪ ŋ
 binge	b ɪ n d͡ʒ
+binged	b ɪ n d͡ʒ d
+binged	b ɪ ŋ d
 binghi	b ɪ ŋ a ɪ
+binging	b ɪ n d͡ʒ ɪ ŋ
+binging	b ɪ ŋ ɪ ŋ
 bingo	b ɪ ŋ ɡ o ʊ
 bingy	b ɪ ŋ i
 binhai	b ɪ n h a ɪ
@@ -8327,8 +8418,9 @@ binner	b ɪ n ɚ
 binning	b ɪ n ɪ ŋ
 binns	b ɪ n z
 binny	b ɪ n i
-binocular	b ɪ n ɒ k j ʊ l ə ɹ
+binocular	b ɪ n ɒ k j ʊ l ɚ
 binomial	b a ɪ n o ʊ m i ə l
+binoxide	b a ɪ n ɒ k s a ɪ d
 bins	b ɪ n z
 bint	b ɪ n t
 bintje	b ɪ n t͡ʃ ə
@@ -8339,6 +8431,7 @@ bioanalytics	b a ɪ o ʊ æ n ə l ɪ t ɪ k s
 biocide	b a ɪ o ʊ s a ɪ d
 biodegradable	b a ɪ o ʊ d ə ɡ ɹ e ɪ d ə b l̩
 biodegradable	b a ɪ ə d ə ɡ ɹ e ɪ d ə b l̩
+biodiversity	b a ɪ o ʊ d ə v ɚ s ə t i
 biodomain	b a ɪ o ʊ d o ʊ m e ɪ n
 biodome	b a ɪ o ʊ d o ʊ m
 biogenesis	b a i o ʊ d͡ʒ ɛ n ə s ɪ s
@@ -8398,7 +8491,7 @@ birefringence	b a ɪ ɹ ɪ f ɹ ɪ n d͡ʒ ə n s
 birkenhead	b ɜː k ə n h ɛ d
 birl	b ɝ l
 birr	b ɝ
-birr	b ɪ ə ɹ
+birr	b ɪ ɚ
 birse	b ɜː ɹ s
 birt	b ɜː ɹ t
 birth	b ɝ ð
@@ -8511,16 +8604,16 @@ bizen	b a ɪ z ə n
 biñan	b ɪ n j a ʊ n
 blab	b l æ b
 blabbed	b l æ b d
-blabber	b l æ b ə ɹ
+blabber	b l æ b ɚ
 blabbing	b l æ b ɪ ŋ
 blabby	b l æ b i
 blabs	b l æ b z
 black	b l æ k
-blackadder	b l æ k æ d ə ɹ
+blackadder	b l æ k æ ɚ
 blackamoor	b l æ k ə m ɔ ɹ
 blackamoor	b l æ k ə m ʊ ɹ
 blackball	b l æ k b ɔː l
-blackberry	b l æ k b e ɹ i
+blackberry	b l æ k b ɛ ɹ i
 blackbird	b l æ k b ɚ d
 blackboard	b l æ k b o ɹ d
 blackboard	b l æ k b ɔ ɹ d
@@ -8563,14 +8656,14 @@ blaeberry	b l e ɪ b ə ɹ i
 blaenrhondda	b l a ɪ n r ɒ n ð ə
 blag	b l æ ɡ
 blaggard	b l æ ɡ ə d
-blagger	b l æ ɡ ə ɹ
+blagger	b l æ ɡ ɚ
 blagoveshchensk	b l ɑ ɡ ə v ɛ ʃ t͡ʃ ɛ n s k
 blah	b l a
 blahaj	b l o ʊ h a ɪ
 blahaj	b l ɑː h ɑː ʒ
 blain	b l e ɪ n
 blaine	b l e ɪ n
-blair	b l ɛ ə ɹ
+blair	b l ɛ ɚ
 blaisdon	b l e ɪ z d ə n
 blake	b l e ɪ k
 blamable	b l e ɪ m ə b ə l
@@ -8590,8 +8683,8 @@ blanchability	b l æ n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l æ n ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n t͡ʃ ə b ɪ l ɪ t i
 blanchability	b l ɑː n ʃ ə b ɪ l ɪ t i
-blancher	b l æ n t͡ʃ ə ɹ
-blancher	b l ɑː n t͡ʃ ə ɹ
+blancher	b l æ n t͡ʃ ɚ
+blancher	b l ɑː n t͡ʃ ɚ
 blancmange	b l ə m ɑ n d͡ʒ
 blanco	b l æ ŋ k ə ʊ
 bland	b l æ n d
@@ -8603,7 +8696,7 @@ blanket	b l æ ŋ k ɪ t
 blankie	b l æ ŋ k i
 blankley	b l æ ŋ k l i
 blanquette	b l ɑ ŋ k ɛ t
-blare	b l ɛ ə ɹ
+blare	b l ɛ ɚ
 blarney	b l ɑ ɹ n i
 blasian	b l e ɪ ʒ ə n
 blaspheme	b l æ s f i m
@@ -8628,12 +8721,12 @@ blazer	b l e ɪ z ɚ
 blazes	b l e ɪ z ɪ z
 blazing	b l e ɪ z ɪ ŋ
 blazon	b l e ɪ z ə n
-blazoner	b l e ɪ z ə n ə ɹ
+blazoner	b l e ɪ z ə n ɚ
 blazoning	b l e ɪ z ə n ɪ ŋ
 blazonry	b l e ɪ z ə n ɹ i
 bleach	b l iː t͡ʃ
 bleached	b l iː t͡ʃ t
-bleacher	b l iː t͡ʃ ə ɹ
+bleacher	b l iː t͡ʃ ɚ
 bleaching	b l iː t͡ʃ ɪ ŋ
 blead	b l iː d
 bleak	b l iː k
@@ -8676,8 +8769,8 @@ blessedness	b l ɛ s ɪ d n ɪ s
 blesses	b l ɛ s ɪ z
 blessing	b l ɛ s ɪ ŋ
 blessings	b l ɛ s ɪ ŋ z
-blessure	b l ɛ s j ʊ ə ɹ
-blessure	b l ɛ ʃ ə ɹ
+blessure	b l ɛ s j ʊ ɚ
+blessure	b l ɛ ʃ ɚ
 blessèd	b l ɛ s ə d
 blest	b l ɛ s t
 blet	b l ɛ t
@@ -8711,7 +8804,7 @@ blindside	b l a ɪ n d s a ɪ d
 bling	b l ɪ ŋ
 blink	b l ɪ ŋ k
 blinkard	b l ɪ ŋ k ə ɹ d
-blinker	b l ɪ ŋ k ə ɹ
+blinker	b l ɪ ŋ k ɚ
 blinks	b l ɪ ŋ k s
 blinky	b l ɪ ŋ k i
 blip	b l ɪ p
@@ -8727,7 +8820,7 @@ blithedale	b l a ɪ θ d e ɪ l
 blitheful	b l a ɪ ð f ʊ l
 blitheful	b l a ɪ θ f ʊ l
 blithely	b l a ɪ ð l i
-blither	b l a ɪ ð ə ɹ
+blither	b l a ɪ ð ɚ
 blither	b l ɪ ð ɚ
 blitz	b l ɪ t s
 blitzed	b l ɪ t s t
@@ -9006,7 +9099,7 @@ boiling	b ɔ ɪ l ɪ ŋ
 boilings	b ɔ ɪ l ɪ ŋ z
 boils	b ɔ ɪ l z
 boinc	b ɔ ɪ ŋ k
-boing	b o ɪ ŋ
+boing	b ɔ ɪ ŋ
 boingy	b ɔ ɪ ŋ ɡ iː
 boink	b ɔ ɪ ŋ k
 boise	b ɔ ɪ s iː
@@ -9079,6 +9172,7 @@ bonanza	b ə n æ n z ə
 bonapartism	b o ʊ n ə p ɑ ɹ t ɪ z ə m
 bonavista	b o ʊ n ə v ɪ s t ə
 bonbright	b ɔ n b ɹ a ɪ t
+bonce	b ɒ n s
 bond	b ɑ n d
 bondage	b ɑ n d ɪ d͡ʒ
 bonds	b ɑ n d z
@@ -9100,7 +9194,7 @@ bonism	b ɑ n ɪ z ə m
 bonjour	b ɑ n ʒ ʊ ɹ
 bonk	b ɑ ŋ k
 bonk	b ɔ ŋ k
-bonkers	b ɒ ŋ k ɚ z
+bonkers	b ɑ ŋ k ɚ z
 bonkler	b ɒ ŋ k l ɚ
 bonnet	b ɑ n ɪ t
 bonnie	b ɒ n i
@@ -9111,6 +9205,7 @@ bonsai	b ɑ n z a ɪ
 bonspiel	b ɑ n s p iː l
 bonus	b o ʊ n ə s
 bony	b o ʊ n i
+bonytail	b o ʊ n i t e ɪ l
 bonza	b ɒ n z ə
 bonze	b ɒ n z
 bonzer	b ɒ n z ə
@@ -9137,6 +9232,7 @@ bookie	b ʊ k i
 booking	b ʊ k ɪ ŋ
 bookings	b ʊ k ɪ ŋ z
 bookish	b ʊ k ɪ ʃ
+bookkeeping	b ʊ k k iː p ɪ ŋ
 booklegging	b ʊ k l ɛ ɡ ɪ ŋ
 booklet	b ʊ k l ə t
 booklist	b ʊ k l ɪ s t
@@ -9193,6 +9289,7 @@ booths	b uː ð z
 booths	b uː θ s
 bootikin	b uː t ɪ k ɪ n
 bootle	b uː t ə l
+bootleggery	b uː t l ɛ ɡ ə ɹ i
 boots	b uː t s
 bootstrap	b uː t s t ɹ æ p
 bootsy	b u t s i
@@ -9253,6 +9350,7 @@ borromean	b ɒ r ə m iː ə n
 borrovian	b ə ɹ o ʊ v i ə n
 borrow	b ɑ ɹ o ʊ
 borrowed	b ɑ ɹ o ʊ d
+borrowed	b ɔ ɹ o ʊ d
 borsch	b ɔ ɹ ʃ
 borscht	b ɔ ɹ ʃ t
 bortezomib	b ɔ ɹ t ɛ z o ʊ m ɪ b
@@ -9263,6 +9361,7 @@ bosanquet	b o ʊ z ə n k ɛ t
 bosanquet	b o ʊ z ə n k ɪ t
 boscage	b ɑ s k ɪ d͡ʒ
 bose	b o ʊ s
+bosentan	b ə ʊ s ɛ n t æ n
 bosh	b ɑ ʃ
 bosk	b ɑ s k
 bosket	b ɒ s k ɪ t
@@ -9280,6 +9379,7 @@ bosque	b ɑ s k
 bosque	b ɑ s k e ɪ
 bosques	b ɒ s k e ɪ z
 boss	b ɔ s
+bossale	b o ʊ s æ l
 bossman	b ɔ s m æ n
 bossy	b ɔ s i
 boston	b ɔ s t ə n
@@ -9312,6 +9412,8 @@ bottom	b ɑ t ə m
 bottoms	b ɑ t ə m s
 botty	b ɒ t i
 botulism	b ɑ t͡ʃ ə l ɪ z ə m
+botw	b ɑː t w ə
+botw	b ɔː t w ə
 botwood	b ɒ t w ʊ d
 bouche	b uː ʃ
 bouclé	b uː k l e ɪ
@@ -9328,6 +9430,9 @@ bougainvillea	b o ʊ ɡ ə n v ɪ l j ə
 bougainvillea	b u ɡ ə n v ɪ l j ə
 bougar	b u ɡ ɚ
 bouge	b uː d͡ʒ
+bouget	b uː d ʒ ɛ t
+bouget	b uː d ʒ ɪ t
+bouget	b uː ɡ ɛ t
 bough	b a ʊ
 boughs	b a ʊ z
 bought	b ɔ t
@@ -9345,6 +9450,8 @@ boul	b uː l
 boulder	b o ʊ l d ə ɹ
 boule	b uː l
 boulevard	b ʊ l ə v ɑ ɹ d
+boulevardier	b ʊ l ə v ɑ ɹ d j e ɪ
+boulevardier	b ʊ l ə v ɑ ɹ d ɪ ɹ
 boulogne	b ə l ɔ ɪ n
 boulogne	b ʊ l ɔ ɪ n
 boulton	b o ʊ l t ə n
@@ -9459,11 +9566,12 @@ boyfriend	b ɔ ɪ f ɹ ɛ n d
 boyhood	b ɔ ɪ h ʊ d
 boyish	b ɔ ɪ ɪ ʃ
 boykin	b ɔ ɪ k ə n
+boymoder	b ɔ ɪ m o ʊ d ɚ
 boys	b ɔ ɪ z
 boysenberry	b ɔ ɪ z n̩ b ɛ ɹ i
 bozal	b o ʊ s æ l
 bozal	b o ʊ z æ l
-bozo	b o ʊ z o ʊ
+bozo	b ə ʊ z ə ʊ
 boötes	b o ʊ o ʊ t iː z
 bra	b ɹ ɑː
 braai	b ɹ a ɪ
@@ -9591,6 +9699,7 @@ branny	b ɹ æ n i
 brans	b ɹ æ n z
 branson	b ɹ æ n s ə n
 brant	b ɹ æ n t
+branta	b r æ n t ə
 brantle	b ɹ æ n t ə l
 brash	b ɹ æ ʃ
 brass	b ɹ æ s
@@ -9656,6 +9765,7 @@ breachings	b ɹ iː t͡ʃ ɪ ŋ z
 bread	b ɹ ɛ d
 breadalbane	b r ə d ɔː l b æ n
 breadbasket	b ɹ ɛ d b æ s k ɪ t
+breadbox	b ɹ ɛ d b ɑ k s
 breadcrumb	b ɹ ɛ d k r ʌ m
 breadfruit	b ɹ e d f ɹ uː t
 breadmaker	b ɹ ɛ d m e ɪ k ɚ
@@ -9701,7 +9811,7 @@ breathe	b ɹ i ð
 breathed	b ɹ iː ð d
 breathed	b ɹ ɛ θ t
 breathes	b ɹ iː ð z
-breathing	b ɹ iː ð ɪ ŋ
+breathing	b ɹ i ð ɪ ŋ
 breathings	b ɹ iː ð ɪ ŋ z
 breathless	b ɹ ɛ θ l ə s
 breaths	b ɹ ɛ θ s
@@ -10109,6 +10219,7 @@ bruv	b ɹ ʌ v
 bruvver	b ɹ ʌ v ɚ
 brux	b ɹ ʌ k s
 bruxism	b ɹ ʌ k s ɪ z ə m
+bruz	b ɹ ʌ z
 bryan	b ɹ a ɪ ə n
 bryanite	b ɹ a ɪ ə n a ɪ t
 bryant	b ɹ a ɪ ə n t
@@ -10146,6 +10257,9 @@ buccal	b ʌ k ə l
 buccally	b ʌ k ə l i
 buccaneer	b ʌ k ə n ɪ ə ɹ
 buccinator	b ʌ k s ə n e ɪ t ɚ
+buccoapical	b ʌ k o ʊ e ɪ p ɪ k l̩
+buccocervical	b ʌ k o ʊ s ɝː v ɪ k l̩
+buccogingival	b ʌ k o ʊ d͡ʒ ɪ n d͡ʒ ɪ v l̩
 buccolabial	b ʌ k o ʊ l e ɪ b i l̩
 buccolingual	b ʌ k o ʊ l ɪ ŋ ɡ w ə l
 buccopalatal	b ʌ k o ʊ p æ l ə t ə l
@@ -10472,6 +10586,7 @@ burr	b ɝ
 burra	b ʌ ɹ ə
 burrampooter	b ʌ r ə m p uː t ə r
 burrata	b ə ɹ ɑ t ə
+burrel	b ʌ ɹ ə l
 burrito	b ə ɹ i t o ʊ
 burro	b ɝ o ʊ
 burro	b ʊ ɹ o ʊ
@@ -10482,7 +10597,7 @@ burrstone	b ɚ s t o ʊ n
 burscough	b ɜː ɹ s k ə
 bursiform	b ɝ s ɪ f ɔ ɹ m
 bursledon	b ɜː ɹ z ə l d ə n
-burst	b ɚ s t
+burst	b ɝ s t
 bursting	b ɝ s t ɪ ŋ
 burt	b ɝ t
 burthen	b ɝ ð n̩
@@ -10541,7 +10656,7 @@ busts	b ʌ s t s
 busty	b ʌ s t i
 busulfan	b j uː s ʌ l f æ n
 busy	b ɪ z i
-busyness	b ɪ z ɪ n ə s
+busyness	b ɪ z ɪ n ɪ s
 but	b ʌ t
 but's	b ʌ t s
 butabarbital	b j u t ə b ɑ ɹ b ɪ t ɔ l
@@ -10698,6 +10813,9 @@ cacahuatepec	k ɑː k ə w ɑː t ɛ p ɛ k
 cacao	k ə k a ʊ̯
 cacao	k ə k e ɪ̯ o ʊ̯
 cacciatore	k ɑ t͡ʃ ə t ɔ ɹ i
+cachaemia	k æ k iː m i ə
+cachaemic	k æ k iː m ɪ k
+cachaemic	k æ k ɛ m ɪ k
 cachalot	k æ ʃ ə l ɑ t
 cachaça	k ə ʃ ɑː s ə
 cache	k e ɪ ʃ
@@ -10723,6 +10841,7 @@ cacoethics	k a k ə ʊ ɛ θ ɪ k s
 cacogamy	k ə k ɒ ɡ ə m i
 cacogenic	k æ k ə d͡ʒ ɛ n ɪ k
 cacology	k ə k ɒ l ə d͡ʒ i
+cacophonic	k ə k ɒ f ə n ɪ k
 cacophonous	k ə k ɑ f ə n ə s
 cacophony	k ə k ɑ f ə n i
 cacti	k æ k t a ɪ
@@ -10797,6 +10916,7 @@ cagey	k e ɪ d͡ʒ i
 cagliari	k æ l j ə ɹ i
 cagliari	k ɑː l j ə ɹ i
 cagot	k ə ɡ o ʊ
+cahier	k a ɪ j e ɪ
 cahokia	k ə h o ʊ k i ə
 cahoot	k ə h uː t
 cahoots	k ə h uː t s
@@ -10896,8 +11016,9 @@ calgary	k æ l ɡ ə ɹ i
 calgary	k æ l ɡ ɹ i
 cali	k æ l i
 caliban	k æ l ɪ b æ n
+caliber	k æ l ə b ɚ
 caliber	k æ l ɪ b ɚ
-calibrate	k æ l ɪ b ɹ e ɪ t
+calibrate	k æ l ə b ɹ e ɪ t
 calibration	k æ l ɪ b ɹ e ɪ ʃ ə n
 calibre	k æ l ə b ɚ
 caliche	k ə l i t͡ʃ i
@@ -10911,11 +11032,11 @@ caliginous	k ə l ɪ d͡ʒ ə n ə s
 calipash	k æ l ɪ p æ ʃ
 calipee	k æ l ɪ p iː
 caliper	k æ l ɪ p ɚ
+calipers	k æ l ɪ p ɚ z
 caliph	k e ɪ l ɪ f
 caliph	k æ l ɪ f
 caliphate	k æ l ɪ f e ɪ t
 calk	k æ l k
-call	k ɑ l
 call	k ɔ l
 call't	k ɔː l t
 callahan	k æ l ə h ə n
@@ -10997,7 +11118,7 @@ cama	k ɑː m ə
 camail	k æ m e ɪ l
 camail	k ə m e ɪ l
 camaldolese	k ə m ɑ l d ə l i z
-camaraderie	k æ m ə ɹ æ d ə ɹ i
+camaraderie	k æ m ə ɹ ɑ d ə ɹ i
 camaraderie	k ɑ m ə ɹ ɑ d ə ɹ i
 camas	k æ m ɪ s
 camas	k ɑː m ə z
@@ -11119,6 +11240,7 @@ candelabrum	k æ n d l̩ ɑ b ɹ ə m
 candelabrum	k æ n d ɪ l e ɪ b ɹ ə m
 candian	k æ n d ɪ ə n
 candid	k æ n d ɪ d
+candidacy	k æ n d ɪ d ə s i
 candidate	k æ n d ɪ d e ɪ t
 candidate	k æ n d ɪ d ɪ t
 candidate	k æ n ɪ d e ɪ t
@@ -11347,6 +11469,7 @@ caracole	k æ ɹ ə k ə ʊ l
 carafe	k ə ɹ æ f
 caragana	k æ ɹ ə ɡ ɑː n ə
 caragana	k ɑː ɹ ə ɡ ɑː n ə
+carambola	k æ ɹ ə m b ə ʊ l ə
 caramel	k æ ɹ ə m ə l
 caramel	k æ ɹ ə m ɛ l
 caramel	k ɑ ɹ m ə l
@@ -11364,7 +11487,9 @@ caravaggesque	k ɑ ɹ ə v ɑ d͡ʒ ɛ s k
 caravaggio	k æ ɹ ə v ɑ d͡ʒ i o ʊ
 caravaggio	k ɑ ɹ ə v ɑ d͡ʒ i o ʊ
 caravan	k æ ɹ ə v æ n
-caravanserai	k ɑ ɹ ə v æ n s ə ɹ a ɪ
+caravansary	k ɛ ɹ ə v æ n s ə ɹ i
+caravanserai	k ɛ ɹ ə v æ n s ə ɹ a ɪ
+caravanserial	k ɛ ɹ ə v æ n s ə ɹ i ə l
 caravel	k æ ɹ ə v ɛ l
 caraway	k ɛ ɹ ə w e ɪ
 carb	k ɑ ɹ b
@@ -11530,6 +11655,7 @@ carnaby	k ɑː ɹ n ə b i
 carnage	k ɑ ɹ n ɪ d͡ʒ
 carnal	k ɑ ɹ n ə l
 carnaroli	k ɑ ɹ n ə ɹ o ʊ l i
+carnatic	k ɑ ɹ n æ t ɪ k
 carnation	k ɑ ɹ n e ɪ ʃ ə n
 carnaval	k ɑ ɹ n ə v ɑ l
 carnegie	k ɑ ɹ n e ɪ ɡ i
@@ -11594,15 +11720,13 @@ carriage	k æ ɹ ɪ d͡ʒ
 carriage	k ɛ ɹ ɪ d͡ʒ
 carriages	k ɛ ɹ ɪ d͡ʒ ɪ z
 carrickmacross	k æ ɹ ɪ k m ə k ɹ ɒ s
-carrie	k æ r i
+carrie	k æ ɹ i
 carrier	k æ ɹ ɪ ɚ
 carrillo	k ə ɹ ɪ l o ʊ
 carrion	k æ ɹ i ə n
 carrol	k ɛ ɹ ə l
 carroll	k æ ɹ ə l
 carronade	k ɛ ɹ ə n e ɪ d
-carrot	k æ ɹ ə t
-carrot	k ɛ ɹ ə t
 carrow	k æ ɹ ə ʊ
 carrying	k æ ɹ i ɪ ŋ
 carrying	k ɛ ɹ i ɪ ŋ
@@ -11800,6 +11924,7 @@ catatonia	k æ t ə t o ʊ n i ə
 catatonic	k æ t ə t ɑ n ɪ k
 catawampus	k æ t ə w ɑ m p ə s
 catbird	k a t b ɝ d
+catcall	k æ t k ɔ l
 catch	k æ t͡ʃ
 catch	k ɛ t͡ʃ
 catchee	k æ t͡ʃ i
@@ -11818,6 +11943,8 @@ catechol	k æ t ə k ɔ l
 catechu	k æ t ə t͡ʃ uː
 catechu	k æ t ə ʃ uː
 catechumen	k æ t ə k j u m ə n
+catechumenate	k æ t ɪ k j uː m ə n e ɪ t
+catechumenate	k æ t ɪ k j uː m ə n ə t
 categorially	k æ t ə ɡ ɒ ɹ ɪ ə l i
 categorical	k æ t ə ɡ ɔ ɹ ɪ k ə l
 categories	k æ t ə ɡ ɔ ɹ i z
@@ -11828,10 +11955,11 @@ cater	k e ɪ t ə ɹ
 cater	k e ɪ t ɚ
 caterer	k e ɪ t ə ɹ ə ɹ
 catering	k e ɪ t ə ɹ ɪ ŋ
+catering	k e ɪ t ɚ ɪ ŋ
 caterpillar	k æ t ə p ɪ l ɚ
 caterpillar	k æ t ɚ p ɪ l ɚ
 caterwaul	k æ t ɚ w ɔ l
-caterwauling	k æ t ə ɹ w ɑ l ɪ ŋ
+caterwauling	k æ t ɚ w ɔ l ɪ ŋ
 catesby	k e ɪ t s b i
 catfighting	k æ t f a ɪ t ɪ ŋ
 catfucker	k æ t f ʌ k ɚ
@@ -11871,6 +11999,10 @@ catloaf	k æ t l o ʊ f
 catmint	k æ t m ɪ n t
 catnip	k a t n ɪ p
 cato	k e ɪ t o ʊ
+catoblepas	k æ t o ʊ b l iː p ə s
+catoblepas	k æ t o ʊ b l ɛ p ə s
+catoblepas	k æ t o ʊ b l ɪ p ə s
+catoblepas	k ə t ɒ b l ɪ p ə s
 catridge	k æ t ɹ ɪ d͡ʒ
 cats	k æ t s
 cattail	k æ t t e ɪ l
@@ -11903,6 +12035,9 @@ caulini	k ɑ l iː n i
 caulini	k ɔ l iː n i
 caulk	k ɔː k
 cauma	k a ʊ m ə
+causal	k ɔ z ə l
+causality	k ɔ z æ l ɪ t ɪ
+causation	k ɔ z e ɪ ʃ ə n
 causative	k ɔ z ə t ɪ v
 causator	k ɔː z e ɪ t ə ɹ
 cause	k ɔ z
@@ -12042,7 +12177,7 @@ celecoxib	s ɛ l ə k ɑ k s ɪ b
 celeriac	s ə l ɛ ə ɹ i æ k
 celeriac	s ə l ɪ ə ɹ i æ k
 celerity	s ɪ l ɛ ɹ ɪ t i
-celery	s ɛ l ə ɹ i
+celery	s ɛ l ɚ i
 celesta	s ə l ɛ s t ə
 celeste	s ə l ɛ s t
 celestial	s ə l ɛ s t i ə l
@@ -12063,7 +12198,6 @@ cells	s ɛ l z
 celluloid	s ɛ l j ə l ɔ ɪ d
 cellulose	s ɛ l j ʊ l ə ʊ z
 celly	s ɛ l i
-celsius	s ɛ l s i ə s
 celt	k ɛ l t
 celt	s ɛ l t
 celta	s ɛ l t ə
@@ -12163,6 +12297,7 @@ cephalopod	s ɛ f a l a p ɑ d
 cephalosporin	k ɛ f ə l ə ʊ s p ɔ ə ɹ ɪ n
 cephalothorax	s ɛ f ə l ə θ ɑ ɹ æ k s
 cephalothorax	s ɛ f ə l ə θ ɔ ɹ æ k s
+cephas	s i f ə s
 cepheus	s iː f i ə s
 cepheus	s iː f j uː s
 cepstrum	k ɛ p s t ɹ ə m
@@ -12203,12 +12338,15 @@ ceremonies	s ɛ ɹ ɪ m o ʊ n i z
 ceremony	s ɛ ɹ ə m o ʊ n i
 cereology	s ɪ ə ɹ ɪ ɑ l ə d͡ʒ i
 cereous	s ɪ ə ɹ i ə s
+cererian	s ə ɹ ɪ ə ɹ ɪ ə n
 ceres	s ɪ ə ɹ iː z
+ceresian	s ə ɹ iː z i ə n
 cerise	s ə ɹ iː s
 cerise	s ə ɹ iː z
 cerium	s ɪ ə ɹ i ə m
 cernuous	s ɜː ɹ n j u ə s
 cerrial	s ɛ ɹ i ə l
+cerrigceinwen	k ɛ r ɪ ɡ k ɛ i n ʊ ɛ n
 certain	s ɝ t n̩
 certain	s ɝ ʔ n̩
 certainly	s ɝ t n̩ l i
@@ -12229,6 +12367,7 @@ cervantes	s ə v æ n t iː z
 cervantes	s ɛ ə v ɑː n t e ɪ z
 cervelliere	s ɛ ɹ v ə l j ɛ ə ɹ
 cervical	s ɝ v ɪ k l̩
+cervices	s ɝ v ɪ s iː z
 cervidae	s ə ɹ v ə d i
 cervix	s ɝ v ɪ k s
 cervus	s ə ɹ v ə s
@@ -12292,7 +12431,7 @@ chainings	t͡ʃ e ɪ n ɪ ŋ z
 chainring	t͡ʃ e ɪ n ɹ ɪ ŋ
 chains	t͡ʃ e ɪ n z
 chainsaw	t͡ʃ e ɪ n s ɔː
-chair	t͡ʃ ɛ ə ɹ
+chair	t͡ʃ ɛ ɚ
 chairman	t ʃ ɛ ɹ m ə n
 chairness	t͡ʃ ɛ ɹ n ə s
 chairs	t͡ʃ ɛ ɹ z
@@ -12306,7 +12445,7 @@ chakra	t͡ʃ ʌ k ɹ ə
 chalaza	k ə l e ɪ z ə
 chalazion	k ə l e ɪ z i ə n
 chalcanthite	k æ l k æ n θ a ɪ t
-chalcedon	k æ l s ɪ d ɑː n
+chalcedon	k æ l s ə d ɑ n
 chalcedony	k æ l s ə d o ʊ n i
 chalcedony	k æ l s ɛ d ə n i
 chalcis	k æ l s ɪ s
@@ -12456,8 +12595,6 @@ char	k ɛ ɹ
 char	t͡ʃ a ɹ
 char	t͡ʃ ɑ ɹ
 charact	k æ ɹ æ k t
-character	k æ ɹ ə k t ɚ
-character	k ɛ ɹ ə k t ɚ
 characteristic	k ɛ ɹ ə k t ə ɹ ɪ s t ɪ k
 characteristics	k ɛ ɹ ə k t ə ɹ ɪ s t ɪ k s
 characterize	k æ ɹ ə k t ə ɹ a ɪ z
@@ -12478,7 +12615,7 @@ chardonnay	ʃ ɑː ɹ d ə n e ɪ
 chare	t͡ʃ ɛ ɹ
 charette	ʃ ə ɹ ɛ t
 charge	t͡ʃ ɑ ɹ d͡ʒ
-charged	t͡ʃ ɑː d͡ʒ d
+charged	t͡ʃ ɑ ɹ d͡ʒ d
 chargeous	t͡ʃ ɑː ɹ d͡ʒ ə s
 charger	t͡ʃ ɑ ɹ d͡ʒ ɚ
 charges	t͡ʃ ɑ ɹ d͡ʒ ɪ z
@@ -12511,7 +12648,6 @@ charms	t͡ʃ ɑ ɹ m z
 charon	k ɛ ə ɹ ɑ n
 charon	k ɛ ə ɹ ə n
 charon	ʃ ɛ ə ɹ ɑ n
-charon	ʃ ɛ ə ɹ ə n
 charonean	k æ r ə n iː ə n
 charonian	k ə r o ʊ n ɪ ə n
 charontean	k ə r ɒ n t ɪ ə n
@@ -12896,7 +13032,6 @@ chilaquiles	t͡ʃ i l ə k i l e ɪ s
 chilblain	t͡ʃ ɪ l b l e ɪ n
 chilcotin	t͡ʃ ɪ l k o ʊ t ɪ n
 child	t͡ʃ a ɪ l d
-child	t͡ʃ a ɪ ə l d
 childbed	t͡ʃ a ɪ l d b ɛ d
 childe	t͡ʃ a ɪ l d
 childer	t͡ʃ ɪ l d ə r
@@ -12937,6 +13072,7 @@ chiltepin	t͡ʃ ɪ l t ɛ p ɪ n
 chilver	t͡ʃ ɪ l v ə ɹ
 chimbley	t͡ʃ ɪ m b l i
 chimed	t͡ʃ a ɪ m d
+chimenea	t ʃ ɪ m ə n e ɪ ə
 chimera	k a ɪ m ɪ ɹ ə
 chimera	k ə m ɪ ɹ ə
 chimerical	k ɪ m ɛ ɹ ɪ k ə l
@@ -12974,6 +13110,8 @@ chinned	t͡ʃ ɪ n d
 chinning	t͡ʃ ɪ n ɪ ŋ
 chinny	t͡ʃ ɪ n i
 chinoiserie	ʃ iː n w ɑː z ə ɹ iː
+chinone	k a ɪ n ə ʊ n
+chinone	k ɪ n ə ʊ n
 chinook	t͡ʃ ɪ n uː k
 chinook	ʃ ɪ n ʊ k
 chinquapin	t͡ʃ ɪ n k ə p ɪ n
@@ -12989,8 +13127,10 @@ chipmunk	t͡ʃ ɪ p m ʌ ŋ k
 chipolata	t͡ʃ ɪ p ə l ɑː t ə
 chipotle	t͡ʃ ɪ p o ʊ t l e ɪ
 chipotle	t͡ʃ ɪ p o ʊ t l i
-chipotle	t͡ʃ ɪ p ɒ t l e ɪ
-chipotle	t͡ʃ ɪ p ɒ t l i
+chipotle	t͡ʃ ɪ p ɑ t l e ɪ
+chipotle	t͡ʃ ɪ p ɑ t l i
+chipotle	t͡ʃ ɪ p ɔ t l e ɪ
+chipotle	t͡ʃ ɪ p ɔ t l i
 chipped	t͡ʃ ɪ p t
 chippendale	t͡ʃ ɪ p n̩ d e ɪ l
 chipper	t͡ʃ ɪ p ɚ
@@ -13010,7 +13150,7 @@ chiromancy	k a ɪ ɹ ə ʊ m æ n s i
 chiron	k a ɪ ɹ ə n
 chiropodist	k ɪ r ɒ p ə d ɪ s t
 chiropterologist	k a ɪ ɹ ɑ p t ə ɹ ɑ l ə d͡ʒ ɪ s t
-chirp	t͡ʃ ɝ p
+chirp	t͡ʃ ɚ p
 chirpy	t͡ʃ ɜː ɹ p i
 chirr	t͡ʃ ɝ
 chirren	t͡ʃ ɪ ɹ ə n
@@ -13023,6 +13163,8 @@ chirurgy	k a ɪ ɹ ɜː ɹ d͡ʒ i
 chirurgy	k ɪ ɹ ɜː ɹ d͡ʒ i
 chisel	t͡ʃ ɪ z ə l
 chiseled	t͡ʃ ɪ z ə l d
+chislic	t͡ʃ ɪ s l ɪ k
+chislic	t͡ʃ ɪ z l ɪ k
 chiswick	t͡ʃ ɪ z ɪ k
 chit	t͡ʃ ɪ t
 chita	t͡ʃ ɪ t ə
@@ -13092,6 +13234,7 @@ chocotini	t͡ʃ ɔ k ə t i n i
 choctaw	t͡ʃ ɒ k t ɔː
 chode	t͡ʃ o ʊ d
 choenix	k iː n ɪ k s
+choi	t ʃ ɔ ɪ
 choice	t͡ʃ ɔ ɪ s
 choiceful	t͡ʃ ɔ ɪ s f ə l
 choices	t͡ʃ ɔ ɪ s ɪ z
@@ -13119,7 +13262,7 @@ cholla	t͡ʃ ɔ ɪ ə
 cholo	t͡ʃ o ʊ l o ʊ
 chomo	t͡ʃ o ʊ m o ʊ
 chomophyte	k ə ʊ m ə ʊ f a ɪ t
-chomp	t͡ʃ ɔ m p
+chomp	t͡ʃ ɑ m p
 chomps	t͡ʃ ɔ m p s
 chon	t͡ʃ ɑ n
 chondrite	k ɒ n d ɹ a ɪ t
@@ -13157,6 +13300,7 @@ choregus	k ə ɹ iː ɡ ə s
 choreograph	k ɔ ɹ j ə ɡ ɹ æ f
 choreography	k ɔ ɹ i ɒ ɡ ɹ ə f i
 chori	k ɔ ɹ a ɪ
+choric	k ɔ ɹ ɪ k
 chorion	k ɔ ɹ i ɑ n
 chorister	k ɔ ɹ ɪ s t ə ɹ
 chorizo	t ʃ ə ɹ i s o ʊ
@@ -13251,12 +13395,14 @@ chrysocolla	k ɹ ɪ s ə k ɑ l ə
 chrysolite	k ɹ ɪ s ə l a ɪ t
 chrysostom	k ɹ ɪ s ə s t ə m
 chrysotile	k ɹ ɪ s ə t ɪ l
+chthamaloid	θ æ m ə l ɔ ɪ d
 chthonian	k θ o ʊ n i ə n
 chthonian	θ ʊ n i ə n
 chthonic	θ ɑ n ɪ k
 chthonophagia	θ ɑ n o ʊ f e ɪ d͡ʒ i ə
 chu	t ʃ u
 chub	t͡ʃ ʌ b
+chubasco	t ʃ uː b ɑː s k ə ʊ
 chubby	t͡ʃ ʌ b i
 chubs	t͡ʃ ʌ b z
 chubster	t͡ʃ ʌ b s t ɚ
@@ -13403,6 +13549,10 @@ cinching	s ɪ n t͡ʃ ɪ ŋ
 cinchona	s ɪ ŋ k o ʊ n ə
 cinchophen	s ɪ ŋ k ə f ɛ n
 cinchy	s ɪ n t͡ʃ i
+cincinnati	s ɪ n s ɪ n æ t i
+cincinnati	s ɪ n s ɪ n æ t ə
+cincinnatus	s ɪ n s ɪ n e ɪ t ə s
+cincinnatus	s ɪ n s ɪ n ɑː t ə s
 cincture	s ɪ ŋ k t͡ʃ ə ɹ
 cinder	s ɪ n d ɚ
 cinderella	s ɪ n d ə ɹ ɛ l ə
@@ -13421,10 +13571,13 @@ cinnabar	s ɪ n ə b ɑː ɹ
 cinnamon	s ɪ m ɪ n
 cinnamon	s ɪ n ə m ə n
 cinnamon	s ɪ n ə m ɪ n
-cinquain	s ɪ n k e n
+cinquain	s æ ŋ k e ɪ n
+cinquain	s ɪ ŋ k e ɪ n
 cinque	s æ ŋ k
 cinque	s ɪ ŋ k
 cinquecentist	t͡ʃ i ŋ k w ə t͡ʃ ɛ n t ɪ s t
+cinquedea	t͡ʃ ɪ ŋ k w ɪ d e ɪ ə
+cinquedea	t͡ʃ ɪ ŋ k w ɪ d i ə
 cinquefoil	s ɪ ŋ k f ɔ ɪ l
 cinques	s ɪ ŋ k s
 cipher	s a ɪ f ɚ
@@ -13460,6 +13613,7 @@ circuline	s ɜː ɹ k j ʊ l a ɪ n
 circumambulate	s ɝ k ə m æ m b j u l e ɪ t
 circumambulation	s ɝ k ə m æ m b j u l e ɪ ʃ ə n
 circumaural	s ɝ k ʌ m a ɹ ʌ l
+circumbendibus	s ɝ k m̩ b ɛ n d ɪ b ə s
 circumcellion	s ɜː k ə m s ɛ l ɪ ə n
 circumclusion	s ɜː ɹ k ə m k l uː ʒ ə n
 circumduction	s ɝ k ə m d ʌ k ʃ ə n
@@ -13730,12 +13884,14 @@ clayey	k l e ɪ i
 claying	k l e ɪ ɪ ŋ
 clays	k l e ɪ z
 clayton	k l e ɪ t ə n
+clazosentan	k l e ɪ z ə ʊ s ɛ n t æ n
 clean	k l i n
 cleaned	k l iː n d
 cleaner	k l i n ɚ
 cleaning	k l iː n ɪ ŋ
 cleanings	k l iː n ɪ ŋ z
 cleanliness	k l ɛ n l i n ə s
+cleanliness	k l ɛ n l i n ɪ s
 cleanly	k l iː n l i
 cleanly	k l ɛ n l i
 cleans	k l iː n z
@@ -13776,7 +13932,7 @@ clementine	k l ɛ m ə n t iː n
 clemizole	k l ɛ m ɪ z o ʊ l
 clen	k l ɛ n
 clench	k l ɛ n t͡ʃ
-cleopatra	k l i o ʊ p æ t ɹ ə
+cleopatra	k l iː o ʊ p æ t ɹ ə
 clepe	k l iː p
 clepsydra	k l ɛ p s ɪ d ɹ ə
 clept	k l ɛ p t
@@ -13915,6 +14071,7 @@ cloning	k l o ʊ n ɪ ŋ
 clonus	k l o ʊ n ə s
 cloom	k l uː m
 clooney	k l uː n i
+clopen	k l o ʊ p ə n
 clopenthixol	k l o ʊ p ɛ n θ ɪ k s ɔ l
 clopidogrel	k l o ʊ p ɪ d ə ɡ ɹ ɛ l
 cloque	k l o ʊ k e ɪ
@@ -13928,7 +14085,6 @@ closen	k l o ʊ s ə n
 closeness	k l ə ʊ s n ə s
 closer	k l o ʊ s ɚ
 closer	k l o ʊ z ɚ
-closer	k l ə ʊ z ɚ
 closes	k l o ʊ s ɪ z
 closes	k l o ʊ z ɪ z
 closest	k l o ʊ s ɪ s t
@@ -14034,6 +14190,8 @@ clutchings	k l ʌ t͡ʃ ɪ ŋ z
 clutter	k l ʌ t ɚ
 clutton	k l ʌ t ə n
 clyde	k l a ɪ d
+clymene	k l a ɪ m ɪ n i
+clymene	k l ɪ m ɪ n i
 clypei	k l ɪ p ɪ a ɪ
 clypeus	k l ɪ p ɪ ə s
 clyster	k l ɪ s t ɚ
@@ -14173,6 +14331,7 @@ codical	k ə ʊ d ɪ k ə l
 codicil	k ɒ d ɪ s ɪ l
 codicil	k ə ʊ d ɪ s ɪ l
 codies	k ə ʊ d i z
+codification	k ɑ d ɪ f ɪ k e ɪ ʃ ə n
 codlet	k ɒ d l ə t
 codling	k ɒ d l ɪ ŋ
 codomain	k o ʊ d o ʊ m e ɪ n
@@ -14203,6 +14362,7 @@ coevous	k ə ʊ iː v ə s
 coextensive	k o ʊ ɛ k s t ɛ n s ɪ v
 coextinct	k o ʊ ɛ k s t ɪ ŋ k t
 coextinct	k o ʊ ɪ k s t ɪ ŋ k t
+cofeoffee	k o ʊ f ɛ f iː
 coffa	k ɔ f ə
 coffee	k ɔ f i
 coffeetini	k ɔ f i t i n i
@@ -14215,7 +14375,6 @@ coffin	k ɔ f ɪ n
 coffle	k ɑ f l̩
 coffle	k ɔ f l̩
 cofounder	k o ʊ f a ʊ n d ɚ
-cog	k ɑ ɡ
 cog	k ɔ ɡ
 cogent	k o ʊ d͡ʒ n̩ t
 coggery	k ɒ ɡ ə ɹ i
@@ -14343,7 +14502,8 @@ colinet	k ɑ l ɪ n ɛ t
 coll	k ɒ l
 collab	k o ʊ l æ b
 collab	k ə l æ b
-collaborate	k ə l a b ə ɹ e ɪ t
+collaborate	k ə l æ b ə ɹ e ɪ t
+collaborate	k ə l æ b ɹ e ɪ t
 collaboration	k ə l æ b ə ɹ e ɪ ʃ ə n
 collaborative	k ə l a b ə ɹ ə t ɪ v
 collaborator	k ə l æ b ə ɹ e ɪ t ɚ
@@ -14351,6 +14511,7 @@ collage	k o ʊ l ɑ ʒ
 collage	k ə l ɑ ʒ
 collagen	k ɒ l ə d͡ʒ ə n
 collagen	k ɒ l ə d͡ʒ ɪ n
+collagenous	k ə l æ d͡ʒ ɪ n ə s
 collagic	k ə l æ d͡ʒ ɪ k
 collapse	k ə l æ p s
 collar	k ɑ l ɚ
@@ -14486,6 +14647,7 @@ comber	k o ʊ m ɚ
 comber	k ɑ m b ɚ
 combi	k ɒ m b i
 combination	k ɑ m b ɪ n e ɪ ʃ ə n
+combinational	k a m b ɪ n e ɪ ʃ ɪ n ə l
 combinations	k ɑ m b ɪ n e ɪ ʃ ə n z
 combinative	k ɑ m b ɪ n e ɪ t ɪ v
 combinative	k ə m b a ɪ n ə t ɪ v
@@ -14592,6 +14754,7 @@ commentator	k ɑ m ə n t e ɪ t ə ɹ
 commented	k ɑ m ɛ n t ɪ d
 comments	k ɑ m ɛ n t s
 commerce	k ɑ m ɚ s
+commerce	k ə m ɝ s
 commercial	k ə m ɝ ʃ ə l
 comminate	k ɒ m ɪ n e ɪ t
 comminute	k ɑ m ɪ n j uː t
@@ -14635,8 +14798,10 @@ communicating	k ə m j u n ə k e ɪ t ɪ ŋ
 communication	k ə m j uː n ɪ k e ɪ ʃ ə n
 communications	k ə m j uː n ɪ k e ɪ ʃ ə n z
 communion	k ə m j uː n j ə n
-communism	k ɒ m j u n ɪ z m̩
-communist	k ɑː m j ə n ɪ s t
+communism	k ɑ m j u n ɪ z m̩
+communism	k ɑ m j ə n ɪ z m̩
+communist	k ɑ m j u n ɪ s t
+communist	k ɑ m j ə n ɪ s t
 communities	k ə m j uː n ɪ t i z
 community	k ə m j u n ə t i
 commute	k ə m j uː t
@@ -14678,7 +14843,7 @@ compartmentalize	k ə m p ɑ ɹ t m ɛ n t ə l a ɪ z
 compass	k ʌ m p ə s
 compassed	k ʌ m p ə s t
 compassion	k ə m p æ ʃ ə n
-compatibility	k ə m p æ t ɪ b ɪ l ɪ t i
+compatibility	k ə m p æ t ə b ɪ l ə t i
 compatible	k ə m p æ t ə b ə l
 compatriot	k ə m p e ɪ t ɹ i ə t
 compatriot	k ə m p æ t ɹ i ə t
@@ -14738,6 +14903,7 @@ completely	k ə m p l iː t l i
 completes	k ə m p l iː t s
 completing	k ə m p l iː t ɪ ŋ
 completion	k ə m p l iː ʃ ə n
+completist	k ə m p l iː t ɪ s t
 completory	k ə m p l iː t ə ɹ i
 complex	k ɑ m p l ɛ k s
 complex	k ə m p l ɛ k s
@@ -14889,7 +15055,7 @@ conche	k ɒ n t ʃ
 conches	k ɒ n t͡ʃ ə z
 conches	k ɒ ŋ k
 conchifer	k ɒ ŋ k ɪ f ə ɹ
-conchoidal	k ɒ n k ɔ ɪ ɪ d ə l
+conchoidal	k ɑ ŋ k ɔ ɪ d ə l
 conchology	k ɒ ŋ k ɒ l ə d͡ʒ i
 conchs	k ɒ n t͡ʃ
 conchs	k ɒ ŋ k s
@@ -14928,7 +15094,7 @@ concupiscent	k ə n k j uː p ə s ə n t
 concur	k ə n k ɝ
 concurrency	k ə ŋ k ʌ ɹ ə n s i
 concurrent	k ə ŋ k ɝ ɹ ə n t
-concussion	k ə n k ʌ ʃ n
+concussion	k ə n k ʌ ʃ n̩
 concussion	k ə n k ʌ ʃ ə n
 condemn	k ə n d ɛ m
 condemnable	k ə n d ɛ m n ə b ə l
@@ -15035,7 +15201,7 @@ conflate	k ə n f l e ɪ t
 conflation	k ə n f l e ɪ ʃ ə n
 conflict	k ɑ n f l ɪ k t
 conflict	k ə n f l ɪ k t
-conflicted	k ə n f l ɪ k t ɪ d
+conflicted	k ə n f l ɪ t ɪ d
 conflow	k ə n f l o ʊ
 confluence	k ɑ n f l u ə n s
 confluence	k ə n f l u ə n s
@@ -15110,6 +15276,7 @@ congruous	k ɑ ŋ ɡ ɹ u ə s
 conic	k ɑ n ɪ k
 conical	k ɑ n ɪ k ə l
 conifer	k ɒ n ɪ f ə ɹ
+coniferous	k ə n ɪ f ə ɹ ə s
 conivaptan	k ɑ n ə v æ p t ə n
 conject	k ə n d͡ʒ ɛ k t
 conjecture	k ə n d͡ʒ ɛ k t͡ʃ ɚ
@@ -15280,13 +15447,15 @@ constancy	k ɑ n s t ə n s i
 constant	k ɑ n s t ə n t
 constantine	k ɑ n s t ə n t iː n
 constantinople	k ɔ n s t æ n t ɪ n ə ʊ p ə l
-constantly	k ɑ n s t ə n t l i
+constantly	k ɑ n s t ə n ʔ l i
 constellation	k ɑ n s t ə l e ɪ ʃ ə n
 constellationally	k ɑ n s t ə l e ɪ ʃ ə n ə l i
 consternation	k ɑ n s t ɚ n e ɪ ʃ ə n
 constipate	k ɒ n s t ɪ p e ɪ t
 constipated	k ɒ n s t ə p e ɪ t ə d
 constipation	k ɒ n s t ɪ p e ɪ ʃ ə n
+constituencies	k ə n s t ɪ t j u ə n s iː z
+constituencies	k ə n s t ɪ t͡ʃ ʊ ə n s iː z
 constituency	k ə n s t ɪ t j u ə n s i
 constituency	k ə n s t ɪ t͡ʃ u ə n s i
 constituent	k ə n s t ɪ t j u ə n t
@@ -15319,6 +15488,7 @@ consubstantiation	k ɔ n s ʌ b s t n̩ ʃ i e ɪ ʃ ə n
 consuetude	k ɒ n s w ɪ t j uː d
 consuetudinal	k ɑ n s w ə t u d ɪ n ə l
 consul	k ɑ n s ə l
+consulate	k ɑ n s ə l ɪ t
 consulate	k ɒ n s ə l ə t
 consult	k ɑ n s ʌ l t
 consult	k ə n s ʌ l t
@@ -15461,6 +15631,7 @@ controller	k ə n t ɹ o ʊ l ɚ
 controllers	k ə n t ɹ o ʊ l ɚ z
 controlling	k ə n t ɹ o ʊ l ɪ ŋ
 controls	k ə n t ɹ o ʊ l z
+controversial	k ɑ n t ɹ ə v ɝ s i ə l
 controversial	k ɑ n t ɹ ə v ɝ s j ə l
 controversial	k ɑ n t ɹ ə v ɝ ʃ ə l
 controversies	k ɑ n t ɹ ə v ɚ s i z
@@ -15575,7 +15746,7 @@ cookie	k ʊ k i
 cookies	k ʊ k i z
 cooking	k ʊ k ɪ ŋ
 cooks	k ʊ k s
-cool	k uː l
+cool	k u l
 coolant	k uː l ə n t
 cooldown	k uː l d a ʊ n
 cooled	k uː l d
@@ -15684,6 +15855,7 @@ cor	k ɔ ɹ
 coral	k ɔ ɚ ɹ ə l
 coranto	k ə ɹ æ n t ə ʊ
 coranto	k ə ɹ ɑː n t ə ʊ
+corb	k ɔː ɹ b
 corbe	k ɔː ɹ b
 corbyn	k ɔ ɹ b ɪ n
 corbynomics	k ɔ ɹ b ɪ n ɑ m ɪ k s
@@ -15762,6 +15934,7 @@ corollary	k ɒ ɹ ə l ə ɹ i
 corollary	k ɔ ɹ ə l ɛ ɹ i
 corona	k ə ɹ o ʊ n ə
 coronach	k ɒ ɹ ə n ə k
+coronado	k ɒ ɹ ə n ɑː d ə ʊ
 coronae	k ə ɹ o ʊ n iː
 coronal	k ɑ ɹ ə n ə l
 coronal	k ɔ ɹ ə n ə l
@@ -15823,6 +15996,8 @@ corresponding	k ɔ ɹ ə s p ɑ n d ɪ ŋ
 corridor	k ɔ ɹ ə d ɔ ɹ
 corridor	k ɔ ɹ ə d ɚ
 corrie	k ɒ ɹ i
+corrigendum	k ɔ ɹ ɪ d͡ʒ ɛ n d ə m
+corrigendum	k ɔ ɹ ɪ ɡ ɛ n d ə m
 corrival	k ə ɹ a ɪ v ə l
 corroborate	k ə ɹ ɑ b ə ɹ e ɪ̯ t
 corroboree	k ə ɹ ɒ b ə ɹ i
@@ -16001,6 +16176,7 @@ countershed	k a ʊ n t ɚ ʃ ɛ d
 countertime	k a ʊ n t ə ɹ t a ɪ m
 countervailing	k a ʊ n t ə v e ɪ l ɪ ŋ
 counterview	k a ʊ n t ə ɹ v j uː
+countess	k a ʊ n t ɪ s
 counties	k a ʊ n t i z
 counting	k a ʊ n t ɪ ŋ
 countings	k a ʊ n t ɪ ŋ z
@@ -16073,6 +16249,7 @@ couvade	k uː v æ d
 couvade	k uː v ɑː d
 covalent	k o ʊ v e ɪ l ə n t
 cove	k o ʊ v
+cove	k ə ʊ v
 covelo	k o ʊ v ə l o ʊ
 coven	k ʌ v ə n
 covenant	k ʌ v n ə n t
@@ -16081,6 +16258,7 @@ covenstead	k ʌ v n̩ s t ɛ d
 coventry	k ɑ v ə n t ɹ i
 cover	k ʌ v ɚ
 coverack	k ɒ v ə ɹ ə k
+coverall	k ʌ v ɚ ɔ l
 covered	k ʌ v ə ɹ d
 covering	k ʌ v ə ɹ ɪ ŋ
 coverlet	k ʌ v ə ɹ l ɪ t
@@ -16130,6 +16308,7 @@ cowrie	k a ʊ ɹ i
 cows	k a ʊ z
 cowslip	k a ʊ s l ɪ p
 cox	k ɑ k s
+coxa	k ɑ k s ə
 coxie	k ɒ k s i
 coxswain	k ɑ k s ə n
 coy	k ɔ ɪ
@@ -16276,7 +16455,7 @@ craxism	k ɹ æ k s ɪ z ə m
 cray	k ɹ æ ɪ
 crayfish	k ɹ e ɪ f ɪ ʃ
 crayon	k ɹ a ʊ n
-crayon	k ɹ e ɪ ɒ n
+crayon	k ɹ e ɪ ɑ n
 crayon	k ɹ e ɪ ɔ n
 crayon	k ɹ æ n
 craze	k ɹ e ɪ z
@@ -16297,6 +16476,7 @@ creaks	k ɹ iː k s
 creaky	k ɹ iː k i
 cream	k ɹ iː m
 creamed	k ɹ iː m d
+creamer	k ɹ iː m ɚ
 creaming	k ɹ iː m ɪ ŋ
 creamings	k ɹ iː m ɪ ŋ z
 creampie	k ɹ iː m p a ɪ
@@ -16311,6 +16491,7 @@ creasings	k ɹ iː s ɪ ŋ z
 creasy	k ɹ i s i
 create	k ɹ iː e ɪ t
 created	k ɹ i e ɪ t ɪ d
+creatic	k ɹ iː æ t ɪ k
 creatify	k ɹ i e ɪ t ə f a ɪ
 creatine	k ɹ i ə t i n
 creating	k ɹ iː e ɪ t ɪ ŋ
@@ -16322,7 +16503,7 @@ creativeness	k ɹ i e ɪ t ɪ v n ə s
 creativity	k ɹ i e ɪ t ɪ v ə t i
 creativize	k ɹ i e ɪ t ə v a ɪ z
 creator	k ɹ i e ɪ t ɚ
-creature	k ɹ iː t͡ʃ ə ɹ
+creature	k ɹ iː t͡ʃ ɚ
 creatures	k ɹ i t͡ʃ ɚ z
 crebrous	k ɹ iː b ɹ ə s
 crebrous	k ɹ ɛ b ɹ ə s
@@ -16417,8 +16598,7 @@ cretic	k ɹ iː t ɪ k
 cretin	k ɹ iː t ɪ n
 cretin	k ɹ ɛ t ɪ n
 crevasse	k ɹ ə v æ s
-crew	k ɹ u ʊ̯
-crew	k ɹ uː
+crew	k ɹ u
 crewe	k ɹ u ʊ̯
 crewe	k ɹ uː
 crewed	k ɹ uː d
@@ -16540,7 +16720,6 @@ criterion	k ɹ ɪ t ɪ ə ɹ i ə n
 criterium	k ɹ a ɪ t ɪ ə ɹ i ə m
 crith	k ɹ ɪ θ
 critic	k ɹ ɪ t ɪ k
-critical	k ɹ ɪ t ə k ə l
 critical	k ɹ ɪ t ɪ k ə l
 critically	k ɹ ɪ t ɪ k l i
 critically	k ɹ ɪ t ɪ k ə l i
@@ -16619,6 +16798,7 @@ crosswordese	k ɹ ɒ s w ɜː ɹ d iː z
 crotalum	k ɹ ə ʊ t ə l ə m
 crotch	k ɹ ɑ t͡ʃ
 crotchet	k ɹ ɑ t͡ʃ ɪ t
+crotchety	k ɹ ɑ t͡ʃ ɪ t i
 croton	k ɹ o ʊ t ə n
 crouch	k ɹ a ʊ t͡ʃ
 crouched	k ɹ a ʊ t͡ʃ t
@@ -16664,8 +16844,10 @@ cruces	k ɹ u s i z
 crucial	k ɹ uː ʃ ə l
 crucially	k ɹ uː ʃ ə l i
 crucian	k ɹ uː ʃ ə n
+cruciate	k r uː ʃ i ə t
 crucible	k ɹ uː s ɪ b ə l
 cruciferous	k ɹ u s ɪ f ə ɹ ə s
+crucifix	k ɹ uː s ɪ f ɪ k s
 crucifixion	k ɹ uː s ɪ f ɪ k ʃ ə n
 crucify	k ɹ uː s ɪ f a ɪ
 cruck	k ɹ ʌ k
@@ -16714,6 +16896,7 @@ crunchings	k ɹ ʌ n t͡ʃ ɪ ŋ z
 crunchy	k ɹ ʌ n t͡ʃ i
 crunk	k ɹ ʌ ŋ k
 crunkmeister	k ɹ ʌ ŋ k m a ɪ s t ɚ
+cruor	k ɹ uː ə ɹ
 crup	k ɹ ʌ p
 crupper	k ɹ ʊ p ɚ
 crupper	k ɹ ʌ p ɚ
@@ -16747,6 +16930,7 @@ crying	k ɹ a ɪ̯ ɪ ŋ
 cryobiotic	k ɹ a ɪ ə ʊ b a ɪ ɒ t ɪ k
 cryogenic	k ɹ a ɪ o ʊ d͡ʒ ɛ n ɪ k
 cryogenic	k ɹ a ɪ ə d͡ʒ ɛ n ɪ k
+cryonicist	k ɹ a ɪ ɒ n ɪ s ɪ s t
 crypsis	k ɹ ɪ p s ɪ s
 crypt	k ɹ ɪ p t
 cryptic	k ɹ ɪ p t ɪ k
@@ -16770,6 +16954,8 @@ crypts	k ɹ ɪ p t s
 crystal	k ɹ ɪ s t ə l
 crystalize	k ɹ ɪ s t ə l a ɪ z
 crystalline	k ɹ ɪ s t ə l a ɪ n
+crystalline	k ɹ ɪ s t ə l iː n
+crystalline	k ɹ ɪ s t ə l ɪ n
 crystallize	k ɹ ɪ s t ə l a ɪ z
 crystals	k ɹ ɪ s t ə l z
 crèche	k ɹ e ɪ ʃ
@@ -16818,10 +17004,12 @@ cud	k ʊ d
 cud	k ʌ d
 cudden	k ʌ d ə n
 cuddle	k ʌ d l̩
+cuddleologist	k ʌ d ə l ɑ l ɒ d͡ʒ ɪ s t
 cuddler	k ʌ d l ɚ
 cuddler	k ʌ d l̩ ɚ
 cuddly	k ʌ d l i
 cuddly	k ʌ d l̩ i
+cuddly	k ʌ d ə l i
 cuddy	k ʌ d i
 cudgel	k ʌ d͡ʒ ə l
 cudraflavone	k uː d ɹ ə f l e ɪ v ə ʊ n
@@ -17146,7 +17334,9 @@ cyanosis	s a ɪ ə n o ʊ s ɪ s
 cyanotype	s a ɪ æ n ə t a ɪ p
 cyanotype	s a ɪ æ n ə ʊ t a ɪ p
 cyattie	k j æ t i
+cybele	s ɪ b ɪ l iː
 cyber	s a ɪ b ə ɹ
+cyberbole	s a ɪ b ɝ b ə l i
 cybernat	s a ɪ b ɚ n æ t
 cybernetic	s a ɪ b ɚ n ɛ t ɪ k
 cyberocracy	s a ɪ b ə ɹ ɒ k ɹ ə s i
@@ -17538,6 +17728,7 @@ darlin'	d ɑ ɹ l ɪ n
 darling	d ɑ ɹ l ɪ ŋ
 darmstadtium	d ɑː ɹ m ʃ t ɑː t i ə m
 darn	d ɑ ɹ n
+darnedest	d ɑ ɹ n d ɪ s t
 darpa	d ɑː ɹ p ə
 darrein	d æ ɹ e ɪ n
 darrein	d ə ɹ e ɪ n
@@ -17550,7 +17741,9 @@ dartos	d ɑ ɹ t ɑ s
 dartos	d ɑ ɹ t ə s
 darty	d ɑ ɹ t i
 daruma	d ɑː ɹ ʊ m ə
+darusentan	d æ ɹ ə s ɛ n t æ n
 darvel	d ɑː ɹ v ə l
+darwin	d ɑ ɹ w ɪ n
 darwinian	d ɑ ɹ w ɪ n i ə n
 das	d æ s
 das	d ɑː z
@@ -17608,6 +17801,7 @@ daunting	d ɔ n t ɪ ŋ
 dauntless	d ɔː n t l ə s
 dauphin	d ɔ f ə n
 dauphin	d ɔ f ɪ n
+dauphiné	d ə ʊ f ɪ n e ɪ
 dauria	d ɑː ʊ ə r ɪ ə
 dauw	d a ʊ
 davao	d ɑ v a ʊ
@@ -17693,6 +17887,7 @@ deafly	d ɛ f l i
 deafs	d ɛ f s
 deal	d iː l
 dealate	d i e ɪ l e ɪ t
+dealate	d i e ɪ l ɪ t
 dealated	d i e ɪ l e ɪ t ə d
 dealie	d iː l i
 dealignment	d iː j ə l a ɪ n m ə n t
@@ -17712,6 +17907,8 @@ dearness	d ɪ ə ɹ n ə s
 dearth	d ɝ θ
 dearthy	d ɝ θ i
 dearworth	d ɪ ə ɹ w ɜː ɹ θ
+deas	d e ɪ ə s
+deas	d iː ə s
 deasil	d i s ə l
 deasil	d i z ə l
 deasil	d j ɛ ʃ ə l
@@ -17761,6 +17958,7 @@ debunks	d ɪ b ʌ ŋ k s
 debut	d e ɪ b j uː
 debut	d ə b j uː
 debuted	d e ɪ b j uː d
+debuted	d ɪ b j uː d
 debuts	d e ɪ b j uː z
 debye	d ə b a ɪ
 decacumination	d iː k ə k j uː m ɪ n e ɪ ʃ ə n
@@ -17784,6 +17982,7 @@ decan	d i k æ n
 decan	d ɛ k ə n
 decanal	d ɛ k ə n æ l
 decanal	d ɛ k ə n ə l
+decanal	d ɪ k e ɪ n ə l
 decangle	d ɛ k æ ŋ ɡ ə l
 decani	d ɪ k e ɪ n a ɪ
 decant	d ə k æ n t
@@ -17836,6 +18035,7 @@ decimal	d ɛ s ɪ m ə l
 decimate	d ɛ s ə m e ɪ t
 decimation	d ɛ s ɪ m e ɪ ʃ ə n
 decime	d ɛ s iː m
+decision	d ɪ s ɪ ʒ ə n
 decitabine	d ɪ s a ɪ t ə b iː n
 deck	d ɛ k
 decked	d ɛ k t
@@ -17895,6 +18095,8 @@ decussate	d ɪ k ʌ s e ɪ t
 decussation	d ɛ k ʌ s e ɪ ʃ ə n
 decussative	d ɪ k ʌ s ə t ɪ v
 dedicant	d ɛ d ɪ k ə n t
+dedicate	d ɛ d ɪ k e ɪ t
+dedicate	d ɛ d ɪ k ɪ t
 dedication	d ɛ d ɪ k e ɪ ʃ ə n
 dedicatory	d ɛ d ə k ə t ɔ ɹ i
 dedolent	d ɛ d ə l ə n t
@@ -17914,6 +18116,7 @@ deep	d iː p
 deepen	d iː p ə n
 deeper	d i p ɚ
 deepest	d iː p ɪ s t
+deepfake	d iː p f e ɪ k
 deeply	d iː p l i
 deer	d ɪ ɹ
 dees	d iː z
@@ -17957,8 +18160,9 @@ defile	d i f a ɪ l
 defile	d ə f a ɪ l
 define	d ɪ f a ɪ n
 defined	d ɪ f a ɪ n d
+definiendum	d ɪ f ɪ n i ɛ n d ə m
+definite	d ɛ f ə n ə t
 definite	d ɛ f ə n ɪ t
-definite	d ɛ f ɪ n ɪ t
 definitely	d ɛ f n ɪ t l i
 definitely	d ɛ f ə n ɪ t l i
 definitely	d ɛ f ɪ n ɪ t l i
@@ -18169,7 +18373,7 @@ demeter	d ə m iː t ə ɹ
 demeter	d ɛ m ɪ t ə ɹ
 demideity	d ɛ m iː d e ɪ ə t i
 demideity	d ɛ m iː d i ə t i
-demigod	d ɛ m ɪ ɡ ɑ d
+demigod	d ɛ m i ɡ ɑ d
 demigrate	d iː m a ɪ ɡ ɹ e ɪ t
 demigrate	d ɛ m ɪ ɡ ɹ e ɪ t
 demilitarize	d ɪ m ɪ l ɪ t ə ɹ a ɪ z
@@ -18223,6 +18427,7 @@ demurity	d ɪ m j ʊ ə ɹ ɪ t i
 demurral	d ɪ m ɝ ə l
 den	d ɛ n
 dena'ina	d ə n aː i n ə
+denali	d ɪ n ɑː l i
 denar	d e ɪ n ɑː ɹ
 denar	d ɛ n ɑː ɹ
 denary	d iː n ə ɹ i
@@ -18292,10 +18497,11 @@ deontic	d iː ɒ n t ɪ k
 deontology	d iː ɒ n t ɒ l ə d͡ʒ i
 deoxy	d iː ɒ k s i
 deoxycorticosterone	d i ɑ k s ɪ k ɔ ɹ t ɪ k ɑ s t ə ɹ o ʊ n
+deoxyribonucleic	d i ɔ k s i ɹ a ɪ b o ʊ n uː k l ɛ ɪ k
 deoxyribosylthymine	d iː ɒ k s i ɹ a ɪ b ə s ɪ l θ a ɪ m iː n
 depart	d ɪ p ɑ ɹ t
 departed	d ɪ p ɑ ɹ t ɪ d
-department	d ə p ɑ ɹ t m ə n t
+department	d ɪ p ɑ ɹ t m ə n t
 departmental	d iː p ɑː ɹ t m ɛ n t ə l
 departmental	d ɪ p ɑː ɹ t m ɛ n t ə l
 depend	d ɪ p ɛ n d
@@ -18335,6 +18541,7 @@ deport	d ɪ p ɔ ɹ t
 deportment	d ɪ p ɔ ɹ t m ə n t
 depose	d i p o ʊ z
 depose	d ə p o ʊ z
+deposit	d ɪ p ɑ z ɪ t
 depositary	d ɪ p ɑ z ɪ t ɛ ɹ i
 deposited	d ɪ p ɑ z ɪ t ɪ d
 deposition	d ɛ p ə z ɪ ʃ ə n
@@ -18455,6 +18662,7 @@ dese	d iː z
 desecrate	d ɛ s ə k ɹ e ɪ̯ t
 desecrate	d ɛ s ɪ k ɹ e ɪ̯ t
 desecration	d ɛ s ə k ɹ e ɪ ʃ ə n
+desecration	d ɛ s ɪ k ɹ e ɪ ʃ ə n
 desecration	d ɛ z ə k ɹ e ɪ ʃ ə n
 desegregation	d i s ɛ ɡ ɹ ə ɡ e ɪ̯ ʃ ə n
 deselect	d iː s ə l ɛ k t
@@ -18515,7 +18723,7 @@ desoxycorticosterone	d ɛ z ɑ k s ɪ k ɔ ɹ t ɪ k ɑ s t ə ɹ o ʊ n
 desoxycortone	d ɛ z ɑ k s ɪ k ɔ ɹ t o ʊ n
 despaghettify	d iː s p ə ɡ ɛ t ɪ f a i
 despaghettifying	d iː s p ə ɡ ɛ t ɪ f a ɪ j ɪ ŋ
-despair	d ɪ s p ɛ ə ɹ
+despair	d ɪ s p ɛ ɚ
 despairer	d ɪ s p ɛ ɹ ɚ
 despairing	d ɪ s p ɛ ə ɹ ɪ ŋ
 despairingly	d ɪ s p ɛ ə ɹ ɪ ŋ l i
@@ -18571,6 +18779,7 @@ detailed	d iː t e ɪ l d
 detailed	d ɪ t e ɪ l d
 details	d iː t e ɪ l z
 details	d ɪ t e ɪ l z
+detained	d ɪ t e ɪ n d
 detected	d ɪ t ɛ k t ɪ d
 detection	d ə t ɛ k ʃ ə n
 detective	d ɪ t ɛ k t ɪ v
@@ -18592,7 +18801,7 @@ detest	d ɪ t ɛ s t
 detestable	d ɪ t ɛ s t ə b l̩
 detestate	d ɪ t ɛ s t e ɪ t
 dethick	d ɛ θ ɪ k
-detonate	d ɛ t ə n e ɪ t
+detonate	d ɛ ʔ ə n e ɪ t
 detour	d i t o ɹ
 detour	d iː t ɔː ɹ
 detour	d iː t ʊ ə ɹ
@@ -18618,6 +18827,7 @@ deucalion	d j uː k e ɪ l ɪ ə n
 deuce	d uː s
 deuced	d j uː s t
 deuced	d j uː s ɪ d
+deucedly	d u s ɪ d l i
 deuteragonist	d j u t ə ɹ æ ɡ ə n ɪ s t
 deuteragonist	d uː t ə ɹ æ ɡ ə n ɪ s t
 deuterium	d j uː t ɪ ɹ i ə m
@@ -18642,6 +18852,7 @@ developers	d ɪ v ɛ l ə p ɚ z
 developing	d ɪ v ɛ l ə p ɪ ŋ
 development	d ɪ v ɛ l ə p m ə n t
 developmentals	d ɪ v ɛ l ə p m ɛ n t ə l z
+developmentation	d ɪ v ɛ l ə p m ə n t e ɪ ʃ ə n
 devi	d e ɪ v i
 deviance	d iː v ɪ ə n s
 deviate	d iː v i e ɪ t
@@ -18724,7 +18935,6 @@ dhyana	d j ɑː n ə
 di	d a ɪ
 diabase	d a ɪ ə b e ɪ s
 diabeetus	d a ɪ ə b iː t ə s
-diabetes	d a ɪ ə b eː t ɪ s
 diabetes	d a ɪ ə b iː t iː z
 diabetes	d a ɪ ə b iː t ɪ s
 diable	d i ɑː b ə l
@@ -18876,6 +19086,7 @@ dicloxacillin	d a ɪ k l ɑ k s ə s ɪ l ɪ n
 dicrotic	d a ɪ k ɹ ɑ t ɪ k
 dicrotophos	d a ɪ k ɹ ə ʊ t ə f ɒ s
 dictamen	d ɪ k t e ɪ m ə n
+dictamina	d ɪ k t æ m ɪ n ə
 dictate	d ɪ k t e ɪ t
 dictated	d ɪ k t e ɪ t ɪ d
 dictation	d ɪ k t e ɪ ʃ ə n
@@ -18889,6 +19100,8 @@ dicycloverine	d a ɪ s a ɪ k l o ʊ v ə ɹ i n
 did	d ɪ d
 didactic	d a ɪ d æ k t ɪ k
 didactic	d ɪ d æ k t ɪ k
+didactician	d a ɪ d ə k t ɪ ʃ ə n
+didactics	d a ɪ d æ k t ɪ k s
 didanosine	d a ɪ d æ n ə s i n
 diddest	d ɪ d ɛ s t
 didelphic	d a ɪ d ɛ l f ɪ k
@@ -18907,6 +19120,7 @@ died	d a ɪ d
 diedre	d ɪ ə d r i
 diegetic	d a ɪ ə d͡ʒ ɛ t ɪ k
 diego	d i e ɪ ɡ o ʊ
+dieguez	d i e ɪ ɡ ɛ z
 diel	d a ɪ ə l
 diel	d i ə l
 dielectric	d a ɪ ə l ɛ k t ɹ ɪ k
@@ -18927,12 +19141,14 @@ diet	d a ɪ ə t
 dietary	d a ɪ ə t ɛ ɹ i
 dietary	d a ɪ ə t ɹ i
 dietetic	d a ɪ ə t ɛ t ɪ k
+dietetician	d a ɪ ə t ɪ t ɪ ʃ ə n
+dietetics	d a ɪ ə t ɛ t ɪ k s
 diethylstilbestrol	d a ɪ ɛ θ ə l s t ɪ l b ɛ s t ɹ ɔ l
 dietitian	d a ɪ ə t ɪ ʃ ə n
 difenoxin	d a ɪ f ə n ɑ k s ɪ n
 diff	d ɪ f
 differ	d ɪ f ɚ
-difference	d ɪ f ɹ ə n s
+difference	d ɪ f ə ɹ ə n s
 differences	d ɪ f ɹ ə n s ɪ z
 different	d ɪ f ə ɹ ə n t
 different	d ɪ f ɹ ə n t
@@ -18966,6 +19182,7 @@ digest	d a ɪ d͡ʒ ə s t
 digest	d a ɪ d͡ʒ ɛ s t
 digest	d ə d͡ʒ ɛ s t
 digestion	d a ɪ d͡ʒ ɛ s t͡ʃ ə n
+digestion	d ɪ d͡ʒ ɛ s t͡ʃ ə n
 digger	d ɪ ɡ ɚ
 diggety	d ɪ ɡ ə t i
 diggs	d ɪ ɡ z
@@ -19086,6 +19303,8 @@ dinette	d a ɪ n ɛ t
 ding	d ɪ ŋ
 dingbat	d ɪ ŋ b æ t
 dinge	d ɪ n d͡ʒ
+dinged	d ɪ n d͡ʒ d
+dinged	d ɪ ŋ d
 dinghy	d ɪ ŋ i
 dingle	d ɪ ŋ ɡ l̩
 dingleberry	d ɪ ŋ ɡ ə ɫ b ɛ ɹ i
@@ -19110,6 +19329,7 @@ dinocarid	d a ɪ n ə k æ ɹ ɪ d
 dinocarid	d a ɪ n ə k ɛ ə ɹ ɪ d
 dinokaryote	d a ɪ n ə ʊ k æ ɹ i ə ʊ t
 dinoprostone	d a ɪ n ə p ɹ ɑ s t o ʊ n
+dinorwig	d ɪ n ɔ r w ɪ ɡ
 dinq	d ɪ ŋ k
 dins	d ɪ n z
 dint	d ɪ n t
@@ -19226,7 +19446,9 @@ disanthropic	d ɪ s æ n θ ɹ ɑ p ɪ k
 disanthropy	d ɪ s æ n θ ɹ ə p i
 disappear	d ɪ s ə p ɪ ɹ
 disappeared	d ɪ s ə p ɪ ɹ d
+disappoint	d ɪ s ə p ɔ ɪ n t
 disappointed	d ɪ s ə p ɔ ɪ n t ɪ d
+disappointment	d ɪ s ə p ɔ ɪ n t m ə n t
 disapproval	d ɪ s ə p ɹ u v ə l
 disaster	d ɪ z æ s t ɚ
 disastrophe	d ɪ z æ s t ɹ ə f i
@@ -19504,6 +19726,7 @@ dissection	d ɪ s ɛ k ʃ ə n
 dissed	d ɪ s t
 disseize	d ɪ s iː z
 disseizin	d ɪ s iː z ɪ n
+dissemination	d ɪ s ɛ m ɪ n e ɪ ʃ ə n
 dissension	d ɪ s ɛ n ʃ ə n
 dissensus	d ɪ s ɛ n s ə s
 dissent	d ə s ɛ n t
@@ -19518,6 +19741,7 @@ disship	d ɪ s ʃ ɪ p
 dissident	d ɪ s ɪ d ə n t
 dissilition	d ɪ s ɪ l ɪ ʃ ə n
 dissimilate	d ɪ s ɪ m ɪ l e ɪ t
+dissimilation	d ɪ s ɪ m ɪ l e ɪ ʃ ə n
 dissimulate	d ɪ s ɪ m j ʊ l e ɪ t
 dissing	d ɪ s ɪ ŋ
 dissipable	d ɪ s ɪ p ɪ b l̩
@@ -19627,6 +19851,7 @@ divers	d a ɪ v ə ɹ z
 divers	d a ɪ v ɜː ɹ z
 diverse	d a ɪ v ɚ s
 diverse	d a ɪ v ɝ s
+diverse	d ɪ v ɝ s
 diversification	d a ɪ v ɝ s ɪ f ɪ k e ɪ ʃ ə n
 diversification	d ɪ v ɝ s ɪ f ɪ k e ɪ ʃ ə n
 diversify	d a ɪ v ɝ s ə f a ɪ
@@ -19639,6 +19864,7 @@ divert	d a ɪ v ɝ t
 divert	d ɪ v ɝ t
 diverticulum	d ɑ ɪ v ɜː t ɪ k j ə l ə m
 divertimento	d ə v ɝ t ə m ɛ n t o ʊ
+divertisement	d ɪ v ɜː ɹ t ɪ z m ə n t
 divertive	d a ɪ v ɜː ɹ t ɪ v
 dives	d a ɪ v z
 divest	d a ɪ v ɛ s t
@@ -19647,6 +19873,7 @@ divestment	d a ɪ v ɛ s t m ə n t
 divey	d a ɪ v i
 dividend	d ɪ v ɪ d ɛ n d
 dividual	d ɪ v ɪ d͡ʒ u ə l
+divination	d ɪ v ɪ n e ɪ ʃ ə n
 divine	d ɪ v a ɪ n
 diviner	d ɪ v a ɪ n ə ɹ
 diving	d a ɪ v ɪ ŋ
@@ -19657,6 +19884,7 @@ divisions	d ɪ v ɪ ʒ ə n z
 divisive	d ɪ v a ɪ s ɪ v
 divisive	d ɪ v ɪ s ɪ v
 divisive	d ɪ v ɪ z ɪ v
+divisor	d ɪ v a ɪ z ɚ
 divo	d iː v o ʊ
 divorce	d ɪ v ɔ ɹ s
 divorcee	d ɪ v ɔ ɹ s i
@@ -19674,6 +19902,7 @@ dixnary	d ɪ k s ə n ɛ ɹ i
 dixnary	d ɪ k s ə ɹ i
 dixnary	d ɪ k s ɛ ɹ i
 dixon	d ɪ k s ə n
+dixy	d ɪ k s i
 diya	d iː j ə
 diya	d iː ə
 diyarbakır	d i a ɹ b ə k i ɹ
@@ -19695,6 +19924,7 @@ djinn	d͡ʒ ɪ n
 djokovic	d͡ʒ o ʊ k ə v ɪ t͡ʃ
 dmz	d iː ɛ m z iː
 dmz	d iː ɛ m z ɛ d
+dna	d i ɛ n e ɪ
 dnieper	n iː p ə ɹ
 dnipro	n i p r o ʊ
 dnipro	n ɪ p r o ʊ
@@ -19805,8 +20035,10 @@ doink	d ɔ ɪ ŋ k
 doit	d ɔ ɪ t
 dojigger	d uː d͡ʒ ɪ ɡ ə ɹ
 dojo	d o ʊ d͡ʒ o ʊ
+dokkaebi	d o ʊ k e ɪ b i
 dolan	d o ʊ l ə n
 dolasetron	d o ʊ l æ s ə t ɹ ɑ n
+dolbadarn	d ɔ l b a d aː n
 dolcetto	d o ʊ l t͡ʃ ɛ t o ʊ
 doldrum	d ɑ l d ɹ ə m
 doldrums	d ɑ l d ɹ ə m z
@@ -19825,6 +20057,7 @@ dollarization	d ɑ l ɝ ɪ z e ɪ̯ ʃ ɪ n
 dollars	d ɑ l ɚ z
 dollop	d ɑ l ə p
 dolly	d ɑ l i
+dollywood	d ɒ l i w ʊ d
 dolman	d o ʊ l m ə n
 dolmen	d o ʊ l m ə n
 dolmen	d ɑ l m ə n
@@ -19843,6 +20076,7 @@ dolphinarium	d ɑ l f ɪ n ɛ ə ɹ i ə m
 dolt	d o ʊ l t
 dolts	d o ʊ l t s
 dolus	d o ʊ l ə s
+dolwyddelan	d ɔ l w ɪ ð ɛ l a n
 dom	d ɑ m
 doma	d o ʊ m ə
 domable	d o ʊ m ə b l̩
@@ -20060,6 +20294,7 @@ double	d ʌ b ə l
 doubled	d ʌ b l̩ d
 doublet	d ʌ b l ə t
 doubly	d ʌ b l i
+doubly	d ʌ b ə l l i
 doubs	d uː
 doubt	d a ʊ t
 doubted	d a ʊ t ɪ d
@@ -20153,6 +20388,7 @@ dows	d a ʊ z
 dowse	d a ʊ s
 dowse	d a ʊ z
 dowser	d a ʊ z ə
+doxa	d ɑ k s ə
 doxastic	d ɒ k s æ s t ɪ k
 doxazosin	d ɑ k s e ɪ z ə s ɪ n
 doxepin	d ɑ k s ə p ɪ n
@@ -20173,6 +20409,7 @@ drabble	d ɹ æ b ə l
 drachm	d ɹ æ m
 drachma	d ɹ æ k m ə
 drachmae	d ɹ æ k m iː
+drachme	d ɹ æ k m i
 draco	d ɹ e ɪ k o ʊ
 draconian	d ɹ e ɪ k o ʊ n i ə n
 draconian	d ɹ ə k o ʊ n i ə n
@@ -20184,6 +20421,7 @@ draff	d ɹ æ f
 draff	d ɹ ɑː f
 draft	d ɹ æ f t
 drafty	d ɹ æ f t i
+drag	d ɹ æ ɡ
 drageoir	d ɹ æ ʒ w ɑː
 draggable	d ɹ æ ɡ ə b ə l
 dragged	d ɹ æ ɡ d
@@ -20276,7 +20514,7 @@ dreams	d ɹ iː m z
 dreamt	d ɹ ɛ m p t
 dreamtime	d ɹ iː m t a ɪ m
 dreamworker	d ɹ i m w ɝ k ɚ
-drear	d ɹ ɪ ə ɹ
+drear	d ɹ ɪ ɚ
 drear	d ɹ ɪ ɹ
 drearing	d ɹ ɪ ə ɹ ɪ ŋ
 dreary	d ɹ ɪ ɹ i
@@ -20456,7 +20694,6 @@ drusilla	d ɹ u s ɪ l ə
 druthers	d ɹ ʌ ð ɚ z
 druxy	d ɹ ʌ k s i
 dry	d ɹ a ɪ
-dry	d͡ʒ ɹ a ɪ
 dryad	d ɹ a ɪ æ d
 dryad	d ɹ a ɪ ə d
 dryas	d ɹ a ɪ æ s
@@ -20494,6 +20731,7 @@ dubitation	d j u b ɪ t e ɪ ʃ ə n
 dubitation	d u b ɪ t e ɪ ʃ ə n
 dubitative	d j uː b ɪ t ə t ɪ v
 dublin	d ʌ b l ə n
+dublin	d ʌ b l ɪ n
 dubnium	d uː b n i ə m
 dubois	d uː b ɔ ɪ z
 dubonnet	d j uː b ə n e ɪ
@@ -20561,6 +20799,7 @@ dukedom	d j u k d ə m
 dukedom	d u k d ə m
 dukedoms	d j uː k d ə m z
 dukkha	d ʊ k ə
+dulce	d ʌ l s
 dulcet	d ʌ l s ə t
 dulcet	d ʌ l s ɪ t
 dulcify	d ʌ l s ɪ f a ɪ
@@ -20844,10 +21083,13 @@ e'er	ɛ ʔ ɚ
 ea	iː ə
 each	i t͡ʃ
 eager	i ɡ ɚ
+eager	ɪ ɡ ə
+eager	ɪ ɡ ɚ
 eagerly	i ɡ ɚ l i
 eagerness	i ɡ ɚ n ə s
 eagle	i ɡ ə l
 eagle	iː ɡ ə l
+eagle	ɪ ɡ ə l
 eaglesham	iː ɡ ə l s ə m
 eagre	e ɪ ɡ ə ɹ
 eagre	iː ɡ ə ɹ
@@ -20886,7 +21128,7 @@ ears	ɪ ɹ z
 earsh	æː ɹ ʃ
 earshot	ɪ ɹ ʃ ɑ t
 earth	ɝ θ
-earthen	ə ɹ θ ə n
+earthen	ɝ θ ə n
 earthful	ɜː θ f ʊ l
 earthling	ɝ θ l ɪ ŋ
 earthquake	ɝ θ k w e ɪ k
@@ -20906,8 +21148,7 @@ eases	iː z ɪ z
 easesome	iː z s ʌ m
 easie	iː z i
 easier	i z i ɚ
-easily	iː z ə l iː
-easily	iː z ɪ l iː
+easily	i z ə l i
 easiness	iː z ɪ n ə s
 easing	iː z ɪ ŋ
 easings	iː z ɪ ŋ z
@@ -21042,6 +21283,7 @@ ecstatic	ɛ k s t æ t ɪ k
 ecstatica	ɛ k s t æ t ɪ k ə
 ectal	ɛ k t ə l
 ectasia	ɛ k t e ɪ z j ə
+ectasis	ɛ k t ə s ɪ s
 ectodomain	ɛ k t o ʊ d o ʊ m e ɪ n
 ectomorph	ɛ k t o ʊ m ɔː ɹ f
 ectomorph	ɛ k t ə m ɔː ɹ f
@@ -21112,6 +21354,7 @@ edmundston	ɛ d m ə n d s t ə n
 edo	ɛ d o ʊ
 edom	i d ə m
 edomite	iː d ə m a ɪ t
+edonentan	ɛ d ə n ɛ n t æ n
 edro	i d ɹ o ʊ
 edrophonium	ɛ d ɹ ə f o ʊ n i ə m
 educate	ɛ d͡ʒ ə k e ɪ t
@@ -21146,6 +21389,7 @@ eff	ɛ f
 efface	ə f e ɪ s
 efface	ɪ f e ɪ s
 effect	ə f ɛ k t
+effect	ɪ f ɛ k t
 effected	ɪ f ɛ k t ɪ d
 effectively	ɪ f ɛ k t ɪ v l i
 effects	ɪ f ɛ k t s
@@ -21202,7 +21446,7 @@ efs	ɛ f s
 eft	ɛ f t
 efta	ɛ f t ɑː
 eftpos	ɛ f t p ɒ s
-egad	iː ɡ æ d
+egad	i ɡ æ d
 egal	iː ɡ ə l
 egalitarian	ɪ ɡ æ l ɪ t ɛ ɹ i ə n
 egality	ɪ ɡ æ l ɪ t i
@@ -21217,6 +21461,7 @@ egging	ɛ ɡ ɪ ŋ
 eggings	ɛ ɡ ɪ ŋ z
 eggless	ɛ ɡ l ə s
 eggnog	ɛ ɡ n ɑ ɡ
+eggplant	ɛ ɡ p l æ n t
 eggs	ɛ ɡ z
 eggshell	ɛ ɡ ʃ ɛ l
 eggy	ɛ ɡ i
@@ -21279,8 +21524,8 @@ eisteddfod	a ɪ s t ɛ ð v ɒ d
 eisteddfodau	a ɪ s t ɛ ð v ɒ d a ɪ
 eisteddfodic	a ɪ s t ɛ ð v ɒ d ɪ k
 eisteddfodwr	a ɪ s t ɛ ð v ɒ d ə ɹ
-either	a ɪ ð ə ɹ
-either	iː ð ə ɹ
+either	a ɪ ð ɚ
+either	i ð ɚ
 ejaculate	ɪ d͡ʒ æ k j ə l e ɪ t
 ejaculate	ɪ d͡ʒ æ k j ə l ə t
 ejaculator	ɪ d͡ʒ æ k j ə l e ɪ t ə ɹ
@@ -21422,6 +21667,7 @@ elevon	ɛ l ə v ɒ n
 elf	ɛ l f
 elfin	ɛ l f ɪ n
 elgan	ɛ l ɡ ə n
+elgin	ɛ l d ʒ ɪ n
 elgin	ɛ l ɡ ɪ n
 elginism	ɛ l ɡ ɪ n ɪ z ə m̩
 elginist	ɛ l ɡ ɪ n ɪ s t
@@ -21433,6 +21679,8 @@ elie	ɛ l i
 eliezer	ɛ l i iː z ə ɹ
 eliezer	ɛ l i ɛ z ə ɹ
 eligible	ɛ l ɪ d͡ʒ ə b ə l
+elijah	ɪ l a ɪ d͡ʒ ə
+elijah	ɪ l a ɪ ʒ ə
 eliminate	ɪ l ɪ m ə n e ɪ t
 elimination	ɪ l ɪ m ɪ n e ɪ ʃ ə n
 elisa	ɪ l ʌ ɪ z ə
@@ -21490,8 +21738,10 @@ elohim	ɛ l o ʊ h i m
 elohim	ɛ l o ʊ h ɪ m
 eloise	ɛ l ə ʊ iː z
 elon	iː l ɔ n
+elongate	i l ɔ ŋ ɡ e ɪ t
 elongate	ɪ l ɔ ŋ ɡ e ɪ t
 elope	ɛ l o ʊ p
+elope	ɪ l o ʊ p
 eloquate	ɛ l ə k w e ɪ t
 eloquence	ɛ l ə k w ə n s
 elrig	ɛ l ɹ ɪ ɡ
@@ -21507,6 +21757,7 @@ elsin	ɛ l z ɪ n
 elsinore	ɛ l s ə n ɔ ɹ
 elton	ɛ l t ə n
 elu	h ɛ l uː
+elucidate	i l uː s ɪ d e ɪ t
 elucidation	ɪ l u s ɪ d e ɪ ʃ ə n
 elucubrate	ɪ l uː k j ʊ b ɹ e ɪ t
 elucubration	ɪ l uː k j ʊ b ɹ e ɪ ʃ ə n
@@ -21715,6 +21966,7 @@ emphysema	ɛ m f ɪ s i m ə
 emphysema	ɛ m f ɪ z i m ə
 empire	ɛ m p a ɪ ɚ
 empire	ɛ m p a ɪ ɹ
+empiric	ɪ m p ɪ ɹ ɪ k
 empirical	ɪ m p ɪ ɹ ɪ k ə l
 employ	ɛ m p l ɔ ɪ
 employ	ɪ m p l ɔ ɪ
@@ -21884,6 +22136,7 @@ endo	ɛ n d ə ʊ
 endocommensalism	ɛ n d o ʊ k ə m ɛ n s ə l ɪ z m̩
 endocrine	ɛ n d o ʊ k ɹ ɪ n
 endocrinology	ɛ n d ə k r ɪ n ɑ l ə d͡ʒ i
+endogenous	ɪ n d ɑ d͡ʒ ə n ə s
 endolymph	ɛ n d ə l ɪ m f
 endolymphatic	ɛ n d ə l ɪ m f æ t ɪ k
 endometrial	e n d ə m iː t ɹ i ə l
@@ -22060,11 +22313,13 @@ enrage	ɪ n ɹ e ɪ d͡ʒ
 enraged	ɪ n ɹ e ɪ d͡ʒ d
 enrapture	ɛ n ɹ æ p t͡ʃ ə ɹ
 enrapture	ɪ n ɹ æ p t͡ʃ ə ɹ
+enrasentan	ɛ n ɹ ə s ɛ n t æ n
 enrich	ɪ n ɹ ɪ t͡ʃ
 enroll	ɛ n ɹ o ʊ l
 enroll	ɪ n ɹ o ʊ l
 ensanguine	ɛ n s æ ŋ ɡ w ə n
 ensconce	ɛ n s k ɑ n s
+enscripturate	ɪ n s k ɹ ɪ p t͡ʃ ə r e ɪ t
 ensear	ɪ n s ɪ ə ɹ
 ensemble	ɑ n s ɑ m b ə l
 ensete	ɛ n s ə t
@@ -22138,6 +22393,7 @@ entirety	ɪ n t a ɪ ə ɹ ɪ t i
 entitled	ɪ n t a ɪ t l̩ d
 entitlement	ə n t a ɪ t ə l m ə n t
 entity	e n t ɪ t i
+entomb	ɪ n t uː m
 entombment	ɛ n t uː m m ə n t
 entombment	ɪ n t uː m m ə n t
 entomophagy	ɛ n t ə m ɑ f ə d͡ʒ i
@@ -22150,6 +22406,7 @@ entrail	ɛ n t ɹ e ɪ l
 entrail	ɛ n t ɹ ə l
 entrails	ɛ n t ɹ e ɪ l z
 entrails	ɛ n t ɹ ə l z
+entrance	ɛ n t ɹ æ n s
 entrance	ɛ n t ɹ ə n s
 entranced	ɛ n t ɹ æ n s t
 entrances	ɛ n t ɹ ə n s ə z
@@ -22192,14 +22449,13 @@ envelope	ɛ n v ɛ l ə p
 enveloped	ɪ n v ɛ l ə p t
 envenom	ɪ n v ɛ n ə m
 enviable	ɛ n v i ə b l̩
+envie	ɑː n v iː
 envie	ɛ n v a ɪ
 envie	ɪ n v a ɪ
 envied	ɛ n v i d
 envied	ɪ n v a ɪ d
 envious	ɛ n v iː ə s
 environ	ə n v a ɪ ə ɹ ə n
-environment	ɪ n v a ɪ ɚ n m ə n t
-environment	ɪ n v a ɪ ɹ ə n m ə n t
 environmental	ə n v a ɪ ɚ n m ɛ n t ə l
 envisage	ɛ n v ɪ z ɪ d͡ʒ
 envisage	ɪ n v ɪ z ɪ d͡ʒ
@@ -22211,6 +22467,7 @@ envowel	ɛ n v a ʊ ə l
 envoy	ɑ n v ɔ ɪ
 envoy	ɛ n v ɔ ɪ
 envy	ɛ n v i
+enyo	ɪ n a ɪ o ʊ
 enzedder	ɛ n z ɛ d ə ɹ
 enzo	ɛ n z o ʊ
 enzo	ɛ n z ə ʊ
@@ -22225,7 +22482,7 @@ eohippus	iː ə ʊ h ɪ p ə s
 eon	iː ɒ n
 eonian	iː ə ʊ n ɪ ə n
 eonism	i ə n ɪ z ə m
-eos	iː ɒ s
+eos	i ɑ s
 eosin	i ə s ɪ n
 eosinophil	i ə s ɪ n ə f ɪ l
 ep	ɛ p
@@ -22341,6 +22598,7 @@ epiphysis	ə p ɪ f ɪ s ɪ s
 epiphysis	ɪ p ɪ f ɪ s ɪ s
 epiphyte	ɛ p ɪ f ɑ ɪ t
 epirubicin	ɛ p ɪ ɹ u b ɪ s n̩
+epirus	ɪ p a ɪ ə ɹ ə s
 episcopal	ə p ɪ s k ə p l̩
 episcopalian	ə p ɪ s k ə p e ɪ l i n̩
 episcopate	ɪ p ɪ s k ə p ə t
@@ -22361,6 +22619,7 @@ epistemology	ɛ p ɪ s t ə m ɑ l ə d͡ʒ i
 epistemology	ɪ p ɪ s t ə m ɑ l ə d͡ʒ i
 epistle	ɪ p ɪ s l
 epistle	ɪ p ɪ s ə l
+epistocracy	ɛ p ɪ s t ɑ k ɹ ə s i
 epitaph	ɛ p ɪ t æ f
 epitapher	ɛ p ɪ t æ f ə ɹ
 epitasis	ɪ p ɪ t ə s ɪ s
@@ -22473,8 +22732,8 @@ eratosthenian	ɛ ɹ æ t ə s θ iː n i ə n
 eratosthenian	ɛ ɹ ə t ə s θ iː n i ə n
 erbium	ɝ b i ə m
 erd	ɝ d
-erdoğan	ɛ ə ɹ d o ʊ ɑː n
-ere	ɛ ə ɹ
+erdoğan	ɛ ə ɹ d ə w ɑː n
+ere	ɛ ɚ
 ere	ɪ ə ɹ
 erebus	ɛ ɹ ə b ə s
 erect	ɪ ɹ ɛ k t
@@ -22504,6 +22763,8 @@ erinaceous	ɛ ɹ ə n e ɪ ʃ ə s
 erinaceous	ɛ ɹ ɪ n e ɪ ʃ ə s
 erinyes	ɪ ɹ ɪ n i iː z
 erinys	ɪ ɹ ɪ n ɪ s
+eris	ɛ ɹ ɪ s
+eris	ɪ ə ɹ ɪ s
 eriskay	ɛ ɹ ɪ s k e ɪ
 eritrea	ɛ ɹ ɪ t ɹ e ɪ ə
 eritrea	ɛ ɹ ɪ t ɹ i ə
@@ -22603,6 +22864,8 @@ escapologist	ɛ s k ə p ɑ l ə d ʒ ɪ s t
 escapology	ɛ s k ə p ɑ l ə d ʒ i
 escargot	ɛ s k ɑ ɹ ɡ o ʊ
 escarole	ɛ s k ə ɹ o ʊ l
+escarp	ɪ s k ɑ ɹ p
+escarpment	ɪ s k ɑ ɹ p m ə n t
 eschar	ɛ s k ɑ ɹ
 eschatological	ɛ s k ə t ə l ɑ d͡ʒ ɪ k ə l
 eschatology	ɛ s k ə t ɔ l ə d͡ʒ i
@@ -22717,6 +22980,7 @@ esthiomene	ɛ s θ i ɒ m ə n i
 esthonia	ɛ s t o ʊ n i ə
 esthonia	ɛ s θ o ʊ n i ə
 estimable	ɛ s t ɪ m ə b ə l
+estimate	ɛ s t ɪ m ɪ t
 estimation	ɛ s t ɪ m e ɪ ʃ ə n
 estimative	ɛ s t ɪ m e ɪ t ɪ v
 estimative	ɛ s t ɪ m ə t ɪ v
@@ -22895,12 +23159,13 @@ euphony	j uː f ə n i
 euphoria	j uː f ɔː ɹ i ə
 euphoriant	j u f ɔ ɹ i ə n t
 euphrates	j uː f ɹ e ɪ t iː z
+euphrosyne	j uː f ɹ ɒ z ɪ n i
 eupyrion	j uː p ɪ ɹ i ə n
 eurafrican	j ʊ ə ɹ æ f ɹ ɪ k ə n
 euramerica	j ʊ ə ɹ ə m ɛ ɹ ə k ə
 eurasia	j ə ɹ e ɪ ʒ ə
 eurasia	j ʊ ɹ e ɪ ʒ ə
-eureka	j u ɹ iː k ə
+eureka	j ʊ ɹ iː k ə
 euric	j ʊ ə ɹ ɪ k
 euripides	j ə ɹ ɪ p ɪ d i z
 euripides	j ʊ ɹ ɪ p ɪ d i z
@@ -23110,6 +23375,7 @@ exceeding	ɪ k s iː d ɪ ŋ
 exceedingly	ɪ k s iː d ɪ ŋ l i
 excel	ɪ k s ɛ l
 excellence	ɛ k s ə l ə n s
+excellent	ɛ k s ə l ə n t
 excentric	ɛ k s ɛ n t ɹ ɪ k
 except	ɛ k s ɛ p t
 except	ɪ k s ɛ p t
@@ -23143,6 +23409,9 @@ excited	ɪ k s a ɪ t ɪ d
 excitement	ɪ k s a ɪ t m ə n t
 exciting	ɛ k s ʌ ɪ t ɪ ŋ
 exciting	ɪ k s ʌ ɪ t ɪ ŋ
+exciton	ɛ k s a ɪ t ɒ n
+exciton	ɛ k s ɪ t ə n
+exciton	ɪ k s a ɪ t ɑ n
 exclaim	ɛ k s k l e ɪ m
 exclaim	ɪ k s k l e ɪ m
 exclaimed	ɛ k s k l e ɪ m d
@@ -23177,7 +23446,7 @@ excruciating	ɪ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ
 excruciatingly	ɛ k s k ɹ uː ʃ iː e ɪ t ɪ ŋ l i
 excruciatingly	ɪ k s k ɹ uː s iː e ɪ t ɪ ŋ l i
 exculpate	ɛ k s k ə l p e ɪ t
-exculpatory	ɛ k s k ʌ l p ə t ɒ ɹ i
+exculpatory	ɛ k s k ʌ l p ə t ɔ ɹ i
 excursion	ɛ k s k ɜː ɹ ʃ ə n
 excursion	ɛ k s k ɜː ɹ ʒ ə n
 excursus	ɪ k s k ɜː s ə s
@@ -23213,7 +23482,7 @@ exegete	ɛ k s ɪ d͡ʒ i t
 exemestane	ɛ k s ə m ɛ s t e ɪ n
 exemplar	ɛ ɡ z ɛ m p l ɑ ɹ
 exemplar	ɪ ɡ z ɛ m p l ɚ
-exemplary	ɛ ɡ z ɛ m p l ə ɹ i
+exemplary	ɪ ɡ z ɛ m p l ə ɹ i
 exemplify	ɛ ɡ z ɛ m p l ɪ f a ɪ
 exemplify	ɪ ɡ z ɛ m p l ɪ f a ɪ
 exempt	ɛ ɡ z ɛ m p t
@@ -23255,6 +23524,7 @@ exhibition	ɛ k s ɪ b ɪ ʃ ə n
 exhilarate	ɪ ɡ z ɪ l ə ɹ e ɪ t
 exhort	ɛ ɡ z ɔ ɹ t
 exhort	ɪ ɡ z ɔ ɹ t
+exhortative	ɪ ɡ z ɔ ɹ t ə t ɪ v
 exhumation	e k s h j uː m e ɪ ʃ ə n
 exhume	ɛ k s j u m
 exhume	ɪ ɡ z j u m
@@ -23355,6 +23625,7 @@ expenditures	ɛ k s p ɛ n d ɪ t͡ʃ ɚ z
 expenditures	ɪ k s p ɛ n d ɪ t͡ʃ ɚ z
 expends	ɛ k s p ɛ n d z
 expends	ɪ k s p ɛ n d z
+expenny	ɪ k s p ɛ n i
 expense	ɪ k s p ɛ n s
 expenses	ɪ k s p ɛ n s ɪ z
 expensive	ɛ k s p ɛ n s ɪ v
@@ -23366,6 +23637,7 @@ experiences	ɪ k s p ɪ ɹ i ə n s ɪ z
 experiential	ɪ k s p ɪ ɹ i ɛ n ʃ ə l
 experiment	ɪ k s p ɛ ɹ ə m ə n t
 experiment	ɪ k s p ɪ ɹ ə m ə n t
+experimental	ɪ k s p ɛ ɹ ə m ɛ n t ə l
 experiments	ɪ k s p ɛ ɹ ə m ə n t s
 experiments	ɪ k s p ɪ ɹ ə m ə n t s
 expert	ɛ k s p ɚ t
@@ -23405,6 +23677,7 @@ exploratory	ɛ k s p l ɔ ɹ ə t ɔ ɹ i
 explore	ɪ k s p l ɔ ɹ
 explorer	ɛ k s p l ɔː ɹ ə ɹ
 explosion	ɛ k s p l o ʊ ʒ ə n
+explosion	ɪ k s p l o ʊ ʒ ə n
 explosive	ɛ k s p l ə ʊ s ɪ v
 explosive	ɪ k s p l ə ʊ s ɪ v
 exponent	ɛ k s p o ʊ n ə n t
@@ -23417,7 +23690,7 @@ expose	ɛ k s p o ʊ z
 expose	ɪ k s p o ʊ z
 exposition	ɛ k s p ə z ɪ ʃ ə n
 expository	ɛ k s p ɑ z ə t ɔ ɹ i
-expostulate	ɛ k s p ɒ s t j ʊ l e ɪ t
+expostulate	ɛ k s p ɑ s t j ʊ l e ɪ t
 exposure	ɪ k s p o ʊ ʒ ɚ
 exposé	ɛ k s p o ʊ z e ɪ
 expound	ɪ k s p a ʊ n d
@@ -23576,7 +23849,6 @@ exude	ɪ k s u d
 exude	ɪ ɡ z u d
 exult	ɪ ɡ z ʌ l t
 exultation	ɛ ɡ z ʌ l t e ɪ ʃ ə n
-exuma	ɛ k s uː m ə
 exuviate	ɛ k s uː v ɪ e ɪ t
 exuviate	ɛ ɡ z uː v ɪ e ɪ t
 ey	e ɪ
@@ -23671,7 +23943,8 @@ factoid	f æ k t ɔ ɪ d
 factor	f æ k t ɚ
 factorial	f æ k t ɔː ɹ i ə l
 factors	f æ k t ɚ z
-factory	f æ k t ə ɹ i
+factory	f æ k t ɚ i
+factory	f æ k t ɹ i
 factotum	f æ k t o ʊ t ə m
 facts	f æ k s
 facts	f æ k t s
@@ -23695,8 +23968,8 @@ fadge	f æ d͡ʒ
 fading	f e ɪ d ɪ ŋ
 fado	f ɑː d o ʊ
 fady	f e ɪ d i
+fady	f æ d i
 fady	f ɑː d i
-faeces	f iː s iː z
 faena	f a e n ə
 faff	f æ f
 faffy	f æ f i
@@ -23725,7 +23998,7 @@ faint	f e ɪ n t
 faintest	f e ɪ n t ə s t
 fainting	f e ɪ n t ɪ ŋ
 faintly	f e ɪ n t l i
-fair	f ɛ ə ɹ
+fair	f ɛ ɚ
 fairbanks	f ɛ ɹ b æ ŋ k s
 fairer	f ɛ ɹ ɚ
 fairest	f ɛ ɹ ɪ s t
@@ -23820,6 +24093,7 @@ fan	f æ n
 fanac	f æ n æ k
 fanatic	f ə n æ t ɪ k
 fanatical	f ə n æ t ɪ k ə l
+fanaticism	f ə n æ t ɪ s ɪ z ə m
 fancied	f æ n s ɪ d
 fancies	f æ n s i z
 fanciful	f æ n s ɪ f ə l
@@ -23827,6 +24101,7 @@ fancy	f æ n s i
 fand	f æ n d
 fandemonium	f æ n d ə m ə ʊ n i ə m
 fandom	f æ n d ə m
+fandosentan	f æ n d ə s ɛ n t æ n
 fandub	f æ n d ʌ b
 fane	f e ɪ n
 faned	f æ n ɛ d
@@ -23871,6 +24146,7 @@ fantastic	f æ n t æ s t ɪ k
 fantastical	f æ n t æ s t ɪ k ə l
 fantasy	f æ n t ə s i
 fanti	f æ n t i
+fantods	f æ n t ɒ d z
 fanzine	f æ n z iː n
 fap	f æ p
 fapiao	f ɑː p i a ʊ
@@ -23891,7 +24167,7 @@ fare	f ɛ ɹ
 fareham	f ɛ ə ɹ ə m
 farer	f ɛ ɹ ɚ
 fareway	f ɛ ɹ w e ɪ
-farewell	f ɛ ə ɹ w ɛ l
+farewell	f ɛ ɚ w ɛ l
 farfalle	f ɑ ɹ f ɑ l e ɪ
 farfetch	f ɑː ɹ f ɛ t͡ʃ
 fargo	f ɑ ɹ ɡ o ʊ
@@ -23997,6 +24273,7 @@ fathom	f æ ð ə m
 fathomable	f æ ð m ə b ə l
 fathomable	f æ ð ə m ə b ə l
 fatidical	f ə t ɪ d ɪ k ə l
+fatigue	f ə t iː ɡ
 fatiloquent	f e ɪ t ɪ l ə k w ə n t
 fatless	f æ t l ə s
 fatness	f æ t n ə s
@@ -24113,6 +24390,7 @@ febuary	f ɛ b j u æ ɹ i
 febuary	f ɛ b j u ɛ ə ɹ i
 febuxostat	f ə b ʌ k s ə s t æ t
 fecal	f iː k ə l
+feces	f iː s iː z
 feck	f ɛ k
 feckful	f ɛ k f ə l
 feckless	f ɛ k l ə s
@@ -24147,6 +24425,7 @@ feeler	f iː l ə ɹ
 feelgoodery	f i l ɡ ʊ d ə ɹ i
 feeling	f i l ɪ ŋ
 feelings	f iː l ɪ ŋ z
+feels	f i j ə l z
 feels	f iː l z
 feely	f iː l i
 feeney	f i n i
@@ -24161,11 +24440,12 @@ feigns	f e ɪ n z
 feijoa	f e ɪ d͡ʒ o ʊ ə
 feijoa	f e ɪ h o ʊ ə
 feijoa	f e ɪ ʒ o ʊ ə
-feijoada	f ɛ ɪ ʒ w ɑː d ə
+feijoada	f e ɪ ʒ w ɑː d ə
 feinstein	f a ɪ n s t a ɪ n
 feinstein	f a ɪ n s t iː n
 feint	f e ɪ n t
 feinter	f e ɪ n t ə ɹ
+feirie	f ɪ ə r i
 feis	f ɛ ʃ
 feiseanna	f ɛ ʃ ə n ə
 feist	f a ɪ s t
@@ -24194,6 +24474,7 @@ felly	f ɛ l i
 felly	f ɛ l l i
 felon	f ɛ l ə n
 felony	f ɛ l ə n i
+feloprentan	f ɛ l ə p ɹ ɛ n t æ n
 felt	f ɛ l t
 felter	f ɛ l t ə ɹ
 feltham	f ɛ l t ə m
@@ -24294,6 +24575,7 @@ fermium	f ɜː ɹ m i ə m
 fern	f ɝ n
 fern	f ɝː n
 fernandez	f ɚ n æ n d ɛ z
+fernando	f ɝ n æ n d o ʊ
 fernet	f ə ɹ n ɛ t
 ferocious	f ə ɹ ə ʊ ʃ ə s
 ferocity	f ə ɹ ɑ s ɪ t i
@@ -24418,6 +24700,8 @@ fibrillate	f ʌ ɪ b r ɪ l e ɪ t
 fibrillogenic	f ɪ b ɹ ɪ l ə ʊ d͡ʒ ɛ n ɪ k
 fibrillose	f ɪ b ɹ ɪ l ə ʊ s
 fibrin	f a ɪ b ɹ ɪ n
+fibrine	f a ɪ b ɹ ɪ n
+fibrocollagenous	f a ɪ b ɹ o ʊ k ə l æ d͡ʒ ɪ n ə s
 fibrosis	f a ɪ b ɹ o ʊ s ɪ s
 fibrous	f a ɪ b ɹ ə s
 fibula	f ɪ b j ə l ə
@@ -24485,7 +24769,7 @@ fifeshire	f a ɪ f ʃ ə ɹ
 fifeshire	f a ɪ f ʃ ɪ ə ɹ
 fifi	f i f i
 fifo	f a ɪ f o ʊ
-fifteenth	f ɪ f t iː n θ
+fifteenth	h ɪ f t iː n θ
 fifth	f ɪ f t
 fifth	f ɪ f θ
 fifth	f ɪ θ
@@ -24596,12 +24880,16 @@ fimbriated	f ɪ m b ɹ i e ɪ t ɪ d
 fin	f ɪ n
 finagle	f ɪ n e ɪ ɡ ə l
 final	f a ɪ n ə l
+finale	f ɪ n æ l i
+finale	f ɪ n ɑ l i
 finalize	f a ɪ n ə l a ɪ z
 finally	f a ɪ n l i
 finally	f a ɪ n ə l i
 finals	f a ɪ n ə l z
 finance	f a ɪ n æ n s
 finance	f ɪ n æ n s
+finances	f a ɪ n æ n s ɪ z
+finances	f ɪ n æ n s ɪ z
 financial	f a ɪ n æ n ʃ ə l
 financial	f ɪ n æ n ʃ ə l
 financier	f a ɪ n æ n s ɪ ə ɹ
@@ -24744,6 +25032,7 @@ fissure	f ɪ ʃ ɚ
 fissure	f ɪ ʒ ɚ
 fist	f ɪ s t
 fisted	f ɪ s t ɪ d
+fister	f ɪ s t ɚ
 fistfight	f ɪ s t f a ɪ t
 fistful	f ɪ s t f ʊ l
 fistiana	f ɪ s t ɪ e ɪ n ə
@@ -24807,7 +25096,6 @@ flabby	f l æ b i
 flabellate	f l ə b ɛ l ə t
 flabellum	f l ə b ɛ l ə m
 flaccid	f l æ k s ɪ d
-flaccid	f l æ s ɪ d
 flaccider	f l æ s ɪ d ɚ
 flack	f l æ k
 flacon	f l æ k ɒ n
@@ -24949,6 +25237,7 @@ flecking	f l ɛ k ɪ ŋ
 fleckings	f l ɛ k ɪ ŋ z
 flecks	f l ɛ k s
 flecky	f l ɛ k i
+flector	f l ɛ k t ə ɹ
 fled	f l ɛ d
 fledge	f l ɛ d͡ʒ
 fledged	f l ɛ d͡ʒ d
@@ -25059,6 +25348,7 @@ floccinaucinihilipilification	f l ɒ k s i n ɒ s i n ɪ h ɪ l ɪ p ɪ l ɪ f �
 floccinaucinihilipilification	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə n
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɒ s ɪ n ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
 floccinaucinihilipilificatious	f l ɒ k s ɪ n ɔː s ɪ n a ɪ h ɪ l ɪ p ɪ l ɪ f ɪ k e ɪ ʃ ə s
+flocculent	f l ɑ k j ə l ə n t
 flock	f l ɑ k
 flocks	f l ɔ k s
 flog	f l ɑ ɡ
@@ -25140,6 +25430,7 @@ flowering	f l a ʊ ə ɹ ɪ ŋ
 flowerpot	f l a ʊ ɚ p ɑ t
 flowers	f l a ʊ ɚ z
 flowing	f l o ʊ ɪ ŋ
+flowk	f l a ʊ k
 flown	f l o ʊ n
 flowrate	f l o ʊ ɹ e ɪ t
 flows	f l o ʊ z
@@ -25193,6 +25484,7 @@ fluorapatite	f l ʊ ə ɹ æ p ə t a ɪ t
 fluorate	f l o ɹ e ɪ t
 fluorate	f l ʊ ə ɹ e ɪ t
 fluorescence	f l ʊ ɹ ɛ s ə n s
+fluorescent	f l ɔ ɹ ɛ s ə n t
 fluorescently	f l o ʊ ɹ ɛ s ə n t l i
 fluoride	f l ɔ ɹ a ɪ d
 fluoride	f l ʊ ɚ a ɪ d
@@ -25349,6 +25641,7 @@ foodstuff	f uː d s t ʌ f
 foofaraw	f u f ə ɹ ɔ
 foofooraw	f uː f ə ɹ ɔː
 fook	f uː k
+fook	f ʊ k
 fool	f uː l
 fooled	f uː l d
 fooler	f uː l ə ɹ
@@ -25413,9 +25706,9 @@ forbear	f ɔ ɹ b ɛ ɚ
 forbearance	f ɔ ɹ b ɛ ɹ ə n t s
 forbes	f ɔ ɹ b z
 forbid	f ɚ b ɪ d
-forbidden	f ɝ b ɪ d ə n
+forbidden	f ɚ b ɪ d n̩
 forbidding	f ɚ b ɪ d ɪ ŋ
-force	f o ɹ s
+force	f ɔ ɹ s
 forced	f ɔ ɹ s t
 forceful	f ɔ ɹ s f ə l
 forcefulness	f ɔː ɹ s f ə l n ə s
@@ -25562,6 +25855,7 @@ formulae	f ɔː ɹ m j ə l e ɪ
 formulae	f ɔː ɹ m j ə l i
 formulaic	f ɔ ɹ m j ə l e ɪ ɪ k
 formulaicity	f ɔ ɹ m j ə l e ɪ ɪ s ə t iː
+formulary	f ɔː ɹ m j ʊ l ə ɹ i
 formulate	f ɔː ɹ m j ʊ l e ɪ t
 formule	f ɔː ɹ m j uː l
 fornicate	f ɔ ɹ n ɪ k e ɪ t
@@ -25623,11 +25917,11 @@ fortunate	f ɔ ɹ t͡ʃ n ɪ t
 fortunate	f ɔ ɹ t͡ʃ ə n ə t
 fortunate	f ɔ ɹ t͡ʃ ə n ɪ t
 fortunately	f ɔ ɹ t͡ʃ ə n ɪ t l i
-fortune	f ɔ ɹ t͡ʃ u n
+fortune	f o ɹ t͡ʃ u n
 fortune	f ɔ ɹ t͡ʃ ə n
 forty	f ɔ ɹ t i
 fortyish	f ɔː ɹ t i ɪ ʃ
-forum	f o ɹ ə m
+forum	f ɔ ɹ ə m
 forward	f o ʊ w ɚ d
 forward	f ɔ ɹ w ɚ d
 forward	f ɔ ɹ ɚ d
@@ -25640,7 +25934,10 @@ foscarnet	f ɑ s k ɑ ɹ n ɪ t
 fosphenytoin	f ɑ s f ə n ɪ t o ʊ ɪ n
 foss	f ɑ s
 foss	f ɔ s
+fossa	f uː s ə
 fossa	f ɑ s ə
+fossa	f ɔ s ə
+fossa	f ʊ s ə
 fossae	f ɑ s i
 fosse	f ɑ s
 fosse	f ɔ s
@@ -25734,6 +26031,7 @@ fragor	f ɹ e ɪ ɡ ə ɹ
 fragrance	f ɹ e ɪ ɡ ɹ ə n s
 fragrant	f ɹ e ɪ ɡ ɹ ə n t
 fraidy	f ɹ e ɪ d i
+fraight	f ɹ e ɪ t
 frail	f ɹ e ɪ l
 frain	f ɹ e ɪ n
 fraischeur	f ɹ e ɪ ʃ ə ɹ
@@ -26139,6 +26437,7 @@ fubar	f uː b ɑː ɹ
 fubbery	f ʌ b ə ɹ i
 fubble	f ʌ b ə l
 fubu	f u b ʊ
+fuchien	f uː t ʃ i ɛ n
 fuchs	f j uː k s
 fuchsia	f j uː ʃ ə
 fuchsine	f j u k s i n
@@ -26178,6 +26477,7 @@ fuel	f j ʊ ə l
 fuero	f w ɛ ə ɹ ə ʊ
 fufufu	f uː f uː f uː
 fug	f ʌ ɡ
+fuga	f j uː ɡ ə
 fugacious	f j uː ɡ e ɪ ʃ ə s
 fugazi	f u ɡ ɑ z i
 fugged	f ʌ ɡ d
@@ -26256,11 +26556,13 @@ fumble	f ʌ m b ə l
 fumed	f j uː m d
 fumer	f j uː m ə ɹ
 fumes	f j uː m z
+fumfer	f ə m f ə r
 fumigate	f j uː m ɪ ɡ e ɪ t
 fumigation	f j uː m ɪ ɡ e ɪ ʃ ə n
 fuming	f j uː m ɪ ŋ
 fumings	f j uː m ɪ ŋ z
 fun	f ʌ n
+funafuti	f uː n ə f uː t i
 funalicious	f ʌ n ə l ɪ ʃ ə s
 funambulate	f j ʊ n æ m b j ʊ l e ɪ t
 funambulist	f j uː n æ m b j ʊ l ɪ s t
@@ -26284,6 +26586,7 @@ fundraiser	f ʌ n d ɹ e ɪ z ɚ
 fundraising	f ʌ n d ɹ e ɪ z ɪ ŋ
 funds	f ʌ n d z
 funemployed	f ʌ n ɪ m p l ɔ ɪ d
+funen	f j uː n ə n
 funeral	f j u n ə ɹ ə l
 funerary	f j uː n ə ɹ ə ɹ i
 funerial	f j uː n ɪ ə ɹ i ə l
@@ -26354,6 +26657,7 @@ fursona	f ɝ s o ʊ n ə
 fursuiter	f ɝ s u t ɚ
 further	f ɝ ð ɚ
 furtherance	f ɚ ð ə ɹ ə n t s
+furthermore	f ɝ ð ɚ m ɔ ɹ
 furthest	f ɜː ɹ ð ɪ s t
 furtive	f ɝ t ɪ v
 furuncle	f j ʊ ɹ ʌ ŋ k ə l
@@ -26458,8 +26762,9 @@ gabby	ɡ æ b i
 gabe	ɡ e ɪ b
 gabel	ɡ e ɪ b ə l
 gabfest	ɡ æ b f ɛ s t
-gabion	ɡ e ɪ b ɪ ə n
+gabion	ɡ e ɪ b i ə n
 gable	ɡ e ɪ b ə l
+gablet	ɡ e ɪ b l ə t
 gabon	ɡ ə b ɒ n
 gabriel	ɡ e ɪ b ɹ i ə l
 gabriella	ɡ æ b ɹ i ɛ l ə
@@ -26488,6 +26793,7 @@ gadolinium	ɡ æ d ə l ɪ n i ə m
 gadroon	ɡ ə d ɹ uː n
 gadrooned	ɡ ə d ɹ uː n d
 gadsbud	ɡ æ d z b ʌ d
+gadus	ɡ e ɪ d ə s
 gadzooks	ɡ æ d z uː k s
 gaea	d͡ʒ iː ə
 gaea	ɡ a ɪ ə
@@ -26541,6 +26847,7 @@ gaiting	ɡ e ɪ t ɪ ŋ
 gaits	ɡ e ɪ t s
 gaiwan	ɡ a ɪ w ɑː n
 gaja	ɡ ɑː d͡ʒ ə
+gak	ɡ æ k
 gal	ɡ æ l
 gala	ɡ e ɪ l ə
 gala	ɡ æ l ə
@@ -26570,6 +26877,7 @@ galicia	ɡ ə l ɪ s i ə
 galicia	ɡ ə l ɪ ʃ ə
 galician	ɡ ə l ɪ s i ə n
 galician	ɡ ə l ɪ ʃ ə n
+galileo	ɡ æ l ɪ l e ɪ ə ʊ
 galimatias	ɡ æ l ə m e ɪ ʃ i ə s
 galingale	ɡ æ l ɪ ŋ ɡ e ɪ l
 gall	ɡ ɔː l
@@ -26617,7 +26925,7 @@ galvanic	ɡ æ l v æ n ɪ k
 galvanism	ɡ æ l v ə n ɪ z ə m
 galvanize	ɡ æ l v ə n a ɪ̯ z
 galvanometer	ɡ æ l v ə n ɑ m ə t ɚ
-galveston	ɡ æ l v ə s t ə n
+galveston	ɡ æ l v ɪ s t ə n
 galway	ɡ ɔ l w e ɪ
 galwegian	ɡ ɔ l w i d͡ʒ ə n
 galyak	ɡ æ l j æ k
@@ -26627,7 +26935,9 @@ gamahuche	ɡ æ m ə h uː ʃ
 gamaliel	ɡ æ m ə l iː ə l
 gamb	ɡ æ m b
 gambell	ɡ æ m b ə l
+gambeson	ɡ æ m b ɪ s ə n
 gambia	ɡ æ m b i ə
+gambison	ɡ æ m b ɪ s ə n
 gambit	ɡ æ m b ɪ t
 gamble	ɡ æ m b ə l
 gambling	ɡ æ m b l ɪ ŋ
@@ -26687,6 +26997,7 @@ gangsteress	ɡ æ ŋ s t ə ɹ ɛ s
 gangue	ɡ æ ŋ
 ganguro	ɡ ɑː n ɡ u ɹ ə ʊ
 ganister	ɡ æ n ɪ s t ə ɹ
+ganj	ɡ æ n d ʒ
 ganja	ɡ ɑ n d͡ʒ ə
 ganjapreneur	ɡ æ n d͡ʒ ə p ɹ ə n ɜː ɹ
 ganjapreneur	ɡ ɑ n d͡ʒ ə p ɹ ə n ɜː ɹ
@@ -26711,7 +27022,7 @@ gapper	ɡ æ p ə ɹ
 gapping	ɡ æ p ɪ ŋ
 gaps	ɡ æ p s
 gar	ɡ ɑ ɹ
-garage	ɡ ə ɹ ɑ d͡ʒ
+garage	ɡ ə ɹ ɑ d ʒ
 garb	ɡ ɑː ɹ b
 garbage	ɡ ɑ ɹ b ɑː ʒ
 garbage	ɡ ɑ ɹ b ɪ d͡ʒ
@@ -26776,11 +27087,13 @@ garw	ɡ æ ɹ u
 garçon	ɡ ɑː ɹ s ɒ n
 garçonnière	ɡ ɑ ɹ s ə n j ɛ ɚ
 gas	ɡ æ s
+gas	ɡ æ z
 gasahol	ɡ æ s ə h ɑ l
 gasbag	ɡ æ s b æ ɡ
 gascon	ɡ æ s k ə n
 gaseous	ɡ æ ʃ ə s
 gases	ɡ æ s ɪ z
+gases	ɡ æ z ɪ z
 gash	ɡ æ ʃ
 gasket	ɡ æ s k ɪ t
 gaskin	ɡ æ s k ɪ n
@@ -26789,7 +27102,7 @@ gaslight	ɡ æ s l a ɪ t
 gasohol	ɡ æ s ə h ɑ l
 gasoline	ɡ æ s l i n
 gasoline	ɡ æ s l̩ i n
-gasoline	ɡ æ s ə l i n
+gasoline	ɡ æ s ə l iː n
 gasometer	ɡ æ s ɑ m ɪ t ɚ
 gasp	ɡ æ s p
 gasped	ɡ æ s p t
@@ -26821,9 +27134,10 @@ gateshead	ɡ e ɪ t s h ɛ d
 gateway	ɡ e ɪ t w e ɪ
 gather	ɡ æ ð ɚ
 gathered	ɡ æ ð ɚ d
-gathering	ɡ æ ð ə ɹ ɪ ŋ
+gathering	ɡ æ ð ɚ ɪ ŋ
 gatifloxacin	ɡ æ t ɪ f l ɑ k s ə s ɪ n
 gator	ɡ e ɪ t ə ɹ
+gatorade	ɡ e ɪ t ə ɹ e ɪ d
 gau	ɡ a ʊ
 gauche	ɡ a ʊ ʃ
 gauche	ɡ o ʊ ʃ
@@ -26865,6 +27179,7 @@ gaw	ɡ ɔː
 gawa	ɡ a w a
 gawain	ɡ ɑː w e ɪ n
 gawain	ɡ ə w e ɪ n
+gawber	ɡ ɔː b ə ɹ
 gawd	ɡ ɔː d
 gawf	ɡ ɔː f
 gawk	ɡ ɔː k
@@ -26894,6 +27209,7 @@ gazehound	ɡ e ɪ z h a ʊ n d
 gazella	ɡ ə z ɛ l ə
 gazelle	ɡ ə z ɛ l
 gazes	ɡ e ɪ z ə z
+gazes	ɡ e ɪ z ɪ z
 gazette	ɡ ə z ɛ t
 gazillion	ɡ ə z ɪ l j ə n
 gazing	ɡ e ɪ z ɪ ŋ
@@ -27000,12 +27316,12 @@ gendersex	d͡ʒ ɛ n d ɚ s ɛ k s
 gene	d͡ʒ iː n
 genealogy	d͡ʒ i n i æ l ə d ʒ i
 genealogy	d͡ʒ i n i ɑ l ə d ʒ i
+genearch	d ʒ iː n i ɑː ɹ k
 genera	d͡ʒ ɛ n ə ɹ ə
 general	d͡ʒ ɛ n ə ɹ ə l
 general	d͡ʒ ɛ n ɹ ə l
 generalia	d͡ʒ ɛ n ə ɹ e ɪ l i ə
-generalissimo	d͡ʒ ɛ n ə ɹ ə l iː s ɪ m ə ʊ
-generalissimo	d͡ʒ ɛ n ə ɹ ə l ɪ s ɪ m ə ʊ
+generalissimo	d͡ʒ ɛ n ə ɹ ə l i s i m o ʊ
 generally	d͡ʒ ɛ n ɚ l i
 generally	d͡ʒ ɛ n ɚ ə l i
 generals	d͡ʒ ɛ n ə ɹ ə l z
@@ -27152,6 +27468,7 @@ georgie	d͡ʒ ɔ ɹ d͡ʒ i
 geoscientist	d͡ʒ i o ʊ s a ɪ ə n t ɪ s t
 geosmin	d͡ʒ i ɑ z m ɪ n
 geospace	d͡ʒ iː ə ʊ s p e ɪ s
+geospeedometry	d ʒ iː ə ʊ s p iː d ɒ m ɪ t ɹ i
 geosphere	d͡ʒ iː ə s f ɪ ə ɹ
 geosphere	d͡ʒ iː ə ʊ s f ɪ ə ɹ
 geostrophic	d͡ʒ ɪ ə s t ɹ o ʊ f ɪ k
@@ -27164,6 +27481,7 @@ geppetto	d͡ʒ ə p ɛ t o ʊ
 ger	ɡ ɛ ə ɹ
 geraint	ɡ ɛ ɹ a ɪ n t
 gerald	d͡ʒ ɛ ɹ ə l d
+geranium	d ʒ ə ɹ e ɪ n i ə m
 geranylgeranylacetone	d͡ʒ ɛ ɹ ə n ɪ l d͡ʒ ɛ ɹ ə n ɪ l æ s ɪ t ə ʊ n
 gerard	d͡ʒ ə ɹ ɑ ɹ d
 gerbe	d͡ʒ ɜː ɹ b
@@ -27180,6 +27498,7 @@ germanize	d͡ʒ ɝ m ə n a ɪ z
 germans	d͡ʒ ɝ m ə n z
 germany	d͡ʒ ɝ m ə n i
 germen	d͡ʒ ɝ m ə n
+germinal	d ʒ ɜː ɹ m ɪ n ə l
 germinal	d͡ʒ ɝ m ə n ə l
 germinate	d͡ʒ ɜː ɹ m ɪ n e ɪ t
 gern	ɡ ɜː ɹ n
@@ -27194,6 +27513,7 @@ gershon	ɡ ɝ ʃ ɑ n
 gersum	ɡ ɝ s ə m
 gertrude	ɡ ɝ t ɹ u d
 gerund	d͡ʒ ɛ ɹ ə n d
+gerygone	d͡ʒ ə ɹ ɪ ɡ ə n ɪ
 gesellschaft	ɡ ə z ɛ l ʃ a f t
 gesso	d͡ʒ ɛ s ə ʊ
 gest	d͡ʒ ɛ s t
@@ -27251,6 +27571,7 @@ gherao	ɡ ɛ ɹ a ʊ
 gherkin	ɡ ɝ k ɪ n
 ghetto	ɡ ɛ t o ʊ
 ghettoize	ɡ ɛ t o ʊ a ɪ z
+ghey	d ʒ a ɪ
 ghibelline	ɡ ɪ b ə l a ɪ n
 ghibelline	ɡ ɪ b ə l i n
 ghibelline	ɡ ɪ b ə l ə n
@@ -27399,6 +27720,7 @@ gingerol	d͡ʒ ɪ n d͡ʒ ə ɹ ɒ l
 gingham	ɡ ɪ ŋ ə m
 gingiva	d͡ʒ ɪ n d͡ʒ a ɪ v ə
 gingiva	d͡ʒ ɪ n d͡ʒ ɪ v ə
+gingival	d͡ʒ ɪ n d͡ʒ ɪ v ə l
 gingivitis	d͡ʒ ɪ n d͡ʒ ɪ v a ɪ t ə s
 gingras	d͡ʒ i ŋ ɡ ɹ ə s
 gink	ɡ ɪ ŋ k
@@ -27430,16 +27752,20 @@ girlcott	ɡ ɚ l k ɒ t
 girlcott	ɡ ɚ ə l k ɔ t
 girldick	ɡ ɚ l d ɪ k
 girldick	ɡ ɚ ə l d ɪ k
+girlf	ɡ ɝ l f
 girlfriend	ɡ ɝ l f ɹ ɛ n d
 girlish	ɡ ɚ l ɪ ʃ
 girls	ɡ ɝ l z
 girly	ɡ ɝ l i
+girlypop	ɡ ɚ l i p ɑ p
 girona	d͡ʒ ɪ ɹ o ʊ n ə
 gironde	d͡ʒ ɪ ɹ ɑ n d
 girt	ɡ ɝ t
 girth	ɡ ɝ θ
 girus	d͡ʒ a ɪ ɹ ə s
 gisborne	ɡ ɪ z b ɚ n
+giselle	d ʒ ɪ z ɛ l
+giselle	ʒ ɪ z ɛ l
 gismu	ɡ iː s m uː
 gist	d͡ʒ ɪ s t
 git	ɡ ɪ t
@@ -27505,7 +27831,7 @@ gland	ɡ l æ n d
 glands	ɡ l æ n d z
 glandular	ɡ l æ n d͡ʒ ə l ɚ
 glans	ɡ l æ n z
-glare	ɡ l ɛ ə ɹ
+glare	ɡ l ɛ ɚ
 glaring	ɡ l ɛ ɹ ɪ ŋ
 glaringly	ɡ l ɛ ɹ ɪ ŋ l i
 glary	ɡ l ɛ ə ɹ i
@@ -27628,6 +27954,7 @@ globster	ɡ l ɑ b s t ɚ
 globular	ɡ l ɑ b j ə l ɚ
 globule	ɡ l ɑ b j u l
 globulin	ɡ l ɑ b j ə l ɪ n
+globus	ɡ l ə ʊ b ə s
 globy	ɡ l ə ʊ b i
 glockenspiel	ɡ l ɑ k ə n ʃ p i l
 glode	ɡ l ə ʊ d
@@ -27665,6 +27992,8 @@ glossary	ɡ l ɒ s ə ɹ i
 glossitis	ɡ l ɒ s a ɪ t ɪ s
 glossolalia	ɡ l ɑ s ə l e ɪ l i ə
 glossology	ɡ l ɔ s ɑ l ə d͡ʒ i
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t a ɪ n
+glossopalatine	ɡ l ɒ s ə ʊ p æ l ə t ɪ n
 glossopharyngeal	ɡ l ɑ s o ʊ f ə ɹ ɪ n d͡ʒ i ə l
 glossopharyngeal	ɡ l ɑ s o ʊ f ə ɹ ɪ n d͡ʒ ə l
 glossopharyngeal	ɡ l ɑ s o ʊ f ɛ ɹ ə n d͡ʒ i ə l
@@ -27904,7 +28233,7 @@ gonad	ɡ ə ʊ n æ d
 gondolet	ɡ ɒ n d ə l ɛ t
 gondolier	ɡ ɑ n d ə l ɪ ɹ
 gondwana	ɡ ɑ n d w ɑ n ə
-gone	ɡ ɔː n
+gone	ɡ ɔ n
 goner	ɡ ɔː n ɚ
 gonfalon	ɡ ɑː n f ə l ɑː n
 gong	ɡ ɑ ŋ
@@ -27969,7 +28298,6 @@ goop	ɡ uː p
 goopy	ɡ uː p i
 goos	ɡ uː s
 goos	ɡ uː z
-goose	ɡ uː s
 gooseberry	ɡ u s b ɛ ɹ i
 goosefoot	ɡ uː s f ʊ t
 goosish	ɡ uː s ɪ ʃ
@@ -27991,8 +28319,10 @@ gorgeous	ɡ ɔ ɹ d͡ʒ ə s
 gorgeret	ɡ ɔ ɹ d͡ʒ ə ɹ ɛ t
 gorgerette	ɡ ɔ ɹ d͡ʒ ə ɹ ɛ t
 gorgerin	ɡ ɔ ɹ d͡ʒ ə ɹ ɪ n
-gorget	ɡ ɔ ɹ d͡ʒ ə t
-gorget	ɡ ɔ ɹ d͡ʒ ɪ t
+gorget	ɡ o ɹ d͡ʒ ə t
+gorget	ɡ o ɹ d͡ʒ ɛ t
+gorget	ɡ o ɹ d͡ʒ ɪ t
+gorget	ɡ o ɹ ʒ e ɪ
 gorgias	ɡ ɔ ɹ d͡ʒ i ə s
 gorgon	ɡ ɔː r ɡ ə n
 gorhen	ɡ ɔː h ɛ n
@@ -28001,7 +28331,7 @@ gork	ɡ ɔː ɹ k
 gorm	ɡ ɔː ɹ m
 gormy	ɡ ɔ ɹ m i
 goropism	ɡ ə ɹ ə ʊ p ɪ z ə m
-gorp	ɡ ɔː ɹ p
+gorp	ɡ ɔ ɹ p
 gorse	ɡ ɔ ɹ s
 gorsedd	ɡ ɔː ɹ s ɛ ð
 gorseddau	ɡ ɔː ɹ s ɛ ð a ɪ
@@ -28013,6 +28343,7 @@ gosewehr	ɡ o ʊ z w ɛ ə ɹ
 gosh	ɡ ɑː ʃ
 gosha	ɡ o ʊ ʃ ə
 goshbustified	ɡ ɒ ʃ b ʌ s t ɪ f a ɪ d
+gosht	ɡ o ʊ ʃ t
 gosling	ɡ ɑ z l ɪ ŋ
 gospel	ɡ ɑ s p ə l
 gosplan	ɡ ɒ s p l æ n
@@ -28077,7 +28408,8 @@ government	ɡ ʌ v ɚ n m ə n t
 governmental	ɡ ʌ v ə n m ɛ n t ə l
 governments	ɡ ʌ v ɚ n m ə n t s
 governor	ɡ ʌ v ə n ə ɹ
-governor	ɡ ʌ v ə ɹ n ə ɹ
+governor	ɡ ʌ v ə n ɚ
+governor	ɡ ʌ v ɚ n ɚ
 governorate	ɡ ʌ v ə ɹ n ə ɹ ə t
 govvy	ɡ ʌ v i
 gow	ɡ a ʊ
@@ -28258,6 +28590,8 @@ grasped	ɡ ɹ æ s p t
 grasping	ɡ ɹ æ s p ɪ ŋ
 grass	ɡ ɹ æ s
 grass	ɡ ɹ ɑː s
+grasshawk	ɡ ɹ æ s h ɔː k
+grasshawk	ɡ ɹ ɑː s h ɔː k
 grasshopper	ɡ ɹ æ s h ɑ p ə ɹ
 grassley	ɡ ɹ æ s l i
 grassley	ɡ ɹ ɑː s l i
@@ -28377,7 +28711,7 @@ greenery	ɡ ɹ iː n ə ɹ i
 greenfield	ɡ ɹ i n f i l d
 greengage	ɡ ɹ iː n ɡ e ɪ d͡ʒ
 greenhouse	ɡ ɹ iː n h a ʊ s
-greeniac	ɡ ɹ i n i æ k
+greeniac	ɡ ɹ iː n i æ k
 greening	ɡ ɹ iː n ɪ ŋ
 greenings	ɡ ɹ iː n ɪ ŋ z
 greenish	ɡ ɹ iː n ɪ ʃ
@@ -28410,6 +28744,7 @@ greeze	ɡ ɹ iː z
 greffier	ɡ ɹ ɛ f i ə ɹ
 greg	ɡ ɹ ɛ ɡ
 gregale	ɡ ɹ e ɪ ɡ ɑː l e ɪ
+gregarious	ɡ ɹ ɪ ɡ ɛ ɹ i ə s
 gregg	ɡ ɹ ɛ ɡ
 gregorian	ɡ ɹ ɪ ɡ ɔː ɹ i ə n
 gregory	ɡ ɹ ɛ ɡ ə ɹ i
@@ -28429,8 +28764,10 @@ greven	ɡ ɹ i v ə n
 greviere	ɡ ɹ ɛ v j ɛ ə ɹ
 grew	ɡ ɹ u ʊ̯
 grew	ɡ ɹ uː
+grex	ɡ ɹ ɛ k s
 grexit	ɡ ɹ ɛ k s ɪ t
 grexit	ɡ ɹ ɛ ɡ z ɪ t
+grey	ɡ ɹ e ɪ
 greyhound	ɡ ɹ e ɪ h a ʊ n d
 greyish	ɡ ɹ e ɪ ɪ ʃ
 greylag	ɡ ɹ e ɪ l æ ɡ
@@ -28440,6 +28777,7 @@ gribenes	ɡ ɹ ɪ b ə n ə s
 grid	ɡ ɹ ɪ d
 gridded	ɡ ɹ ɪ d ɪ d
 gridding	ɡ ɹ ɪ d ɪ ŋ
+griddle	ɡ ɹ ɪ d ə l
 gride	ɡ ɹ a ɪ d
 griding	ɡ ɹ a ɪ d ɪ ŋ
 gridlock	ɡ ɹ ɪ d l ɑ k
@@ -28462,6 +28800,7 @@ griff	ɡ ɹ ɪ f
 griffe	ɡ ɹ ɪ f
 griffin	ɡ ɹ ɪ f ɪ n
 griffith	ɡ ɹ ɪ f ɪ θ
+griffon	ɡ ɹ ɪ f ə n
 grift	ɡ ɹ ɪ f t
 grifter	ɡ ɹ ɪ f t ɚ
 grifting	ɡ ɹ ɪ f t ɪ ŋ
@@ -28469,6 +28808,7 @@ grig	ɡ ɹ ɪ ɡ
 grike	ɡ ɹ a ɪ k
 grill	ɡ ɹ ɪ l
 grillade	ɡ ɹ i j ɑː d
+grillade	ɡ ɹ ɪ l ɑː d
 grillbilly	ɡ ɹ ɪ l b ɪ l i
 grille	ɡ ɹ ɪ l
 grilled	ɡ ɹ ɪ l d
@@ -28647,6 +28987,7 @@ gruel	ɡ ɹ uː ə l
 gruelling	ɡ ɹ u l ɪ ŋ
 gruelling	ɡ ɹ u ə l ɪ ŋ
 grues	ɡ ɹ uː z
+gruesome	ɡ ɹ uː s ʌ m
 gruff	ɡ ɹ ʌ f
 gruffish	ɡ ɹ ʌ f ɪ ʃ
 gruit	ɡ ɹ a ɪ t
@@ -28696,6 +29037,7 @@ guadeloupe	ɡ w ɑ d ə l ʊ p
 guadeloupe	ɡ w ɑː d ə l uː p
 guadiana	ɡ w ɑ d i ɑ n ə
 guadiana	ɡ w ɑ d j ɑ n ə
+guaifenesin	ɡ w a ɪ f ɛ n ɪ s ɪ n
 guam	ɡ w ɑ m
 guamanian	ɡ w ɑː m e ɪ n i ə n
 guamanian	ɡ w ɑː m e ɪ n j ə n
@@ -28712,6 +29054,7 @@ guanines	ɡ w ɑː n iː n z
 guano	ɡ w ɑː n ə ʊ
 guanxi	k w a n ʃ i
 guanxi	ɡ w a n ʃ i
+guanylate	ɡ w ɑː n ɪ l e ɪ t
 guarana	ɡ w ə ɹ ɑː n ə
 guaranine	ɡ w ɑː ɹ ə n iː n
 guarantee	ɡ ɛ ə ɹ ə n t iː
@@ -28759,6 +29102,7 @@ guffaw	ɡ ə f ɔ
 guhr	ɡ ʊ ə ɹ
 gui	d ʒ iː j uː a ɪ
 gui	ɡ uː i
+guiana	ɡ i æ n ə
 guiche	ɡ iː ʃ
 guidance	ɡ a ɪ d ə n s
 guide	ɡ a ɪ d
@@ -28860,6 +29204,7 @@ gulpings	ɡ ʌ l p ɪ ŋ z
 gulps	ɡ ʌ l p s
 guly	ɡ j u l i
 gum	ɡ ʌ m
+gumbo	ɡ ʌ m b o ʊ
 gumdrop	ɡ ʌ m d ɹ ɑː p
 gummed	ɡ ʌ m d
 gumming	ɡ ʌ m ɪ ŋ
@@ -28869,6 +29214,7 @@ gumption	ɡ ʌ m p ʃ ə n
 gums	ɡ ʌ m z
 gumshoe	ɡ ʌ m ʃ uː
 gun	ɡ ʌ n
+guna	ɡ ʊ n ə
 gunai	ɡ ʌ n a ɪ
 gunate	ɡ u n e ɪ t
 gundelet	ɡ ʌ n d ə l ə t
@@ -28926,6 +29272,7 @@ gusle	ɡ ʊ s l ə
 gusset	ɡ ʌ s ɪ t
 gust	ɡ ʌ s t
 gustable	ɡ ʌ s t ə b ə l
+gustatory	ɡ ʌ s t ə t ɔ ɹ i
 gustavia	ɡ ʊ s t æ v i ə
 gusted	ɡ ʌ s t ɪ d
 gustfulness	ɡ ʌ s t f ə l n ə s
@@ -28958,6 +29305,7 @@ guys	ɡ a ɪ z
 guyu	ɡ uː j uː
 guyver	ɡ a ɪ v ə
 guz	ɡ ʌ z
+guze	ɡ j uː z
 guzheng	ɡ uː d͡ʒ ʌ ŋ
 guzman	ɡ u z m ɑ n
 guzzle	ɡ ʌ z ə l
@@ -28970,6 +29318,8 @@ gwyneth	ɡ w ɪ n e θ
 gwyneth	ɡ w ɪ n ə θ
 gwyneth	ɡ w ɪ n ɪ θ
 gwyniad	ɡ w ɪ n iː ɑː ɹ d
+gyaru	ɡ j æ ɹ uː
+gyaru	ɡ j ɑː ɹ uː
 gybe	d͡ʒ a ɪ b
 gylany	ɡ ɪ l ə n i
 gyle	ɡ a ɪ l
@@ -29151,7 +29501,7 @@ hagging	h æ ɡ ɪ ŋ
 haggis	h æ ɡ ɪ s
 haggis	h ɑ d͡ʒ i s
 haggle	h æ ɡ ə l
-hagiographer	h e ɪ d͡ʒ i ɑ ɡ ɹ ə f ə ɹ
+hagiographer	h æ ɡ i ɑ ɡ ɹ ə f ɚ
 hagiographic	h æ ɡ i o ʊ ɡ ɹ æ f ɪ k
 hagiography	h e ɪ d͡ʒ i ɒ ɡ ɹ ə f i
 hagiography	h æ ɡ i ɒ ɡ ɹ ə f i
@@ -29180,13 +29530,11 @@ hainan	h a ɪ n ɑː n
 haines	h e ɪ n z
 haint	h e ɪ n t
 haiphong	h a ɪ f ɒ ŋ
-hair	h ɛ ə
 hair	h ɛ ə ɹ
-hair	h ɛ ɚ
-hair	h ɛː
 hairbow	h ɛ ə ɹ b ə ʊ
 haircolor	h ɛ ə k ʌ l ɚ
 haircolor	h ɛ ɚ k ʌ l ɚ
+haircut	h ɛ ə ɹ k ʌ t
 hairdo	h ɛ ə d uː
 hairen	h ɛ ə ɹ ə n
 hairline	h ɛ ɹ l a ɪ n
@@ -29235,6 +29583,8 @@ halfness	h æ f n ə s
 halfpence	h e ɪ p ə n s
 halfpenny	h e ɪ p ə n i
 halfway	h æ f w e ɪ
+halibut	h æ l ɪ b ə t
+halibut	h ɒ l ɪ b ə t
 halicarnassus	h æ l ɪ k ɑ ɹ n æ s ə s
 halicore	h ə l ɪ k ə ɹ iː
 halide	h e ɪ l a ɪ d
@@ -29249,7 +29599,7 @@ hall	h ɔ l
 hallage	h ɔː l ɪ d͡ʒ
 hallatrow	h æ l ə t ɹ ə ʊ
 hallecret	h æ l ɪ k r ɛ t
-hallelujah	h æ l ɪ l j uː j ə
+hallelujah	h æ l ə l j uː j ə
 hallewell	h æ l ɪ w ɛ l
 halley	h æ l i
 hallmark	h ɔ l m ɑ ɹ k
@@ -29339,6 +29689,7 @@ hamsa	h æ m s ə
 hamsa	h ɑ m s ə
 hamster	h æ m p s t ɚ
 hamstring	h æ m s t ɹ ɪ ŋ
+hamtramck	h æ m t r æ m ɪ k
 hamulose	h æ m j ʊ l ə ʊ z
 han	h e ɪ n
 han	h æ n
@@ -29371,6 +29722,7 @@ handiwork	h æ n d i w ɝ k
 handkerchief	h e ɪ ŋ k ɚ t͡ʃ ɪ f
 handkerchief	h æ ŋ k ɚ t͡ʃ ɪ f
 handle	h æ n d l̩
+handle	h ɛ ə n d l̩
 handlebar	h æ n d ə l b ɑː ɹ
 handled	h æ n d l̩ d
 handler	h æ n d l ɚ
@@ -29477,6 +29829,8 @@ hard	h ɑ ɹ d
 hardcore	h ɑː ɹ d k ɔː ɹ
 harden	h ɑ ɹ d n̩
 hardened	h ɑ ɹ d n̩ d
+hardener	h ɑ ɹ d n̩ ɚ
+hardener	h ɑ ɹ d ə n ɚ
 hardest	h ɑ ɹ d ɪ s t
 hardline	h ɑː ɹ d l a ɪ n
 hardly	h ɑ ɹ d l i
@@ -29488,7 +29842,7 @@ hardwood	h ɑ ɹ d w ʊ d
 hardy	h ɑ ɹ d i
 hare	h ɛ ə
 hare	h ɛ ɚ
-hare	h ɛ ɹ
+hare	h ɛː
 harem	h æ ɹ ə m
 harem	h ɛ ə ɹ ə m
 hares	h e ɹ z
@@ -29529,6 +29883,8 @@ harpist	h ɑ ɹ p ɪ s t
 harpoon	h ɑː ɹ p uː n
 harpsichord	h ɑ ɹ p s ɪ k ɔ ɹ d
 harpy	h ɑ ɹ p i
+harquebus	h ɑ ɹ k w ɪ b ʌ s
+harquebus	h ɑ ɹ k ɪ b ʌ s
 harrage	h æ ɹ ɪ d͡ʒ
 harras	h æ ɹ ə s
 harridan	h æ ɹ ɪ d ə n
@@ -29542,7 +29898,6 @@ harrogate	h æ ɹ ə ɡ ə t
 harrow	h æ ɹ o ʊ
 harrow	h ɛ ɹ o ʊ
 harry	h æ ɹ i
-harry	h ɛ ə ɹ i
 harry	h ɛ ɹ i
 harsh	h ɑ ɹ ʃ
 hart	h ɑ ɹ t
@@ -29582,7 +29937,7 @@ hasn't	h æ z n̩ t
 hasp	h æ s p
 hasp	h ɑː s p
 hassium	h æ s i ə m
-hassle	h æ s l
+hassle	h æ s l̩
 hast	h æ s t
 hasta	h æ s t ə
 hasta	h ʌ s t ə
@@ -29838,6 +30193,7 @@ hebrides	h ɛ b ɹ ə d iː z
 hecate	h ɛ k ə t i
 hecate	h ɛ k ɪ t
 hecatomb	h ɛ k ə t o ʊ m
+hecatonicosachoron	h ɛ k ə t ɔ n a ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hechsher	h ɛ k ʃ ə ɹ
 heck	h ɛ k
 hecka	h ɛ k ə
@@ -29928,6 +30284,7 @@ heliacal	h ɪ l a ɪ ə k ə l
 helianthus	h iː l iː æ n θ ə s
 helical	h iː l ɪ k ə l
 helical	h ɛ l ɪ k ə l
+helicopter	h ɛ l ɪ k ɑ p t ɚ
 heligoland	h ɛ l ɪ ɡ o ʊ l æ n d
 helimagnetic	h ɛ l i m æ ɡ n ɛ t ɪ k
 heling	h iː l ɪ ŋ
@@ -30019,6 +30376,7 @@ hemodynamic	h i m o ʊ d a ɪ n æ m ɪ k
 hemodynamics	h i m o ʊ d a ɪ n æ m ɪ k s
 hemopoietic	h iː m ə p ɔ ɪ ɛ t ɪ k
 hemorrhage	h ɛ m ə ɹ ɪ d͡ʒ
+hemorrhagiparous	h ɛ m ə r ɪ d͡ʒ ɪ p ə r ə s
 hemorrhoid	h ɛ m ə ɹ ɔ ɪ d
 hemorrhoid	h ɛ m ɹ ɔ ɪ d
 hemosiderosis	h iː m ə ʊ s ɪ d ə ɹ ə ʊ s ɪ s
@@ -30043,6 +30401,7 @@ hendecanol	h ɛ n d ɛ k ə n ɒ l
 hendecasyllabic	h ɛ n d ɛ k ə s ɪ l æ b ɪ k
 henderson	h ɛ n d ɚ s ə n
 hendiadys	h ɛ n d a ɪ ə d ɪ s
+hendiatris	h ɛ n d a ɪ ə t ɹ ɪ s
 henge	h ɛ n d͡ʒ
 henna	h ɛ n ə
 hennepin	h ɛ n ɪ p ɪ n
@@ -30083,6 +30442,7 @@ herb	h
 herb	h ɜː ɹ b
 herb	h ɝ b
 herbaceous	h ɝ b e ɪ ʃ ə s
+herbage	h ɚ b ɪ d ʒ
 herbal	ɝ b ə l
 herbary	h ɜː ɹ b ə ɹ i
 herbary	ɜː ɹ b ə ɹ i
@@ -30114,6 +30474,7 @@ hereon	h ɪ ə ɹ ɒ n
 herero	h ɛ r ɛ ə r o ʊ
 heresiarch	h ə ɹ i z i ɑ ɹ k
 heresy	h ɛ ɹ ə s i
+heretic	h ɛ ɹ ɪ t ɪ k
 heretical	h ə ɹ ɛ t ɪ k ə l
 heretofore	h ɪ ɹ t ə f o ɹ
 heretofore	h ɪ ɹ t ə f ɔ ɹ
@@ -30123,6 +30484,7 @@ herkimer	h ɚ k ɪ m ɚ
 herman	h ɝ m ə n
 hermaphrodite	h ɝ m æ f ɹ ə d a ɪ t
 hermaphroditus	h ɚ m æ f ɹ ə d a ɪ t ə s
+hermeneutical	h ɝ m ə n j uː t ɪ k ə l
 hermeneutics	h ɜː ɹ m ə n j uː t ɪ k s
 hermes	h ɝ m iː z
 hermetic	h ə ɹ m ɛ t ɪ k
@@ -30172,6 +30534,7 @@ hertz	h ɝ t s
 herzegovina	h ɛ ə ɹ t s ə ɡ o ʊ v ɪ n ə
 herzegovina	h ɜ ɹ t s ə ɡ o ʊ v iː n ə
 hes	h iː z
+hes	h ɛ s
 hes	h ɛ z
 hesiod	h iː s i ə d
 hesiod	h ɛ s i ə d
@@ -30212,6 +30575,7 @@ heteropathic	h ɛ t ə ɹ ə ʊ p æ θ ɪ k
 heterophenomenological	h ɛ t ə ɹ ə ʊ f ə n ɒ m ɪ n ə l ɒ d͡ʒ ɪ k ə l
 heteroradical	h ɛ t ɜ ɹ ə ɹ æ d ɪ k ə l
 heterorganic	h ɛ t ə ɹ ɔː ɹ ɡ æ n ɪ k
+heteroscedasticity	h ɛ t ə ɹ o ʊ s k ɪ d æ s t ɪ s ɪ t i
 heterosexual	h ɛ t ə ɹ o ʊ s ɛ k ʃ u ə l
 heterosexual	h ɛ t ə ɹ ə s ɛ k ʃ u ə l
 hetfic	h ɛ t f ɪ k
@@ -30233,9 +30597,11 @@ hew	h j uː
 hewed	h j uː d
 hewing	h j uː ɪ ŋ
 hewings	h j uː ɪ ŋ z
+hewitt	h j uː ɪ t
 hewn	h j uː n
 hews	h j uː z
 hex	h ɛ k s
+hexacosichoron	h ɛ k s ə ɪ k o ʊ s ɪ k o ʊ ɹ ɔ n
 hexad	h ɛ k s æ d
 hexadecile	h ɛ k s ə d ɛ s a ɪ l
 hexadecile	h ɛ k s ə d ɛ s ə l
@@ -30340,6 +30706,7 @@ higham	h a ɪ ə m
 higher	h a ɪ ɚ
 higher	h a ɪ ɹ
 highest	h a ɪ ɪ s t
+highfalutin	h a ɪ f ə l u t ɪ n
 highflier	h a ɪ f l a ɪ ə ɹ
 highland	h a ɪ l ə n d
 highland	h a ɪ l ɪ n d
@@ -30439,7 +30806,7 @@ hippyish	h ɪ p i ɪ ʃ
 hips	h ɪ p s
 hipshot	h ɪ p ʃ ɒ t
 hipster	h ɪ p s t ɚ
-hir	h i ɹ
+hir	h ɪ ɹ
 hiragana	h ɪ ɹ ə ɡ æ n ə
 hiragana	h ɪ ɹ ə ɡ ɑː n ə
 hiram	h a ɪ ɹ ə m
@@ -30508,6 +30875,8 @@ hithe	h ʌ ɪ ð
 hither	h ɪ ð ɚ
 hitherto	h ɪ ð ɚ t u
 hitler	h ɪ t l ɚ
+hitman	h ɪ t m æː n
+hitman	h ɪ t m ə n
 hits	h ɪ t s
 hitter	h ɪ t ɚ
 hitting	h ɪ t ɪ ŋ
@@ -30588,6 +30957,7 @@ hogshead	h ɑ ɡ z h ɛ d
 hogwarts	h ɔ ɡ w ɔ ɹ t s
 hogwash	h ɒ ɡ w ɒ ʃ
 hohenzollern	h o ʊ ə n z ɑ l ə ɹ n
+hohhot	h o ʊ h ɒ t
 hoik	h ɔ ɪ k
 hoise	h ɔ ɪ z
 hoisin	h ɔ ɪ s ɪ n
@@ -30702,6 +31072,7 @@ homie	h o ʊ m i
 homiletical	h ɒ m ɪ l ɛ t ɪ k ə l
 homily	h ɑ m ɪ l i
 homing	h o ʊ m ɪ ŋ
+hominy	h ɒ m ɪ n i
 hommage	o ʊ m ɑː ʒ
 hommage	ɒ m ɑː ʒ
 homo	h o ʊ m o ʊ
@@ -30785,6 +31156,7 @@ honeymoon	h ʌ n i m uː n
 honeymooner	h ʌ n i m u n ɚ
 honeys	h ʌ n i z
 honeysuckle	h ʌ n iː s ʌ k ə l
+honfidence	h ʌ n f ɪ d ə n s
 hongbao	h ɔ ŋ b a ʊ
 hongi	h ɒ ŋ i
 hongkong	h ɒ ŋ k ɒ ŋ
@@ -30803,6 +31175,8 @@ honor	ɑ n ɚ
 honorable	ɑ n ə ɹ ə b l̩
 honorable	ɑ n ɹ ə b l̩
 honorarium	ɑ n ə ɹ ɛ ɹ i ə m
+honorary	ɑ n ə r ɛ r i
+honoree	ɑ n ɚ i
 honorific	ɑː n ə ɹ ɪ f ɪ k
 honorificabilitudinitatibus	ɑ n ə ɹ ɪ f ɪ k ə b ɪ l ə t j u d ɪ n ɪ t e ɪ t ɪ b ə s
 honors	ɑ n ɚ z
@@ -30837,6 +31211,7 @@ hoojah	h uː d͡ʒ ə
 hook	h ʊ k
 hookah	h u k ə
 hookah	h ʊ k ə
+hookaroon	h ʊ k ə ɹ uː n
 hooked	h ʊ k t
 hooker	h ʊ k ɚ
 hooking	h ʊ k ɪ ŋ
@@ -30892,6 +31267,7 @@ hopenosis	h ə ʊ p n ə ʊ s ɪ s
 hopes	h o ʊ p s
 hopi	h o ʊ p i
 hoping	h o ʊ p ɪ ŋ
+hopium	h o ʊ p i ə m
 hopkins	h ɑ p k ɪ n z
 hoplite	h ɒ p l a ɪ t
 hopper	h ɑ p ɚ
@@ -30958,8 +31334,8 @@ horsemen	h ɔ r s m ə n
 horsepower	h ɔ ɹ s p a ʊ ɚ
 horseradish	h ɔ ɹ s ɹ æ d ɪ ʃ
 horseradished	h ɔ ɹ s ɹ æ d ɪ ʃ t
-horses	h ɔ r s ə z
-horses	h ɔ r s ɪ z
+horses	h o ɹ s ə z
+horses	h o ɹ s ɪ z
 horseshoe	h ɔː ɹ s ʃ uː
 horseshoe	h ɔː ɹ ʃ uː
 horsetail	h ɔː ɹ s t e ɪ l
@@ -31264,7 +31640,6 @@ humpback	h ʌ m p b æ k
 humped	h ʌ m p t
 humper	h ʌ m p ɚ
 humph	h ə m f
-humph	h ʌ m f
 humphrey	h ʌ m f ɹ i
 humping	h ʌ m p ɪ ŋ
 humpings	h ʌ m p ɪ ŋ z
@@ -31407,7 +31782,7 @@ hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ i ə
 hydrangea	h a ɪ d ɹ e ɪ n d͡ʒ ə
 hydrant	h a ɪ d ɹ ə n t
 hydrargyron	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ɒ n
-hydrargyrum	h a ɪ d ɹ ɑː d͡ʒ ɪ ɹ ə m
+hydrargyrum	h a ɪ d ɹ ɑː ɹ d͡ʒ ɪ ɹ ə m
 hydrate	h a ɪ d ɹ e ɪ t
 hydration	h a ɪ d ɹ e ɪ ʃ ə n
 hydraulic	h a ɪ d ɹ ɔː l ɪ k
@@ -31442,6 +31817,7 @@ hydroponic	h ʌ ɪ d ɹ ə p ɒ n ɪ k
 hydroponics	h a ɪ d ɹ ə p ɑ n ɪ k s
 hydropsy	h a ɪ d ɹ ɑ p s i
 hydroptic	h a ɪ d ɹ ɒ p t ɪ k
+hydroquinone	h a ɪ d ɹ ə k w ɪ n ə ʊ n
 hydrostatic	h a ɪ d ɹ ə ʊ s t æ t ɪ k
 hydrous	h a ɪ d ɹ ə s
 hydrovolcanic	h a ɪ d ɹ o ʊ v ɑ l k æ n ɪ k
@@ -31479,6 +31855,7 @@ hymenopteran	h a ɪ m ə n ɑ p t ə ɹ ə n
 hymie	h a ɪ m i
 hymn	h ɪ m
 hymnal	h ɪ m n ə l
+hymnic	h ɪ m n ɪ k
 hymnody	h ɪ m n ə d i
 hyoglossi	h a ɪ o ʊ ɡ l ɑ s a ɪ
 hyoglossi	h a ɪ o ʊ ɡ l ɔ s a ɪ
@@ -31543,6 +31920,7 @@ hypermyoglobinemia	h a ɪ p ɚ m a ɪ o ʊ ɡ l o ʊ b ɪ n i m i ə
 hypernatremia	h a ɪ p ɚ n ə t ɹ i m i ə
 hypernatremic	h a ɪ p ɚ n ə t ɹ i m ɪ k
 hypernym	h a ɪ p ɚ n ɪ m
+hyperon	h a ɪ p ə ɹ ɒ n
 hyperparasite	h a ɪ p ɚ p æ ɹ ə s a ɪ t
 hyperplasia	h a ɪ p ɚ p l e ɪ ʒ ə
 hyperplasma	h a ɪ p ə ɹ p l æ z m ə
@@ -31565,10 +31943,12 @@ hyphen	h a ɪ f ə n
 hyphenation	h a ɪ f ə n e ɪ ʃ ə n
 hyphy	h a ɪ f iː
 hyping	h a ɪ p ɪ ŋ
+hypnic	h ɪ p n ɪ k
 hypnos	h ɪ p n o ʊ s
 hypnos	h ɪ p n ɒ s
 hypnosis	h ɪ p n o ʊ s ɪ s
 hypnotic	h ɪ p n ɒ t ɪ k
+hypnotism	h ɪ p n ə t ɪ z ə m
 hypnotist	h ɪ p n ə t ɪ s t
 hypnotize	h ɪ p n ə t a ɪ̯ z
 hypo	h a ɪ p o ʊ
@@ -31589,6 +31969,7 @@ hypodorian	h a ɪ p ə ʊ d ɔː ɹ i ə n
 hypoglossal	h a ɪ p ə ɡ l ɑ s ə l
 hypoglossus	h a ɪ p ə ɡ l ɑ s ə s
 hypoglycemic	h a ɪ p ə ʊ ɡ l a ɪ s iː m ɪ k
+hypohalous	h a ɪ p ə ʊ h e ɪ l ə s
 hypolemma	h a ɪ p o ʊ l ɛ m ə
 hyponatremia	h a ɪ p o ʊ n e ɪ t ɹ iː m i ə
 hyponym	h a ɪ p o ʊ n ɪ m
@@ -31616,6 +31997,7 @@ hypotrochoid	h a ɪ p o ʊ t ɹ o ʊ k ɔ ɪ d
 hypotrochoid	h a ɪ p ə t ɹ o ʊ k ɔ ɪ d
 hypsipyle	h ɪ p s ɪ p ɪ l iː
 hypsometry	h ɪ p s ɑ m ə t ɹ i
+hypural	h a ɪ p j ʊ ə ɹ ə l
 hyraceum	h a ɪ r e ɪ s i ə m
 hyrax	h a ɪ ɹ æ k s
 hyssop	h ɪ s ə p
@@ -31711,6 +32093,7 @@ ichnology	ɪ k n ɒ l ə d͡ʒ ɪ
 ichnusaite	ɪ k n u s ə a ɪ t
 ichor	a ɪ k ɔ ɹ
 ichor	ɪ k ə ɹ
+ichthyic	ɪ k θ iː ɪ k
 ichthyology	ɪ k θ i ɒ l ə d͡ʒ i
 ichthyonym	ɪ k θ i ə n ɪ m
 ichthyosaur	ɪ k θ i ə s ɔː ɹ
@@ -31732,6 +32115,7 @@ icosahedra	a ɪ k ɒ s ə h iː d ɹ ə
 icosahedron	a ɪ k o ʊ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɒ s ə h iː d ɹ ə n
 icosahedron	a ɪ k ɔ s ə h iː d ɹ ə n
+icositetrachoron	a ɪ k o ʊ s ɪ t ɛ t ɹ ə k o ʊ ɹ ɔ n
 icq	a ɪ s iː k j uː
 icy	a ɪ s i
 id	a ɪ d iː
@@ -31765,6 +32149,7 @@ ident	a ɪ d ɛ n t
 identic	a ɪ d ɛ n t ɪ k
 identical	a ɪ d ɛ n t ɪ k l̩
 identical	ɪ d ɛ n t ɪ k l̩
+identically	a ɪ d ɛ n t ɪ k ə l i
 identification	a ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identification	ɪ d ɛ n t ɪ f ɪ k e ɪ ʃ ə n
 identified	a ɪ d ɛ n t ɪ f a ɪ d
@@ -31773,6 +32158,8 @@ identify	a ɪ d ɛ n t ɪ f a ɪ
 identify	ɪ d ɛ n t ɪ f a ɪ
 identikit	a ɪ d e n t ə k ɪ t
 identitarian	a ɪ d ɛ n t ɪ t ɛ ə ɹ i ə n
+identity	a ɪ d ɛ n t ə t i
+identity	a ɪ d ɛ n t ɪ t i
 ideocracy	ɪ d i ɑ k ɹ ə s i
 ideocratic	ɪ d i o ʊ k ɹ æ t ɪ k
 ideogram	ɪ d i o ʊ ɡ ɹ æ m
@@ -31816,6 +32203,7 @@ idiotropic	ɪ d i o ʊ t ɹ ɒ p ɪ k
 idiotropic	ɪ d i ə t ɹ o ʊ p ɪ k
 idiots	ɪ d iː ə t s
 idiotype	ɪ d iː o ʊ t a ɪ p
+idjit	ɪ d ʒ ɪ t
 idle	a ɪ d ə l
 idleness	a ɪ d ə l n ə s
 idlesse	a ɪ d l ə s
@@ -31847,6 +32235,7 @@ ifs	ɪ f s
 iftar	ɪ f t ɑː ɹ
 igbo	i b o ʊ
 igbo	i ɡ b o ʊ
+ight	a ɪ t
 igloo	ɪ ɡ l uː
 ignatius	ɪ ɡ n e ɪ ʃ ə s
 igneous	ɪ ɡ n i ə s
@@ -31859,7 +32248,7 @@ ignominy	ɪ ɡ n ɑ m ə n i
 ignominy	ɪ ɡ n ə m ə n i
 ignominy	ɪ ɡ n ə m ɪ n i
 ignoramus	ɪ ɡ n ə ɹ e ɪ m ə s
-ignorance	ɪ ɡ n ə ɹ ə n s
+ignorance	ɪ ɡ n ɚ ə n s
 ignorant	ɪ ɡ n ə ɹ ə n t
 ignoranter	ɪ ɡ n ə ɹ ə n t ə ɹ
 ignore	ɪ ɡ n ɔ ɹ
@@ -31996,6 +32385,7 @@ imhotep	ɪ m h o ʊ t ɛ p
 imidazole	ɪ m ə d æ z o ʊ l
 imidazole	ɪ m ɪ d æ z o ʊ l
 imide	a ɪ m a ɪ d
+imine	ɪ m iː n
 imipramine	ɪ m ɪ p ɹ ə m iː n
 imitate	ɪ m ɪ t e ɪ t
 imitation	ɪ m ɪ t e ɪ ʃ ə n
@@ -32011,6 +32401,7 @@ immaterial	ɪ m ə t ɪ ɹ i ə l
 immature	ɪ m ə t j ʊ ə ɹ
 immature	ɪ m ə t͡ʃ ə ɹ
 immature	ɪ m ə t͡ʃ ʊ ə ɹ
+immaturely	ɪ m ə t j ʊ ə ɹ l i
 immaturity	ɪ m ə t͡ʃ ʊ ɹ ɪ t i
 immeability	ɪ m i ə b ɪ l ɪ t i
 immeasurability	ɪ m ɛ ʒ ə ɹ ə b ɪ l ə t i
@@ -32073,6 +32464,7 @@ impactful	ɪ m p æ k t f ə l
 impaction	ɪ m p æ k ʃ ə n
 impactor	ɪ m p æ k t ɚ
 impair	ɪ m p ɛ ə
+impairment	ɪ m p ɛ ə ɹ m ə n t
 impala	ɪ m p ɑː l ə
 impale	ɪ m p e ɪ l
 impaled	ɪ m p e ɪ l d
@@ -32130,7 +32522,9 @@ impermissible	ɪ m p ɝ m ɪ s ɪ b l
 impersonal	ɪ m p ɝ s ə n ə l
 impersonate	ɪ m p ɜː s ə n e ɪ t
 impertinence	ɪ m p ɝ t n ə n s
+impertinence	ɪ m p ɝ t ɪ n ə n s
 impertinent	ɪ m p ɝ t n ə n t
+impertinent	ɪ m p ɝ t ɪ n ə n t
 imperturbable	ɪ m p ɚ t ɝ b ə b ə l
 impervious	ɪ m p ɝ v i ə s
 impetigo	ɪ m p ə t a ɪ ɡ o ʊ
@@ -32166,7 +32560,8 @@ implicit	ɪ m p l ɪ s ɪ t
 implied	ɪ m p l a ɪ d
 implies	ɪ m p l a ɪ z
 implike	ɪ m p l a ɪ k
-implore	ɪ m p l ɔ ɹ
+implore	ɪ m p l o ɹ
+implosion	ɪ m p l ə ʊ ʒ ə n
 imply	ɪ m p l a ɪ
 impolite	ɪ m p ə l a ɪ t
 imponderable	ɪ m p ɑː n d ə ɹ ə b l
@@ -32538,6 +32933,7 @@ indirection	ɪ n d ɪ ɹ ɛ k ʃ ə n
 indirectly	ɪ n d a ɪ ɹ ɛ k t l i
 indirectly	ɪ n d ɪ ɹ ɛ k t l i
 indiscovery	ɪ n d ɪ s k ʌ v ə ɹ i
+indiscretion	ɪ n d ɪ s k ɹ ɛ ʃ ə n
 indisposition	ɪ n d ɪ s p ə z ɪ ʃ ə n
 indisputable	ɪ n d ɪ s p j u t ə b ə ɫ
 indissipable	ɪ n d ɪ s ɪ p ə b ə l
@@ -32639,6 +33035,7 @@ inexplicable	ɪ n ɪ k s p l ɪ k ə b l̩
 inexpugnable	ɪ n ɛ k s p ʌ ɡ n ə b ə l
 inexpugnable	ɪ n ɪ k s p ʌ ɡ n ə b ə l
 infallible	ɪ n f æ l ɪ b l̩
+infame	ɪ n f e ɪ m
 infamous	ɪ n f ə m ə s
 infamy	ɪ n f ə m i
 infancy	ɪ n f ə n s i
@@ -32660,7 +33057,7 @@ infelt	ɪ n f ɛ l t
 infer	ɪ n f ɝ
 inference	ɪ n f ə ɹ ə n s
 inferior	ɪ n f ɪ ɹ i ɚ
-infernal	ɪ n f ə ɹ n ə l
+infernal	ɪ n f ɝ n ə l
 inferno	ɪ n f ɝ n o ʊ
 inferred	ɪ n f ɝ d
 infertile	ɪ n f ɝ t ɪ l
@@ -32839,9 +33236,10 @@ injudiciously	ɪ n d͡ʒ ʊ d ɪ ʃ ə s l ɪ
 injunction	ɪ n d͡ʒ ʌ n k ʃ ə n
 injure	ɪ n d͡ʒ ɚ
 injured	ɪ n d͡ʒ ɚ d
+injuria	ɪ n d ʒ ʊ ə ɹ i ə
 injurious	ɪ n d͡ʒ ɝ i ə s
 injurious	ɪ n d͡ʒ ʊ ɹ i ə s
-injury	ɪ n d͡ʒ ə ɹ i
+injury	ɪ n d͡ʒ ɚ i
 injury	ɪ n d͡ʒ ɹ i
 injustice	ɪ n d͡ʒ ʌ s t ɪ s
 ink	i ŋ k
@@ -32879,6 +33277,7 @@ innocently	ɪ n ə s ə n t l i
 innocuous	ɪ n ɑ k j u ə s
 innocuousness	ɪ n ɒ k j u ə s n ə s
 innovation	ɪ n ə v e ɪ ʃ ə n
+innovator	ɪ n ə v e ɪ t ə ɹ
 innovent	ɪ n ə v ɛ n t
 innovented	ɪ n ə v ɛ n t ɪ d
 innoventor	ɪ n ə v ɛ n t ɚ
@@ -32892,6 +33291,7 @@ inoculent	ɪ n ɑ k j ə l ə n t
 inodiate	ɪ n ə ʊ d i e ɪ t
 inoptimal	ɪ n ɒ p t ɪ m ə l
 inordinate	ɪ n ɔ ɹ d n̩ ə t
+inorganic	ɪ n ɔ ɹ ɡ æ n ɪ k
 inorganity	ɪ n ɔː ɹ ɡ æ n ɪ t i
 inosculate	ɪ n ɒ s k j ʊ l e ɪ t
 inosite	ɪ n ə s a ɪ t
@@ -32913,8 +33313,6 @@ inquire	ɪ n k w a ɪ ɹ
 inquired	ɪ n k w a ɪ ɹ d
 inquiries	ɪ n k w ɪ ɹ i z
 inquiring	ɪ n k w a ɪ ɹ ɪ ŋ
-inquiry	ɪ n k w a ɪ ə ɹ i
-inquiry	ɪ n k w ɪ ɹ i
 inquisition	ɪ ŋ k w ɪ z ɪ ʃ ə n
 inquisitive	ɪ ŋ k w ɪ z ə t ɪ v
 inquisitor	ɪ n k w ɪ z ə t ə ɹ
@@ -32989,11 +33387,13 @@ inspect	ɪ n s p ɛ k t
 inspection	ɪ n s p ɛ k ʃ ə n
 inspector	ɪ n s p ɛ k t ɚ
 inspiration	ɪ n s p ə ɹ e ɪ ʃ ə n
+inspirational	ɪ n s p ə ɹ e ɪ ʃ ə n ə l
 inspire	ɪ n s p a ɪ ɹ
 inspired	ɪ n s p a ɪ ɹ d
 inspiring	ɪ n s p a ɪ ɹ ɪ ŋ
 inspissate	ɪ n s p ɪ s e ɪ t
 inspo	ɪ n s p o ʊ
+insta	ɪ n s t ə
 instadeath	ɪ n s t ə d ɛ θ
 instagram	ɪ n s t ə ɡ ɹ æ m
 instagrammable	ɪ n s t ə ɡ r æ m ə b ə l
@@ -33008,6 +33408,7 @@ instant	ɪ n s t ə n t
 instantaneous	ɪ n s t ə n t e ɪ n i ə s
 instanter	ɪ n s t æ n t ɚ
 instantial	ɪ n s t æ n ʃ ə l
+instantially	ɪ n s t æ n ʃ ə l i
 instantiate	ɪ n s t æ n ʃ i e ɪ t
 instantiation	ɪ n s t æ n ʃ i e ɪ ʃ ə n
 instar	ɪ n s t ɑ ɹ
@@ -33078,8 +33479,11 @@ insurgent	ɪ n s ə ɹ d͡ʒ ə n t
 insusurration	ɪ n s uː s ə ɹ e ɪ ʃ ə n
 int'resting	ɪ n t ɹ ɛ s t ɪ ŋ
 intact	ɪ n t æ k t
+intaglio	ɪ n t æ l i j o ʊ
 intaglio	ɪ n t æ l j o ʊ
+intaglio	ɪ n t æ ɡ l i o ʊ
 intaglio	ɪ n t ɑ l j o ʊ
+intaglio	ɪ n t ɑ ɡ l i o ʊ
 intake	ɪ n t e ɪ k
 intangible	ɪ n t æ n d͡ʒ ə b ə l
 intarweb	ɪ n t ɑ ɚ w ɛ b
@@ -33122,6 +33526,7 @@ intention	ɪ n t ɛ n ʃ ə n
 intentional	ɪ n t ɛ n ʃ ə n ə l
 intentions	ɪ n t ɛ n ʃ ə n z
 intentive	ɪ n t ɛ n t ɪ v
+intentively	ɪ n t ɛ n t ɪ v l i
 intently	ɪ n t ɛ n t l i
 inter	ɪ n t ɝ
 interabled	ɪ n t ɚ e ɪ b l̩ d
@@ -33134,6 +33539,7 @@ interacts	ɪ n t ə ɹ æ k s
 interacts	ɪ n t ə ɹ æ k t s
 interagency	ɪ n t ə ɹ e ɪ d͡ʒ ə n s i
 interarytenoid	ɪ n t ɚ æ ɹ ə t i n ɔ ɪ d
+interaxillary	ɪ n t ə ɹ æ k s ɪ l ə ɹ i
 interbedded	ɪ n t ɚ b ɛ d ə d
 interbred	ɪ n t ɚ b ɹ ɛ d
 interbreed	ɪ n t e ɹ b ɹ i d
@@ -33177,6 +33583,7 @@ interface	ɪ n t ɚ f e ɪ s
 interfaces	ɪ n t ə f e ɪ s
 interfere	ɪ n t ɚ f ɪ ɹ
 interfered	ɪ n t ɚ f ɪ ɹ d
+interference	ɪ n t ə ɹ f i ɹ ɪ n s
 interfrastically	ɪ n t ɚ f ɹ æ s t ɪ k ʌ l i
 interim	ɪ n t ə ɹ ɪ m
 interior	ɪ n t ɪ ɹ i ɚ
@@ -33195,6 +33602,7 @@ interlocutor	ɪ n t ə ɹ l ɑ k j u t ə ɹ
 interlocutor	ɪ n t ə ɹ l ɑ k j ə t ə ɹ
 interlocutor	ɪ n t ə ɹ l ɑ k ə t ə ɹ
 interlocutory	ɪ n t ə ɹ l ə k j uː t ə ɹ i
+interloper	ɪ n t ɚ l o ʊ̯ p ɚ
 interlude	ɪ n t ə ɹ l j uː d
 interlude	ɪ n t ə ɹ l uː d
 intermarry	ɪ n t ə ɹ m æ ɹ i
@@ -33237,6 +33645,7 @@ interocular	ɪ n t ə ɹ ɒ k j ə l ə ɹ
 interosseus	ɪ n t ə ɹ ɒ s i ə s
 interpellate	ɪ n t ə ɹ p ɛ l e ɪ t
 interpellate	ɪ n t ɜ ɹ p ə l e ɪ t
+interpetiolar	ɪ n t ə ɹ p ɛ t i ə ʊ l ə ɹ
 interphrasally	ɪ n t ɚ f ɹ e ɪ z ʌ l i
 interphrasic	ɪ n t ɚ f ɹ æ s ɪ k
 interphrastic	ɪ n t ɚ f ɹ æ s t ɪ k
@@ -33268,6 +33677,7 @@ intersex	ɪ n t ɚ s ɛ k s
 intershell	ɪ n t ɚ ʃ ɛ l
 interslavic	ɪ n t ɚ s l ɑː v ɪ k
 intersow	ɪ n t ə ɹ s ə ʊ
+interspecial	ɪ n t ɚ s p iː ʃ i ə l
 interspecific	ɪ n t ɚ s p ə s ɪ f ɪ k
 intersperse	ɪ n t ə ɹ s p ɜː ɹ s
 interstate	ɪ n t ɚ s t e ɪ t
@@ -33369,6 +33779,7 @@ intrude	ɪ n t ɹ uː d
 intrusion	ɪ n t ɹ uː ʒ ə n
 intrusive	ɪ n t ɹ uː s ɪ v
 intuit	ɪ n t u ɪ t
+intuition	ɪ n t u w ɪ ʃ ə n
 intuitive	ɪ n t j uː ɪ t ɪ v
 intuitiveness	ɪ n t j uː ɪ t ɪ v n ə s
 intumescent	ɪ n t u m ɛ s ə n t
@@ -33417,6 +33828,7 @@ invert	ɪ n v ɝ t
 invest	ɪ n v ɛ s t
 invested	ɪ n v ɛ s t ɪ d
 investigation	ɪ n v ɛ s t ə ɡ e ɪ ʃ ə n
+investigation	ɪ n v ɛ s t ɪ ɡ e ɪ ʃ ə n
 investigative	ɪ n v ɛ s t ɪ ɡ e ɪ t ɪ v
 investigative	ɪ n v ɛ s t ɪ ɡ ə t ɪ v
 investment	ɪ n v ɛ s m ə n t
@@ -33430,6 +33842,7 @@ invidious	ɪ n v ɪ d i ə s
 invigilator	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ə ɹ
 invigilatrix	ɪ n v ɪ d͡ʒ ɪ l e ɪ t ɹ ɪ k s
 invigorate	ɪ n v ɪ ɡ ə ɹ e ɪ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə t i
 invincible	ɪ n v ɪ n s ə b ə l
 invincible	ɪ n v ɪ n s ɪ b ə l
 inviolable	ɪ n v a ɪ ə l ə b l̩
@@ -33530,14 +33943,14 @@ ire	a ɪ ɹ
 ireland	a ɪ ə ɹ l ə n d
 irenarch	a ɪ ɹ ɪ n ɑː ɹ k
 irene	a ɪ ɹ iː n
-irenic	a ɪ ɹ iː n ɪ k
-irenic	a ɪ ɹ ɛ n ɪ k
+irenic	a ɪ ɹ i n ɪ k
 iri	a ɪ ɑː ɹ a ɪ
 irides	a ɪ ɹ ɪ d i z
 irides	ɪ ɹ ɪ d i z
 iridescence	ɪ ɹ ɪ d ɛ s ə n s
 iridescent	ɪ ɹ ɪ d ɛ s ə n t
 iridium	ɪ ɹ ɪ d i ə m
+iridocyclitis	i ɹ ɪ d o ʊ s ɪ k l a ɪ t ə s
 iris	a ɪ ɹ ɪ s
 irised	a ɪ ɹ ɪ s t
 irish	a ɪ ə ɹ ɪ ʃ
@@ -33556,6 +33969,7 @@ irony	a ɪ ɹ ə n i
 iroquois	ɪ ɹ ə k w ɔ ɪ
 iroquois	ɪ ɹ ə k ɔ ɪ
 irp	ɜː ɹ p
+irradicate	ɪ ɹ æ d ɪ k e ɪ t
 irrational	ɪ ɹ æ ʃ ə n ə l
 irrawaddy	ɪ ɹ ə w ɑ d i
 irrealis	ɪ ɹ i æ l ɪ s
@@ -33604,6 +34018,7 @@ irritation	ɪ ɹ ɪ t e ɪ ʃ ə n
 irruent	ɪ ɹ ɪ ʊ ə n t
 irrumation	ɪ ɹ ʊ m e i ʃ ə n
 irs	a ɪ ɑ ɹ ɛ s
+irtysh	ɪ ə ɹ t ɪ ʃ
 irukandji	ɪ ɹ ə k æ n d͡ʒ i
 irv	ɝ v
 irvin	ɝ v ɪ n
@@ -33660,6 +34075,8 @@ islay	ɪ z l e ɪ
 isle	a ɪ̯ l
 islet	a ɪ l ə t
 ism	ɪ z ə m
+ismael	ɪ z m e ɪ l
+ismael	ɪ z m e ɪ ə l
 ismahel	ɪ z m ə h ɛ l
 ismaili	ɪ s m ɑː i l i
 ismaili	ɪ s m ʌ ɪ iː l i
@@ -33713,6 +34130,7 @@ israel	ɪ z ɹ i ə l
 israeli	ɪ z ɹ e ɪ l i
 israelite	ɪ z ɹ e ɪ ə l a ɪ t
 israelite	ɪ z ɹ i ə l a ɪ t
+israelite	ɪ z ɹ ɪ l a ɪ t
 issue	ɪ ʃ j u
 issued	ɪ ʃ j u d
 issued	ɪ ʃ u d
@@ -33826,6 +34244,7 @@ jabs	d͡ʒ æ b z
 jacal	h ə k ɑː l
 jacana	d͡ʒ æ k ɑː n ə
 jace	d͡ʒ e ɪ s
+jacent	d ʒ e ɪ s ə n t
 jacinda	d͡ʒ ə s ɪ n d ə
 jacinth	d͡ʒ e ɪ s ɪ n θ
 jacinth	d͡ʒ æ s ɪ n θ
@@ -33860,6 +34279,7 @@ jacobite	d͡ʒ æ k ə b a ɪ t
 jacobs	d͡ʒ e ɪ k ə b z
 jacobson	d͡ʒ e ɪ k ə b s ə n
 jaconet	d͡ʒ æ k ə n ɪ t
+jacqueline	d ʒ æ k ə l ɪ n
 jacques	d͡ʒ æ k
 jacques	ʒ ɑː k
 jactitation	d͡ʒ æ k t ɪ t e ɪ ʃ ə n
@@ -34006,6 +34426,7 @@ java	d͡ʒ ɑː v ə
 javan	d͡ʒ ɑː v ə n
 javanka	d͡ʒ ə v ɑː ŋ k ə
 javans	d͡ʒ ɑː v ə n z
+javascript	d ʒ ɑː v ə s k ɹ ɪ p t
 javel	d͡ʒ æ v ə l
 javelin	d͡ʒ æ v ə l ɪ n
 javertian	ʒ ə v ɛ ɹ ʃ ə n
@@ -34062,6 +34483,7 @@ jeffrey	d͡ʒ ɛ f ɹ i
 jegging	d͡ʒ ɛ ɡ ɪ ŋ
 jeggings	d͡ʒ ɛ ɡ ɪ ŋ z
 jehovah	d͡ʒ ə h o ʊ v ə
+jehovist	d͡ʒ ə h o ʊ v ɪ s t
 jehovistic	d͡ʒ i h o ʊ v ɪ s t ɪ k
 jehovistic	d͡ʒ ə h o ʊ v ɪ s t ɪ k
 jejune	d͡ʒ i d ʒ uː n
@@ -34093,6 +34515,7 @@ jeopard	d͡ʒ ɛ p ə ɹ d
 jeopardize	d͡ʒ ɛ p ə d ʌ ɪ z
 jeopardy	d͡ʒ ɛ p ɚ d i
 jepson	d͡ʒ ɛ p s ə n
+jerboa	d ʒ ɜː ɹ b ə ʊ ə
 jeremiad	d͡ʒ ɛ ɹ ə m a ɪ ə d
 jeremiah	d͡ʒ ɛ ɹ ə m a ɪ ə
 jeremias	d͡ʒ ɛ ɹ ə m a ɪ ə s
@@ -34318,6 +34741,7 @@ joggle	d͡ʒ ɒ ɡ ə l
 joh	d͡ʒ ə ʊ
 johanna	d͡ʒ ə ʊ h æ n ə
 johanna	d͡ʒ ə ʊ æ n ə
+johannes	d ʒ ə ʊ h æ n ɪ s
 johannesburg	d͡ʒ o ʊ h æ n ɪ s b ɜː r ɡ
 johannesburg	d͡ʒ o ʊ h ɑː n ɪ s b ɜː r ɡ
 johannine	d͡ʒ o ʊ h æ n a ɪ n
@@ -34379,6 +34803,7 @@ josiah	d͡ʒ o ʊ z a ɪ ə
 josser	d͡ʒ ɒ s ə ɹ
 jostle	d͡ʒ ɑ s ə l
 josue	d͡ʒ ɒ s j u iː
+josue	h o ʊ s w e ɪ
 jot	d͡ʒ ɑ t
 jota	h o ʊ t ə
 jotation	d͡ʒ ə ʊ t e ɪ ʃ ə n
@@ -34530,6 +34955,7 @@ jumping	d͡ʒ ʌ m p ɪ ŋ
 jumpings	d͡ʒ ʌ m p ɪ ŋ z
 jumps	d͡ʒ ʌ m p s
 jumpy	d͡ʒ ʌ m p i
+jun	d ʒ ʌ n
 juncate	d͡ʒ ʌ ŋ k ɪ t
 junco	d͡ʒ ʌ ŋ k o ʊ
 junction	d͡ʒ ʌ ŋ k ʃ ə n
@@ -34562,6 +34988,7 @@ jupe	ʒ uː p
 jupiter	d͡ʒ u p ɪ t ɚ
 jupon	d͡ʒ u p ɑ n
 jura	d͡ʒ ʊ ɹ ə
+jural	d ʒ ʊ ə ɹ ə l
 jurat	d͡ʒ ʊ ɹ æ t
 jurator	d͡ʒ ʊ r e ɪ t ə r
 juratorial	d͡ʒ ʊ ə r ə t ɔ ə r ɪ ə l
@@ -34585,6 +35012,7 @@ justice	d͡ʒ ʌ s t ɪ s
 justiciar	d͡ʒ ʌ s t ɪ s i ɑː ɹ
 justification	d͡ʒ ʌ s t ɪ f ɪ k e ɪ ʃ ə n
 justificatory	d͡ʒ ə s t ɪ f ə k ə t ɔ ɹ i
+justificatory	d͡ʒ ʌ s t ɪ f ə k e ɪ t ə ɹ i
 justified	d͡ʒ ʌ s t ɪ f a ɪ d
 justify	d͡ʒ ʌ s t ɪ f a ɪ
 justin	d͡ʒ ʌ s t ɪ n
@@ -34608,6 +35036,7 @@ juxtapose	d͡ʒ ʌ k s t ə p o ʊ z
 juxtaposit	d͡ʒ ʌ k s t ə p ɒ z ɪ t
 juxtaposition	d͡ʒ ʌ k s t ə p ə z ɪ ʃ ə n
 juxtology	d͡ʒ ʌ k s t ɑ l ə d͡ʒ i
+jwics	d ʒ e ɪ w ɪ k s
 jy	d͡ʒ a ɪ
 jynges	d͡ʒ ɪ n d͡ʒ iː z
 jynges	d͡ʒ ɪ n d͡ʒ ɪ z
@@ -34616,6 +35045,7 @@ jynx	d͡ʒ ɪ ŋ k s
 jyothis	d͡ʒ o ʊ t ɪ s
 jäger	j e ɪ ɡ ɚ
 jägerbomb	j e ɪ ɡ ɚ b ɑ m
+jägermeister	j e ɪ ɡ ə r m a ɪ s t ə r
 jèrriais	ʒ ɛ ɹ i e ɪ
 jõgeva	j ə ʊ ɡ ɪ v ə
 jõgeva	j ʊ ɡ ɪ v ə
@@ -34639,6 +35069,8 @@ kachina	k ə t͡ʃ i n ə
 kaddish	k ɑ d ɪ ʃ
 kadkhoda	k æ d k ə ʊ d ə
 kady	k e ɪ d i
+kaffir	k æ f ɚ
+kafir	k ɑː f ɪ ɹ
 kafka	k ɑ f k ɑ
 kafka	k ɑ f k ə
 kafkaesque	k ɑ f k ə ɛ s k
@@ -34722,6 +35154,7 @@ kangchenjunga	k ʌ ŋ t͡ʃ ə n d͡ʒ ʌ ŋ ɡ ə
 kangding	k ɒ ŋ d ɪ ŋ
 kanghui	k ɒ ŋ h w i
 kangling	k æ ŋ ɡ ə l ɪ ŋ ɡ
+kango	k ɑ ŋ ɡ o ʊ
 kangri	k æ ŋ ɡ ɹ i
 kangxi	k ɑ ŋ ʃ iː
 kanigget	k ə n ɪ ɡ ə t
@@ -34808,6 +35241,7 @@ kashers	k ɑ ʃ ɚ z
 kashmir	k æ ʃ m i ɹ
 kashmir	k æ ʒ m i ɹ
 kashmiri	k æ ʃ m i ɹ i
+kashrut	k ɑː ʃ ɹ uː t
 kashubian	k ə ʃ uː b ɪ ə n
 kasich	k e ɪ s ɪ k
 kasserine	k æ s ə ɹ ɪ n
@@ -35058,6 +35492,7 @@ khamsin	k æ m s ɪ n
 khan	k ɑː n
 khanjar	k a n d͡ʒ ə
 khanji	k ɑː n d͡ʒ i
+khariboli	k a ɹ iː b o ʊ ɫ iː
 kharkiv	h ɑ ɹ k i v
 kharkiv	h ɑ ɹ k ɪ v
 kharkiv	h ɑː k iː v
@@ -35147,6 +35582,8 @@ kierkegaardianism	k ɪ ɹ k ə ɡ ɑ ɹ d i ə n ɪ z ə m
 kiev	k iː ɛ f
 kiev	k iː ɛ v
 kiev	k iː ɪ v
+kiev	k j ɛ f
+kiev	k j ɛ v
 kievan	k iː ɛ f ə n
 kievan	k iː ɛ v ə n
 kif	k iː f
@@ -35229,6 +35666,7 @@ kinematic	k ɪ n ə m æ t ɪ k
 kinematics	k ɪ n ə m æ t ɪ k s
 kines	k a ɪ n z
 kineses	k a ɪ n z ɪ z
+kinesics	k ə n i s ɪ k s
 kinesiology	k ə n i z i ɔ l ə d͡ʒ ɪ
 kinesis	k ə n iː s ɪ s
 kinesthesia	k a ɪ n ɪ s θ i ʒ ə
@@ -35283,6 +35721,9 @@ kippens	k ɪ p ə n z
 kipper	k ɪ p ə ɹ
 kirby	k ɝ b i
 kirghiz	k ɪ ɹ ɡ iː z
+kiribati	k iː ɹ ɪ b æ s
+kiribati	k iː ɹ ɪ b ɑ s
+kiribati	k iː ɹ ɪ b ɑ t i
 kiritimati	k ə ɹ ɪ s m ə s
 kirk	k ɝ k
 kirkby	k ɝ b i
@@ -35290,6 +35731,7 @@ kirkcaldy	k ə ɹ k ɔː d i
 kirkcudbright	k ɚ k u b ɹ i
 kirkheaton	k ə r k h iː t ə n
 kirkwood	k ɝ k w ʊ d
+kirmess	k ɜː ɹ m ə s
 kirpan	k ɪ ə ɹ p ɑː n
 kirsch	k ɜː ɹ ʃ
 kirsch	k ɪ ə ɹ ʃ
@@ -35408,6 +35850,7 @@ knapweed	n æ p w iː d
 knar	n ɑ ɹ
 knarr	n ɔː ɹ
 knarred	n ɑː ɹ d
+knarry	n ɑː ɹ i
 knave	n e ɪ v
 knavery	n e ɪ v ə ɹ i
 knaves	n e ɪ v z
@@ -35500,6 +35943,7 @@ knuff	n ʌ f
 knur	n ɜː ɹ
 knurl	n ɝ l
 knurly	n ɜː ɹ l i
+knurry	n ɜː ɹ i
 knuth	k ə n uː θ
 knysna	n a ɪ z n ə
 ko	k ə ʊ
@@ -35544,6 +35988,7 @@ kolkata	k o ʊ l k ɑ t ə
 kolkhoz	k ə l k ɒ z
 kolkhozy	k ə l k ɒ z ɪ
 kolo	k o ʊ l o ʊ
+kolyma	k ə l ɪ m a
 kombu	k ɒ m b uː
 kombucha	k ɑ m b u t͡ʃ ə
 kombucha	k ɑ m b u ʃ ə
@@ -35601,6 +36046,7 @@ kraken	k ɹ æ k ə n
 kraken	k ɹ ɑː k ə n
 kramatorsk	k ɹ æ m ə t ɔ ɹ s k
 kramer	k ɹ e ɪ m ɚ
+krang	k ɹ æ ŋ
 kraut	k ɹ a ʊ t
 kremlin	k ɹ e m l ɪ n
 kretek	k ɹ ɛ t ɛ k
@@ -35689,6 +36135,7 @@ kye	k a ɪ
 kye	k j e ɪ
 kyiv	k iː v
 kyiv	k iː ɪ v
+kyiv	k j ɪ v
 kyivan	k iː ɪ v ə n
 kyke	k a ɪ k
 kyla	k a ɪ l ə
@@ -35700,6 +36147,7 @@ kylix	k a ɪ l ɪ k s
 kylixes	k a ɪ l ɪ k s ə z
 kylym	k ɪ l ɪ m
 kynodesme	k a ɪ n ə ʊ d ɛ z m i
+kyoto	k i j o ʊ t o ʊ
 kyoto	k j o ʊ t o ʊ
 kyphotone	k a ɪ f ə t ə ʊ n
 kyra	k a ɪ ɹ ə
@@ -35833,10 +36281,13 @@ lagevrio	l ə ɡ ɛ v ɹ i o ʊ
 laggard	l æ ɡ ɚ d
 laggy	l æ ɡ i
 lagid	l æ d͡ʒ ɪ d
+lagids	l æ d͡ʒ ɪ d z
 lagniappe	l æ n j æ p
 lagomorphic	l æ ɡ ə m ɔ ɹ f ɪ k
 lagoon	l ə ɡ uː n
 lagtime	l æ ɡ t a ɪ m
+lagune	l ə ɡ j uː n
+lagune	l ə ɡ uː n
 lah	l ɑ
 lahar	l ɑ h ɑ ɹ
 lahore	l ə h ɔː r
@@ -35851,7 +36302,7 @@ laicize	l e ɪ ɪ s a ɪ z
 laid	l e ɪ d
 laik	l e ɪ k
 lain	l e ɪ n
-lair	l ɛ ə ɹ
+lair	l ɛ ɚ
 laird	l ɛ ə ɹ d
 lairy	l ɛ ə ɹ i
 laisse	l e ɪ s
@@ -35939,6 +36390,7 @@ lanai	l ə n a ɪ
 lanark	l æ n ə ɹ k
 lancaster	l æ n k æ s t ɚ
 lancaster	l æ ŋ k ə s t ə ɹ
+lancaster	l æ ŋ k ɪ s t ɚ
 lance	l æ n s
 lancefield	l æ n s f iː l d
 lancelot	l æ n s ə l ɒ t
@@ -36066,12 +36518,11 @@ large	l ɑ ɹ d͡ʒ
 largely	l ɑ ɹ d͡ʒ l i
 largeness	l ɑː d͡ʒ n ə s
 larger	l ɑ ɹ d͡ʒ ɚ
-largess	l ɑ ɹ d͡ʒ ɛ s
-largess	l ɑ ɹ ʒ ɛ s
-largesse	l ɑ ɹ d͡ʒ ɛ s
+largesse	l ɑ ɹ d ʒ ɛ s
 largest	l ɑ ɹ d͡ʒ ɪ s t
 lariat	l æ ɹ ɪ ə t
 larissa	l ə ɹ ɪ s ə
+larixinic	l æ ɹ ɪ k s ɪ n ɪ k
 lark	l ɑ ɹ k
 larnax	l ɑ ɹ n æ k s
 larne	l ɑː ɹ n
@@ -36082,12 +36533,13 @@ larrup	l æ ɹ ə p
 larva	l ɑ ɹ v ə
 larvae	l ɑ ɹ v i
 larval	l ɑ ɹ v ə l
+larve	l ɑː ɹ v
 laryngeal	l æ ɹ ə n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n d͡ʒ i ə l
 laryngeal	l ə ɹ ɪ n d͡ʒ ə l
 laryngeal	l ɛ ɹ ə n d͡ʒ i ə l
 larynges	l ə ɹ ɪ n d͡ʒ iː z
-laryngitis	l æ ɹ ɪ n d͡ʒ a ɪ t ɪ s
+laryngitis	l ɛ ɹ ɪ n d͡ʒ a ɪ t ɪ s
 larynx	l æ ɹ ɪ ŋ k s
 larynx	l ɛ ɹ ɪ ŋ k s
 las	l ɑː z
@@ -36225,7 +36677,9 @@ laundromat	l ɔː n d ɹ ə ʊ m æ t
 laundry	l ɔː n d ɹ i
 laura	l ɔ ɹ ə
 lauraceous	l ɔ ɹ e ɪ ʃ ə s
+laureate	l ɑ ɹ i e ɪ t
 laureate	l ɑ ɹ i ə t
+laureate	l ɔ ɹ i e ɪ t
 laureate	l ɔ ɹ i ə t
 laureation	l ɔː ɹ i e ɪ ʃ ə n
 laurel	l ɔ ɹ ə l
@@ -36289,6 +36743,7 @@ lay	l e ɪ
 layabout	l e ɪ ə b a ʊ t
 layan	l ʌ j ʌ n
 layer	l e ɪ ɚ
+layer	l ɛ ɚ
 layers	l e ɪ ɚ z
 layin'	l e ɪ ɪ n
 laying	l e ɪ ɪ ŋ
@@ -36402,6 +36857,8 @@ leaven	l ɛ v ə n
 leaves	l iː v z
 leaving	l iː v ɪ ŋ
 lebanon	l ɛ b ə n ɑ n
+lebanon	l ɛ b ə n ə n
+lecce	l ɛ t ʃ e ɪ
 lech	l ɛ k
 lech	l ɛ t͡ʃ
 lechayim	l ə h a ɪ ɪ m
@@ -36417,6 +36874,7 @@ lectical	l ɛ k t ɪ k ə l
 lectinological	l ɛ k t ɪ n ə l ɒ d͡ʒ ɪ k ə l
 lectinologist	l ɛ k t ɪ n ɒ l ə d͡ʒ ɪ s t
 lection	l ɛ k ʃ ə n
+lector	l ɛ k t ə ɹ
 lecture	l ɛ k t͡ʃ ɚ
 lecturer	l ɛ k t͡ʃ ə ɹ ɚ
 lectures	l ɛ k t͡ʃ ɚ z
@@ -36457,6 +36915,7 @@ lefty	l ɛ f t i
 leg	l ɛ ɡ
 legacy	l ɛ ɡ ə s i
 legal	l i ɡ ə l
+legal	l ɪ ɡ æ l
 legalist	l i ɡ ə l ɪ s t
 legalize	l iː ɡ ə l a ɪ z
 legally	l iː ɡ ə l i
@@ -36496,10 +36955,13 @@ leguleian	l ɛ ɡ j ʊ l iː ə n
 legume	l ə ɡ j uː m
 legume	l ɛ ɡ j uː m
 legume	l ɪ ɡ j uː m
+legumen	l ɪ ɡ j uː m ə n
 legumes	l ɛ ɡ j uː m z
 legumes	l ɪ ɡ j uː m z
 legwork	l ɛ ɡ w ɚ k
 leh	l e ɪ
+lehavdil	l ə h ɑ v d i l
+lehavdil	l ə h ɑ v d ɪ l
 lehua	l ɛ h uː ə
 lei	l e ɪ
 leia	l e ɪ ə
@@ -36556,6 +37018,7 @@ length	l ɛ ŋ k θ
 lengthen	l ɛ ŋ k θ ə n
 lengthening	l ɛ ŋ k θ ə n ɪ ŋ
 lengthman	l ɛ ŋ θ m ə n
+lengthsman	l ɛ ŋ θ s m ə n
 lenient	l iː n i ə n t
 lenify	l iː n ɪ f a ɪ
 lenify	l ɛ n ɪ f a ɪ
@@ -36572,6 +37035,7 @@ lenite	l iː n a ɪ t
 lenite	l ə n a ɪ t
 lenition	l i n ɪ ʃ ə n
 lenition	l ə n ɪ ʃ ə n
+lenity	l ɛ n ɪ t i
 lennon	l ɛ n ə n
 lenox	l ɛ n ɪ k s
 lens	l ɛ n z
@@ -36673,6 +37137,7 @@ lettuce	l ɛ t ə s
 lettuce	l ɛ t ɪ s
 leu	l e ɪ uː
 leuchars	l uː k ə ɹ z
+leucinemia	l j uː s ɪ n iː m i ə
 leucite	l u s a ɪ t
 leucoderm	l uː k ə d ɝ m
 leucodermic	l uː k ə d ɜː m ɪ k
@@ -36719,7 +37184,8 @@ leveret	l ɛ v ə ɹ ɪ t
 leveret	l ɛ v ɹ ɪ t
 leverpostej	l e ɪ v ə ɹ p ɒ s t a ɪ
 levet	l ɛ v ɪ t
-levi	l iː v a ɪ
+levetiracetam	l ɛ v ɪ t ɪ r æ s ɪ t æ m
+levi	l iː v a j
 leviathan	l ə v a ɪ ə θ ə n
 levidrome	l i v a ɪ d ɹ o ʊ m
 levidrome	l i v ɪ d ɹ o ʊ m
@@ -36769,8 +37235,6 @@ li	l iː
 liability	l a ɪ ə b ɪ l ɪ t i
 liable	l a ɪ̯ ə b ə l
 liaise	l iː e ɪ z
-liaison	l a ɪ ə s ə n
-liaison	l i e ɪ s ɑ n
 liaison	l i e ɪ z ɑ n
 liam	l iː ə m
 liana	l iː ɑː n ə
@@ -36836,7 +37300,6 @@ licorice	l ɪ k ə ɹ ɪ s
 licorice	l ɪ k ə ɹ ɪ ʃ
 lid	l ɪ d
 lidar	l a ɪ d ɑ ɹ
-liddat	l a ɪ d ɛ t
 lidge	l ɪ d͡ʒ
 lidocaine	l a ɪ d ə k e ɪ n
 lids	l ɪ d z
@@ -36912,6 +37375,8 @@ ligiid	l ɪ d ʒ i ɪ d
 ligma	l ɪ ɡ m ə
 lignify	l ɪ ɡ n ɪ f a ɪ
 lignite	l ɪ ɡ n a ɪ̯ t
+lignose	l ɪ ɡ n ə ʊ s
+lignose	l ɪ ɡ n ə ʊ z
 ligula	l ɪ ɡ j ʊ l ə
 liguria	l ɪ ɡ j ʊ ɹ i ə
 lihou	l iː uː
@@ -36942,6 +37407,7 @@ lilac	l a ɪ l ɑ k
 lilac	l a ɪ l ə k
 lilangeni	l ɪ l æ ŋ ɡ e ɪ n i
 lilian	l ɪ l i ə n
+liliana	l ɪ l i ɑ n ə
 liliate	l ɪ l i ə t
 lilies	l ɪ l i z
 liliger	l a ɪ l a ɪ ɡ ə ɹ
@@ -37019,6 +37485,7 @@ lindsey	l ɪ n z i
 lindworm	l ɪ n d w ɜː ɹ m
 line	l a ɪ n
 lineage	l ɪ n i ɪ d͡ʒ
+lineages	l ɪ n i ɪ d ʒ ɪ z
 lineal	l ɪ n i ə l
 linear	l ɪ n i ɚ
 linearithmic	l ɪ n i ə ɹ ɪ ð m ɪ k
@@ -37326,6 +37793,7 @@ lobster	l ɑ b s t ɚ
 lobsterman	l ɒ b s t ə ɹ m ə n
 lobsterwoman	l ɒ b s t ə ɹ w ʊ m ə n
 lobule	l ɑ b j u l
+loc	l o ʊ k
 local	l o ʊ k l̩
 locale	l o ʊ k æ l
 localism	l o ʊ k ə l ɪ z ə m
@@ -37375,8 +37843,8 @@ loess	l o ʊ ə s
 loess	l ɛ s
 loess	l ʌ s
 loft	l ɔ f t
+lofton	l ɒ f t ə n
 lofty	l ɔː f t i
-log	l ɑ ɡ
 log	l ɔ ɡ
 logan	l o ʊ ɡ ə n
 logarithm	l ɑ ɡ ə ɹ ɪ ð m
@@ -37421,6 +37889,7 @@ logo	l o ʊ ɡ o ʊ
 logodaedaly	l o ʊ ɡ o ʊ d i d ə l i
 logogram	l ɑ ɡ ə ɡ ɹ æ m
 logogram	l ɔː ɡ ə ɡ ɹ æ m
+logological	l ɑ ɡ o ʊ l ɑ d͡ʒ ɪ k ə l
 logomachy	l o ʊ ɡ ɑ m ə k i
 logorrhea	l ɔ ɡ ə ɹ i ə
 logos	l o ʊ ɡ o ʊ s
@@ -37443,7 +37912,6 @@ lojban	l o ʊ ʒ b æ n
 lojban	l o ʊ ʒ b ɑː n
 lojban	l ɒ ʒ b æ n
 loki	l o ʊ k i
-lol	l o l
 lol	l o ʊ l
 lol	l ɑ l
 lol	l ɔ l
@@ -37452,6 +37920,7 @@ lola	l o ʊ l ə
 lolcat	l ɑ l k æ t
 loll	l ɑ l
 lollapalooza	l ɑ l ə p ə l u z ə
+lollard	l ɒ l ɑː ɹ d
 lollipop	l ɑ l i p ɑ p
 lollop	l ɒ l ə p
 lollygag	l ɒ l ɪ ɡ æ ɡ
@@ -37473,7 +37942,9 @@ loneliness	l o ʊ n l i n ə s
 lonely	l o ʊ n l i
 loner	l o ʊ n ɚ
 lonesome	l o ʊ n s ə m
+long	l ɒ ŋ
 long	l ɔ ŋ
+long	l ʊ ŋ
 longan	l ɑ ŋ ɡ ə n
 longdon	l ɒ ŋ d ə n
 longe	l ʌ n d͡ʒ
@@ -37559,6 +38030,7 @@ lopsided	l ɑ p s a ɪ d ɪ d
 loquacious	l o ʊ k w e ɪ ʃ ə s
 loquat	l o ʊ k w ɑ t
 lorazepam	l ɔ ɹ æ z ə p æ m
+lorazepam	l ɚ æ z ə p æ m
 lorcha	l ɔ ɹ t͡ʃ ə
 lorcha	l ɔ ɹ ʃ ə
 lorchel	l ɔː ɹ k ə l
@@ -37652,6 +38124,7 @@ lovable	l ʌ v ə b ə l
 lovage	l ʌ v ə d͡ʒ
 lovastatin	l o ʊ v ə s t æ t n̩
 lovastatin	l ʌ v ə s t æ t n̩
+love	l ʊ v
 love	l ʌ v
 lovecraft	l ʌ v k ɹ æ f t
 lovecraftian	l ʌ v k ɹ æ f t i ə n
@@ -37763,7 +38236,6 @@ luftwaffe	l ʊ f t w ɑ f ə
 lug	l ʌ ɡ
 luganda	l uː ɡ æ n d ə
 luganda	l uː ɡ ɑː n d ə
-luge	l u ʒ
 luged	l uː ʒ d
 luger	l u ɡ ɚ
 luggage	l ʌ ɡ ɪ d͡ʒ
@@ -37851,6 +38323,7 @@ lupine	l uː p a ɪ n
 lupine	l uː p ɪ n
 lupulin	l u p j ə l ɪ n
 lupus	l uː p ə s
+lur	l ʊ ə ɹ
 lurch	l ɝ t͡ʃ
 lure	l ɔ ɹ
 lure	l ɝ
@@ -37926,6 +38399,7 @@ luxury	l ʌ k ʃ ə ɹ i
 luxury	l ʌ ɡ ʒ ə ɹ i
 luzon	l u z ɔ n
 lviv	l ə v iː v
+lyam	l a ɪ ə m
 lycan	l a ɪ k ə n
 lycanthrope	l a ɪ k æ n θ ɹ o ʊ p
 lycanthrope	l a ɪ k ə n θ ɹ o ʊ p
@@ -37981,6 +38455,7 @@ lyra	l ɪ ə ɹ ə
 lyre	l a ɪ ɚ
 lyre	l a ɪ ɹ
 lyric	l ɪ ɹ ɪ k
+lyrical	l ɪ ɹ ɪ k ə l
 lyricist	l ɪ ɹ ɪ s ɪ s t
 lyrics	l ɪ ɹ ɪ k s
 lyrid	l a ɪ ɹ ɪ d
@@ -38075,6 +38550,7 @@ machismo	m ə t͡ʃ i z m o ʊ
 macho	m ɑː t͡ʃ o ʊ
 machoness	m ɑ t͡ʃ o ʊ n ə s
 macilent	m a s ɪ l ə n t
+macitentan	m æ s ɪ t ɛ n t æ n
 mack	m æ k
 mackerel	m æ k ɹ ə l
 mackey	m æ k i
@@ -38117,6 +38593,7 @@ macrovirus	m æ k ɹ o ʊ v a ɪ ɹ ə s
 macroworld	m æ k ɹ o ʊ w ɝ l d
 macs	m æ k s
 macspaunday	m ə k s p ɔː n d e ɪ
+macula	m æ k j ʊ l ə
 maculature	m æ k j ʊ l ə t j ʊ ə ɹ
 maculature	m æ k j ʊ l ə t͡ʃ ə ɹ
 maculele	m ɑː k u l e ɪ l e ɪ
@@ -38208,6 +38685,7 @@ maggot	m æ ɡ ə t
 maggots	m æ ɡ ə t s
 maggoty	m æ ɡ ə t i
 maghreb	m ɑː ɡ ɹ ɛ b
+maghreb	m ʌ ɡ ɹ ə b
 maghull	m ə ɡ ʌ l
 magi	m e ɪ d͡ʒ a ɪ
 magi	m e ɪ ɡ a ɪ
@@ -38392,6 +38870,7 @@ malagasy	m æ l ə ɡ e ɪ z i
 malagasy	m æ l ə ɡ æ s i
 malagueta	m ɑ l ə ɡ e ɪ d ə
 malagueta	m ɑ l ə ɡ w e ɪ d ə
+malai	m ə l a ɪ
 malaise	m ə l e ɪ z
 malakoplakia	m æ l ə k o ʊ p l æ k i ə
 malamute	m æ l ə m j uː t
@@ -38495,6 +38974,7 @@ malt	m ɔ l t
 malta	m ɑ l t ə
 malta	m ɔ l t ə
 maltalent	m æ l t æ l ə n t
+maltaxation	m æ l t æ k s e ɪ ʃ ə n
 maltese	m ɑ l t i z
 maltitol	m ɔː l t ə t ɑ l
 malum	m æ l ə m
@@ -38553,6 +39033,7 @@ manchuria	m æ n t͡ʃ ʊ ə ɹ i ə
 manchurian	m æ n t͡ʃ ʊ ə ɹ i ə n
 mancia	m æ n t͡ʃ ə
 mancipatory	m æ n s ɪ p e ɪ t ə ɹ i
+manciple	m æ n s ɪ p ə l
 mancunian	m æ n k j u n i ə n
 mand	m æ n d
 mand	m ɑː n d
@@ -38565,6 +39046,7 @@ mandate	m æ n d e ɪ t
 mandatory	m æ n d ə t ɔ ɹ i
 mandela	m æ n d ɛ l ə
 mandement	m æ n d m ə n t
+mandeville	m æ n d ə v ɪ l
 mandible	m æ n d ɪ b ə l
 mandibles	m æ n d ə b ə l z
 mandibles	m æ n d ɪ b ə l z
@@ -38661,6 +39143,7 @@ manitoba	m æ n ɪ t o ʊ b ə
 manitou	m a n ɪ t uː
 manitowoc	m æ n ɪ t ə w ɔː k
 manizer	m æ n a ɪ z ə ɹ
+manjuristics	m æ n d͡ʒ ə ɹ ɪ s t ɪ k s
 mank	m æ ŋ k
 mankind	m æ n k a ɪ n d
 mankiw	m æ n k j uː
@@ -38673,6 +39156,7 @@ manna	m æ n ə
 manned	m æ n d
 mannequin	m æ n ə k ɪ n
 manner	m æ n ɚ
+mannerism	m æ n ə ɹ ɪ z ə m
 manners	m æ n ɚ z
 mannish	m æ n ɪ ʃ
 mannopeptimycin	m n æ ə ʊ p ɛ p t ɪ m a ɪ s ɪ n
@@ -38693,6 +39177,7 @@ manship	m æ n ʃ ɪ p
 mansi	m æ n s i
 mansi	m ɑː n s i
 mansion	m æ n t͡ʃ ə n
+mansion	m æ n ʃ ə n
 manslot	m æ n z l ɑ t
 manson	m æ n s ə n
 mansonia	m æ n s o ʊ n i ə
@@ -38757,6 +39242,7 @@ mapless	m æ p l ə s
 mapping	m æ p ɪ ŋ
 maprotiline	m ə p ɹ o ʊ t ə l iː n
 maps	m æ p s
+mapuche	m ə p uː t ʃ e ɪ
 maputo	m ə p uː t ə ʊ
 maquette	m æ k ɛ t
 mar	m ɑ ɹ
@@ -38795,6 +39281,7 @@ marches	m ɑː t͡ʃ ɪ z
 marches	m ɒ ɹ t͡ʃ ə z
 marching	m ɑ ɹ t͡ʃ ɪ ŋ
 marchioness	m ɑ ɹ ʃ ə n ɛ s
+marchioness	m ɑ ɹ ʃ ə n ɪ s
 marchland	m ɑ ɹ t͡ʃ l æ n d
 marchpane	m ɑ ɹ t͡ʃ p e ɪ n
 marcia	m ɑ ɹ ʃ ə
@@ -38863,6 +39350,8 @@ mariupol	m ɑː ɹ i uː p o ʊ l
 marjoram	m ɑ ɹ d͡ʒ ə ɹ ə m
 mark	m ɑ ɹ k
 marked	m ɑ ɹ k t
+marked	m ɑ ɹ k ə d
+marked	m ɑ ɹ k ɪ d
 marker	m ɑː ɹ k ə ɹ
 market	m ɑ ɹ k ə t
 market	m ɑ ɹ k ɪ t
@@ -38875,6 +39364,8 @@ markovian	m ɑ ɹ k o ʊ v i ə n
 marks	m ɑ ɹ k s
 marksman	m ɑ ɹ k s m ə n
 marksmanship	m ɑ ɹ k s m ə n ʃ ɪ p
+markèd	m ɑ ɹ k ə d
+markèd	m ɑ ɹ k ɪ d
 marl	m ɑ ɹ l
 marley	m ɑ ɹ l i
 marlin	m ɑ ɹ l ɪ n
@@ -38970,7 +39461,6 @@ masaccio	m ə z ɑː t͡ʃ i o ʊ
 masala	m ə s ɑː l ə
 masbate	m ə s b ɑ t ɛ
 masc	m æ s k
-masc	m ɑː s k
 mascara	m æ s k æ ɹ ə
 mascaron	m æ s k ə ɹ ɒ n
 mascarpone	m æ s k ə ɹ p ə ʊ n i
@@ -39052,7 +39542,7 @@ masterman	m æ s t ɚ m ə n
 mastermind	m æ s t ɚ m a ɪ n d
 masterpiece	m æ s t ɚ p i s
 masters	m æ s t ɚ z
-mastery	m æ s t ə ɹ i
+mastery	m æ s t ɚ i
 mastic	m æ s t ɪ k
 masticate	m æ s t ɪ k e ɪ t
 mastication	m æ s t ɪ k e ɪ ʃ ə n
@@ -39095,7 +39585,7 @@ materialistic	m ə t ɪ ə ɹ i ə l ɪ s t ɪ k
 materials	m ə t ɪ ɹ i ə l z
 materiel	m ə t ɪ ɹ i ɛ l
 materiel	m ə t ɪ ɹ j ɛ l
-maternal	m ə t ɜ ɹ n ə l
+maternal	m ə t ɝ n ə l
 maternity	m ə t ɜː ɹ n ɪ t i
 mates	m e ɪ t s
 math	m æ θ
@@ -39159,6 +39649,7 @@ maturate	m æ t͡ʃ ə ɹ e ɪ t
 mature	m ə t j ʊ ə ɹ
 mature	m ə t͡ʃ ɝ
 mature	m ə t͡ʃ ʊ ə ɹ
+maturely	m ə t j ʊ ə ɹ l i
 maturity	m ə t ʊ ə ɹ ə t i
 matutinal	m æ t͡ʃ ə t a ɪ n ə l
 matutinal	m ə t j u t ə n l̩
@@ -39237,7 +39728,6 @@ maykop	m a ɪ k ɒ p
 mayn't	m e ɪ n t
 mayn't	m e ɪ ə n t
 maynooth	m ə n uː θ
-mayo	m e ɪ o ʊ
 mayo	m e ɪ ə ʊ
 mayonnaise	m e ɪ ə n e ɪ z
 mayonnaise	m æ n e ɪ z
@@ -39267,6 +39757,7 @@ mccobb	m ə k ɑ b
 mcconaughey	m ə k k ɑ n ə h e ɪ̯
 mccoy	m ə k ɔ ɪ
 mccrea	m ɪ k k r e ɪ
+mccrum	m ɪ k ɹ ʌ m
 mcdonald	m ə k d ɑ n ə l d
 mcghie	m ɪ ɡ iː
 mcgough	m ə ɡ j uː
@@ -39317,6 +39808,7 @@ meant	m ɛ n t
 meantime	m iː n t a ɪ m
 meanwhile	m iː n w a ɪ l
 mear	m ɪ ɹ
+measle	m i z ə l
 measles	m i z ə l z
 measlings	m iː z l ɪ ŋ z
 measly	m i z l i
@@ -39406,6 +39898,7 @@ medieval	m ɪ d i v ə l
 medievaldom	m ɪ d i v ə l d ə m
 medina	m ə d i n ə
 mediocre	m i d i o ʊ k ə ɹ
+mediocrity	m i d ɪ ɑ k ɹ ɪ t i
 mediolanum	m e ɪ d i o ʊ l ɑ n ə m
 mediolanum	m ɛ d i o ʊ l ɑ n ə m
 medish	m iː d ɪ ʃ
@@ -39427,6 +39920,7 @@ medusa	m ə d uː s ə
 medusa	m ɪ d j uː s ə
 medusa	m ɪ d j uː z ə
 medusoid	m ə d u s ɔ ɪ d
+medway	m ɛ d w e ɪ
 meed	m iː d
 meedless	m iː d l ə s
 meef	m iː f
@@ -39486,6 +39980,7 @@ meghalaya	m e ɪ ɡ ə l e ɪ ə
 meghan	m e ɪ ɡ ə n
 meghan	m iː ɡ ə n
 meghan	m ɛ ɡ ə n
+meghna	m e ɡ n a
 megiddo	m ə ɡ ɪ d ə ʊ
 megillah	m ə ɡ ɪ l ə
 megilp	m ə ɡ ɪ l p
@@ -39524,6 +40019,7 @@ melee	m ɛ l e ɪ
 melena	m ə l iː n ə
 melena	m ɛ l ɪ n ə
 melena	m ɪ l iː n ə
+melete	m ɛ l ɪ t i
 melic	m ɛ l ɪ k
 melinda	m ə l ɪ n d ə
 melinda	m ɛ l ɪ n d ə
@@ -39545,6 +40041,7 @@ mellon	m ɛ l ɒ n
 mellow	m ɛ l o ʊ
 melly	m ɛ l i
 melodeon	m ə l o ʊ d i ə n
+melodic	m ɪ l ɒ d ɪ k
 melodious	m ə l ə ʊ d i ə s
 melodrama	m ɛ l ə d ɹ ɑː m ə
 melodramata	m ɛ l ə d ɹ ɑ m ə t ə
@@ -39610,15 +40107,19 @@ mendoza	m ɛ n d o ʊ z ə
 menelaus	m ɛ n ɪ l e ɪ ə s
 menendez	m ə n ɛ n d ɛ z
 mengzhou	m ʌ ŋ d͡ʒ o ʊ
+menhaden	m ɛ n h e ɪ d ə n
 menhir	m ɛ n h ɪ ə ɹ
 menial	m iː n i ə l
 meningeal	m ɛ n ə n d͡ʒ i ə l
+meningitis	m ɛ n ɪ n d ʒ a ɪ t ɪ s
 meninx	m i n ɪ ŋ k s
 meninx	m ɛ n ɪ ŋ k s
 meniscus	m ə n ɪ s k ə s
 meniscus	m ɛ n ɪ s k ə s
 mennish	m ɛ n ɪ ʃ
 menobranch	m ɛ n ə b ɹ æ ŋ k
+menoetius	m ɪ n iː ʃ i ə s
+menoetius	m ɪ n iː ʃ ə s
 menopause	m ɛ n o ʊ p ɔː z
 menopause	m ɛ n ə p ɔː z
 menorah	m ɪ n ɔː ɹ ə
@@ -39681,6 +40182,7 @@ merc	m ɝ k
 mercantile	m ɝ k ə n t a ɪ l
 mercaptopurine	m ɚ k æ p t ə p j ʊ ɹ i n
 mercator	m ɜ ɹ k e ɪ t ɜ ɹ
+merce	m ɜː ɹ s
 merced	m ɜː r s ɛ d
 mercedes	m ɚ s e ɪ d i z
 mercenary	m ɝ s ə n ɛ ɹ i
@@ -39766,6 +40268,7 @@ meropic	m ɛ ɹ ɒ p ɪ k
 merovingian	m ɛ ɹ ə v ɪ n d͡ʒ i ə n
 merrily	m ɛ ɹ ɪ l i
 merriment	m ɛ ɹ i m ə n t
+merriment	m ɛ ɹ i m ɪ n t
 merry	m e ɪ ɹ i
 merry	m ɛ ɹ i
 merrythought	m ɛ ɹ ɪ θ ɔː t
@@ -39900,6 +40403,7 @@ metaverse	m ɛ t ə v ɜː ɹ s
 mete	m iː t
 meteor	m iː t i ɚ
 meteoric	m iː t i ɒ ɹ ɪ k
+meteorical	m iː t i ɒ ɹ ɪ k ə l
 meteorite	m i t i ə ɹ a ɪ t
 meteoritics	m iː t ɪ ə ɹ ɪ t ɪ k s
 meteorological	m i t i ə ɹ ə l ɑ d͡ʒ ɪ k l̩
@@ -39932,6 +40436,7 @@ methicilin	m ɛ θ ɪ s ɪ l ɪ n
 methicillin	m ɛ θ ɪ s ɪ l ɪ n
 methimazole	m ə θ ɪ m ə z o ʊ l
 methionine	m ɛ θ a ɪ ə n iː n
+methioninemia	m ə θ a ɪ ə n ɪ n iː m i ə
 methionyl	m ə θ a ɪ ə n ɪ l
 methoctramine	m ɛ θ ɑ k t ɹ ə m iː n
 method	m ɛ θ ə d
@@ -39962,6 +40467,8 @@ methyprylon	m ɛ θ ɪ p ɹ a ɪ l ɒ n
 metic	m ɛ t ə k
 metical	m ɛ t ɪ k ɑː l
 meticillin	m ɛ t ɪ s ɪ l ɪ n
+meticulous	m ɪ t ɪ k j u l ə s
+meticulous	m ɪ t ɪ k j ɪ l ɪ s
 metings	m iː t ɪ ŋ z
 metis	m e ɪ t iː
 metis	m e ɪ t iː s
@@ -39998,6 +40505,7 @@ metz	m ɛ t s
 metzian	m ɛ t s i ə n
 meu	m j u
 meum	m i ə m
+meuse	m j uː z
 meute	m j uː t
 mevushal	m ɪ v uː ʃ ɑː l
 mevushal	m ɪ v ʊ ʃ ə l
@@ -40006,7 +40514,6 @@ mew	m j uː
 mews	m j uː z
 mexicali	m ɛ k s ɪ k æ l i
 mexican	m ɛ k s ə k ə n
-mexican	m ɛ k s ɪ k ə n
 mexico	m ɛ k s ɪ k o ʊ
 mexicoke	m ɛ k s ɪ k ə ʊ k
 mexiletine	m ɛ k s ɪ l ə t iː n
@@ -40029,6 +40536,7 @@ mi'kmaq	m ɪ ɡ m ɔː
 mi'kmaq	m ɪ ɡ ə m ɒ k
 mia	m iː ə
 miami	m a ɪ æ m i
+miami	m a ɪ æ m ə
 miasma	m a ɪ æ z m ə
 miasma	m i æ z m ə
 miasmatic	m a ɪ ə z m æ t ɪ k
@@ -40115,6 +40623,7 @@ miculek	m ɪ t͡ʃ ə l ɛ k
 mid	m ɪ d
 midas	m a ɪ d ə s
 midazolam	m ɪ d æ z ə l æ m
+midbroad	m ɪ d b ɹ ɔː d
 midday	m ɪ d d e ɪ
 middelmannetjie	m ɪ d ə l m æ n ə k i
 middelmannetjie	m ɪ d ə l m æ n ə t͡ʃ i
@@ -40215,7 +40724,6 @@ milliary	m ɪ l i ə ɹ i
 milliary	m ɪ l j ə ɹ i
 milligram	m ɪ l ɪ ɡ ɹ æ m
 milliner	m ɪ l ɪ n ɚ
-millinery	m ɪ l n ɚ i
 millinery	m ɪ l ɪ n ɚ i
 milling	m ɪ l ɪ ŋ
 million	m ɪ l j ə n
@@ -40308,6 +40816,7 @@ minim	m ɪ n ɪ m
 minimal	m ɪ n ə m ə l
 minimifidian	m ɪ n ɪ m ɪ f ɪ d i ə n
 minimize	m ɪ n ə m a ɪ z
+minimize	m ɪ n ɪ m a ɪ z
 minimum	m ɪ n ə m ə m
 mining	m a ɪ n ɪ ŋ
 minion	m ɪ n j ə n
@@ -40415,6 +40924,8 @@ mirrour	m ɪ ɹ ə
 mirrour	m ɪ ɹ ɚ
 mirtazapine	m ɪ ɹ t æ z ə p i n
 mirth	m ɜ ɹ θ
+mirthless	m ɝ θ l ə s
+mirthless	m ɝ θ l ɪ s
 misandry	m ɪ s æ n d ɹ i
 misanswer	m ɪ s æ n s ə ɹ
 misanswer	m ɪ s ɑː n s ə ɹ
@@ -40476,6 +40987,7 @@ miser	m a ɪ z ə ɹ
 miserabilist	m ɪ z ə ɹ ə b ə l ɪ s t
 miserable	m ɪ z ə ɹ ə b ə l
 miserabler	m ɪ z ɹ ə b ə l ə ɹ
+miserere	m ɪ z ə ɹ ɛ ə ɹ i
 misericordia	m ɪ s ə ɹ ɪ k ɔː ɹ d i ə
 miserly	m a ɪ z ə ɹ l i
 misery	m ɪ z ə ɹ i
@@ -40556,6 +41068,7 @@ misregard	m ɪ s ɹ ɪ ɡ ɑː ɹ d
 misregister	m ɪ s ɹ ɛ d͡ʒ ɪ s t ə ɹ
 misremember	m ɪ s ɹ ɪ m ɛ m b ɚ
 misrepair	m ɪ s ɹ ɪ p ɛ ə ɹ
+misrepresentation	m ɪ s ɹ ɛ p ɹ ɪ z ɛ n t e ɪ ʃ ə n
 misrespect	m ɪ s ɹ ɪ s p ɛ k t
 misrule	m ɪ s ɹ uː l
 miss	m ɪ s
@@ -40731,6 +41244,7 @@ mocha	m o ʊ k ə
 mochi	m o ʊ t ʃ i
 mochi	m ɒ t ʃ i
 mock	m ɑ k
+mock	m ɔ k
 mockado	m ɒ k e ɪ d ə ʊ
 mockery	m ɑ k ə ɹ i
 mocking	m ɑ k ɪ ŋ
@@ -40782,6 +41296,7 @@ mofetil	m o ʊ f ə t ɪ l
 moffie	m ɒ f i
 moffitt	m ɒ f ɪ t
 mofo	m o ʊ f o ʊ
+mog	m ɔ ɡ
 moggy	m ɔ ɡ i
 mogollon	m o ʊ ɡ ə j o ʊ n
 mogul	m o ʊ ɡ ə l
@@ -40819,6 +41334,8 @@ mol	m o l
 mol	m o ʊ l
 mola	m o ʊ l ə
 molar	m o ʊ l ɚ
+molasses	m ə l æ s ɪ z
+molasses	m ə l ɑ s ɪ z
 mold	m o ʊ l d
 moldavite	m ɒ l d ə v ʌ ɪ t
 molding	m o ʊ l d ɪ ŋ
@@ -40837,6 +41354,7 @@ molest	m ə l ɛ s t
 molestation	m o ʊ l ɪ s t e ɪ ʃ ə n
 molester	m ə l ɛ s t ɚ
 moliminous	m o ʊ l ɪ m ɪ n ə s
+molineux	m ɒ l ɪ n j uː
 molise	m ɔ l i z e ɪ
 moll	m ɒ l
 mollie	m ɑ l i
@@ -40886,6 +41404,7 @@ moncton	m ʌ ŋ k t ə n
 monday	m ʌ n d e ɪ
 monday	m ʌ n d i
 mondegreen	m ɑ n d ə ɡ ɹ iː n
+mondial	m ɒ n d i ə l
 monet	m o ʊ n e ɪ
 monetary	m ɑ n ɪ t ɛ ɹ i
 monetary	m ʌ n ə t ɛ ɹ i
@@ -41013,6 +41532,7 @@ montenegro	m ɑ n t ɪ n i ɡ ɹ o ʊ
 monterey	m ɑ n ə ɹ e ɪ
 montero	m ɒ n t ɛ ə ɹ o ʊ
 monterrey	m ɑ n t ə ɹ e ɪ
+montes	m ɒ n t i z
 montevideo	m ɒ n t ɪ v ɪ d e ɪ ə ʊ
 montezuma	m ɒ n t ɪ z uː m ə
 montferrat	m ɑ n t f ə ɹ ɑ t
@@ -41023,6 +41543,7 @@ month	m ʌ n θ
 monthiversary	m ʌ n θ ɪ v ɝ s ə ɹ i
 monthly	m ʌ n θ l i
 months	m ʌ n θ s
+montiform	m ɒ n t ɪ f ɔː m
 montjuïc	m ɒ n t ʒ uː iː k
 montpelier	m ɑ n t p ɪ l j ɚ
 montpelier	m ɔ n t p i l i ɚ
@@ -41057,6 +41578,8 @@ moon	m u n
 moonbat	m uː n b æ t
 moonbeam	m u n b i m
 mooncake	m u n k e ɪ k
+moonflask	m uː n f l æ s k
+moonflask	m uː n f l ɑː s k
 moong	m ʊ ŋ
 moonlight	m u n l a ɪ t
 moonlit	m uː n l ɪ t
@@ -41272,7 +41795,7 @@ motionless	m o ʊ ʃ ə n l ɛ s
 motivate	m o ʊ t ɪ v e ɪ t
 motive	m o ʊ t ɪ v
 motives	m o ʊ t ɪ v z
-motley	m ɒ t l i
+motley	m ɑ t l i
 motlopi	m o ʊ t l o ʊ p i
 motor	m o ʊ t ə ɹ
 motorbike	m ə ʊ t ə ɹ b a ɪ k
@@ -41348,7 +41871,7 @@ mow	m o ʊ
 mower	m o ʊ ɚ
 mowing	m ə ʊ ɪ ŋ
 mown	m o ʊ n
-moxa	m ɒ k s ə
+moxa	m ɑ k s ə
 moxibustion	m ɒ k s ɪ b ʌ s t͡ʃ ə n
 moxie	m ɒ k s i
 moy	m ɔ ɪ
@@ -41377,6 +41900,7 @@ mses	m ɪ z ə z
 mss	m ɪ z ə z
 mth	ɛ m θ
 mthwakazi	ə m t w ɑː k ɑː z i
+mtskheta	m ə t s k e ɪ t ə
 mtso	m ɛ t s o ʊ
 mu	m j u
 mu	m j uː
@@ -41431,6 +41955,7 @@ muggy	m ʌ ɡ i
 mugham	m u ɡ ɑ m
 mugient	m j uː d͡ʒ i ə n t
 mugient	m j uː d͡ʒ ə n t
+mugwort	m ʌ ɡ w ɝ t
 mugwump	m ʌ ɡ w ʌ m p
 mugwumps	m ʌ ɡ w ʌ m p s
 muh	m ə
@@ -41464,6 +41989,7 @@ muleteer	m j uː l ə t ɪ ə ɹ
 mulga	m ʌ l ɡ ə
 mulgrave	m ʌ l ɡ ɹ e ɪ v
 mulhouse	m ə l uː z
+muliebral	m j uː l ɪ iː b ɹ ə l
 muliebrity	m j u l i ɛ b ɹ ə t i
 mull	m ʌ l
 mullah	m ʊ l ə
@@ -41475,6 +42001,7 @@ mullered	m ʊ l ə ɹ d
 mullet	m ʌ l ə t
 mullet	m ʌ l ɪ t
 mulligan	m ʌ l ɪ ɡ ə n
+mulligatawny	m ʌ l ɪ ɡ ə t ɔː n i
 mullins	m ʌ l ɪ n z
 mullion	m ʌ l i ə n
 multibillion	m ʌ l t i b ɪ l j ə n
@@ -41519,7 +42046,7 @@ mum	m ʌ m
 mumbai	m ʊ m b a ɪ
 mumble	m ʌ m b ə l
 mumchance	m ʌ m t͡ʃ æ n s
-mummerset	m ʌ m ə ɹ s ɛ t
+mummerset	m ʌ m ɚ s ɛ t
 mummiform	m ʌ m ɪ f ɔ ɹ m
 mummy	m ʌ m i
 mump	m ʌ m p
@@ -41528,6 +42055,7 @@ mums	m ʌ m z
 mun	m ʌ n
 munchies	m ʌ n t͡ʃ i z
 munchkin	m ʌ n t͡ʃ k ɪ n
+muncie	m ʌ n s i
 mund	m ʊ n d
 mund	m ʌ n d
 mundane	m ʌ n d e ɪ n
@@ -41537,11 +42065,17 @@ mundungus	m ə n d ə ŋ ɡ ə s
 mung	m uː ŋ
 mung	m ʌ ŋ
 munge	m ʌ n d͡ʒ
+munged	m ʌ n d͡ʒ d
+munged	m ʌ ŋ d
 munger	m ʌ n d͡ʒ ɚ
+munger	m ʌ ŋ ɚ
+munging	m ʌ n d͡ʒ ɪ ŋ
+munging	m ʌ ŋ ɪ ŋ
 munich	m j uː n ɪ k
 municipal	m j u n ɪ s ɪ p ə l
 municipium	m j u n ə s ɪ p i ə m
 munificence	m j uː n ɪ f ɪ s ə n s
+munificent	m j u n ɪ f ɪ s n̩ t
 munite	m j uː n a ɪ t
 munity	m j uː n ɪ t i
 munji	m ʊ n d͡ʒ i
@@ -41663,6 +42197,7 @@ mussed	m ʌ s t
 mussel	m ʌ s ə l
 musselburgh	m ʌ s ə l b ə ɹ ə
 mussitate	m ʌ s ɪ t e ɪ t
+mussitation	m ʌ s ɪ t e ɪ ʃ ə n
 mussolini	m ʊ s ə l iː n i
 mussuck	m ʌ s ə k
 mussulman	m ʌ s ə l m ə n
@@ -41754,6 +42289,7 @@ myocardial	m a ɪ o ʊ k ɑ ɹ d i ə l
 myoclonus	m a ɪ o ʊ k l o ʊ n ə s
 myofilament	m a ɪ o ʊ f ɪ l ə m ə n t
 myoglobinemia	m a ɪ o ʊ ɡ l o ʊ b ɪ n i m i ə
+myokine	m a ɪ ə ʊ k a ɪ n
 myoma	m a ɪ o ʊ m ə
 myometrium	m a ɪ ə ʊ m iː t ɹ i ə m
 myopia	m a ɪ o ʊ p i ə
@@ -41845,6 +42381,7 @@ nacelle	n ə s ɛ l
 nacho	n ɑ t͡ʃ o ʊ
 nachos	n ɑ t͡ʃ o ʊ z
 nack	n æ k
+nackawic	n æ k ə w ɪ k
 nacogdoches	n æ k ə d o ʊ t͡ʃ ɪ s
 nacre	n e ɪ k ə ɹ
 nacreous	n e ɪ k ɹ i ə s
@@ -41977,6 +42514,7 @@ naratriptan	n ɑː ɹ ə t ɹ ɪ p t æ n
 narc	n ɑː ɹ k
 narcissine	n ɑ ɹ s ɪ s i n
 narcissism	n ɑ ɹ s ə s ɪ z m
+narcissistic	n ɑ ɹ s ɪ s ɪ s t ɪ k
 narcissus	n ɑ ɹ s ɪ s ə s
 narcokleptocracy	n ɑ ɹ k o ʊ k l ɛ p t ɑ k ɹ ə s i
 narcolepsy	n ɑː ɹ k ə l ɛ p s i
@@ -41992,10 +42530,11 @@ naris	n ɛ ə ɹ ɪ s
 nark	n ɑː ɹ k
 narrabundah	n æ r ə b ʌ n d ə
 narrate	n æ ɹ e ɪ t
+narration	n æ ɹ e ɪ ʃ ə n
 narration	n ɛ ɚ ɹ e ɪ ʃ ə n
 narrative	n æ ɹ ə t ɪ v
 narrative	n ɛ ɹ ə t ɪ v
-narrator	n æ ɹ e ɪ t ə ɹ
+narrator	n æ ɹ e ɪ t ɚ
 narrow	n æ ɹ o ʊ
 narrow	n ɛ ɹ o ʊ
 narrowly	n ɛ ɹ o ʊ l i
@@ -42118,7 +42657,7 @@ nauseated	n ɔː z i e ɪ t ɪ d
 nauseatic	n ɔː z i æ t ɪ k
 nauseous	n ɔː ʃ ə s
 nauseous	n ɔː ʒ ə s
-nausicaa	n ɔː s ɪ k e ɪ ə
+nausicaa	n ɔː s ɪ k i ə
 nausicaan	n ɔː s ə k e ɪ ə n
 nautch	n ɔː t͡ʃ
 nautical	n ɑ t ɪ k ə l
@@ -42187,6 +42726,7 @@ neave	n iː v
 neb	n ɛ b
 nebbiolo	n ɛ b i o ʊ l o ʊ
 nebbish	n ɛ b ɪ ʃ
+nebentan	n ə b ɛ n t æ n
 nebracetam	n ə b ɹ æ s ɪ t æ m
 nebraska	n ə b ɹ æ s k ə
 nebuchadnezzar	n ɛ b ə k ə d n ɛ z ɚ
@@ -42221,6 +42761,8 @@ necktie	n ɛ k t a ɪ
 neckwear	n ɛ k w ɛ ɚ
 necrectomy	n ə k ɹ ɛ k t ə m i
 necrocracy	n ə k ɹ ɑ k ɹ ə s i
+necrolysis	n ə k ɹ ɔ l ə s ə s
+necrolysis	n ə k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ə s ɪ s
 necrolysis	n ɛ k ɹ ɔ l ɪ s ɪ s
 necromancer	n e k ɹ ə m æ n s ɚ
@@ -42240,7 +42782,7 @@ necropolises	n ɛ k ɹ ɒ p ɒ l ɪ s ɪ z
 necropsy	n ɛ k ɹ ɑ p s i
 necrosectomy	n ɛ k ɹ o ʊ z ɛ k t ə m i
 nectar	n ɛ k t ə ɹ
-nectarine	n ɛ k t ə ɹ i n
+nectarine	n ɛ k t ə ɹ iː n
 ned	n ɛ d
 neddy	n ɛ d i
 nederland	n i d ɚ l ə n d
@@ -42502,6 +43044,7 @@ nevin	n ɛ v ɪ n
 nevirapine	n ə v a ɪ ɹ ə p i n
 nevirapine	n ə v ɪ ɹ ə p i n
 nevis	n iː v ɪ s
+nevus	n iː v ə s
 new	n j u
 newall	n uː ə l
 newark	n uː ə ɹ k
@@ -42536,7 +43079,7 @@ newman	n u m ə n
 newness	n j uː n ə s
 newport	n u p ɔ ɹ t
 newquay	n j uː k iː
-news	n j uː z
+news	n j u z
 newsletter	n j u z l ɛ t ɚ
 newspaper	n j u z p e ɪ p ɚ
 newspapers	n u s p e ɪ p ɚ z
@@ -42859,6 +43402,7 @@ noetic	n o ʊ ɛ t ɪ k
 nog	n ɒ ɡ
 nogai	n o ʊ ɡ a ɪ
 noggin	n ɑ ɡ n̩
+noggin	n ɑ ɡ ɪ n
 nogoodnik	n o ʊ ɡ ʊ d n ɪ k
 noice	n ɔ ɪ s
 noil	n ɔ ɪ l
@@ -42986,6 +43530,8 @@ norepinephrine	n ɔː ɹ ɛ p ɪ n ɛ f ɹ ɪ n
 norethindrone	n ɔ ɹ ɛ θ ɪ n d ɹ o ʊ n
 norethisterone	n ɔ ɹ ə θ ɪ s t ə ɹ o ʊ n
 norfloxacin	n ɔ ɹ f l ɑ k s ə s ɪ n
+norfolk	n ɔː ɹ f o ʊ l k
+norfolk	n ɔː ɹ f ə k
 norgestimate	n ɔ ɹ d͡ʒ ɛ s t ɪ m e ɪ t
 norgestrel	n ɔ ɹ d͡ʒ ɛ s t ɹ ə l
 noria	n ɔ ɹ i ə
@@ -43110,7 +43656,7 @@ novemdecillion	n o ʊ v ə m d ə s ɪ l i ə n
 novercal	n ə ʊ v ɜː ɹ k ə l
 novgorod	n ɒ v ɡ ə ɹ ɒ d
 novgorod	n ɔː v ɡ ə ɹ ə t
-novice	n ɑː v ɪ s
+novice	n ɑ v ɪ s
 novitiate	n ə v ɪ ʃ i ə t
 novitious	n ə ʊ v ɪ ʃ ə s
 novity	n ɑ v ɪ t i
@@ -43192,6 +43738,7 @@ numbered	n ʌ m b ɚ d
 numberous	n ʌ m b ə ɹ ə s
 numberous	n ʌ m b ɹ ə s
 numbers	n ʌ m b ɚ z
+numby	n ʌ m i
 numchuck	n ʌ m t͡ʃ ʌ k
 numen	n uː m ə n
 numeral	n u m ə ɹ ə l
@@ -43362,7 +43909,6 @@ obedient	ə b i d i ə n t
 obediential	ə ʊ b iː d i ɛ n ʃ ə l
 obeisance	o ʊ b e ɪ s ə n s
 obeisance	o ʊ b iː s ə n s
-obeisance	ə b e ɪ s ə n s
 obeisance	ə b iː s ə n s
 obeli	ɑ b ə l a ɪ
 obelisk	ɑ b ə l ɪ s k
@@ -43428,6 +43974,8 @@ obliquation	ɒ b l ɪ k w e ɪ ʃ ə n
 oblique	o ʊ b l iː k
 oblite	ə b l a ɪ t
 obliterate	ə b l ɪ t ə ɹ e ɪ t
+obliterate	ə b l ɪ t ə ɹ ə t
+obliterated	ə b l ɪ t ə ɹ e ɪ t ɪ d
 obliviality	ə b l ɪ v i æ l ɪ t i
 oblivion	ə b l ɪ v iː ə n
 oblivious	ə b l ɪ v iː ə s
@@ -43504,7 +44052,7 @@ obtaining	ə b t e ɪ n ɪ ŋ
 obtend	ɒ b t ɛ n d
 obtend	ə b t ɛ n d
 obtest	ɒ b t ɛ s t
-obtrusive	ə b t ɹ uː s ɪ v
+obtrusive	ə b t ɹ u s ɪ v
 obtund	ɑ b t ʌ n d
 obtund	ə b t ʌ n d
 obtuse	ə b t j u s
@@ -43613,7 +44161,6 @@ octogenary	ɑ k t ɑ d͡ʒ ə n ɛ r i
 octogram	ɒ k t o ʊ ɡ ɹ æ m
 octogram	ɒ k t ə ɡ ɹ æ m
 octopawn	ɒ k t ə p ɔː n
-octopodes	ɒ k t ɒ p ə d iː z
 octopus	ɑ k t ə p ə s
 octopus	ɑ k t ə p ʊ s
 octosyllabic	ɑ k t o ʊ s ɪ l æ b ɪ k
@@ -43670,6 +44217,7 @@ odysseus	o ʊ d ɪ s i ə s
 odysseus	o ʊ d ɪ s j uː s
 odysseus	ə d ɪ s j uː s
 odyssey	ɑ d ə s i
+odyssey	ɑ d ɪ s i
 oe	o i
 oe	o ʊ
 oe	ɔ ɪ
@@ -43727,6 +44275,7 @@ officer	ɔ f ə s ɚ
 officer	ɔ f ɪ s ɚ
 officers	ɔ f ɪ s ɚ z
 offices	ɔ f ɪ s ɪ z
+officetel	ɒ f ɪ s t ɛ l
 officey	ɔ f ɪ s i
 official	ə f ɪ ʃ ə l
 officialdom	ə f ɪ ʃ ə l d ə m
@@ -43773,7 +44322,6 @@ ogler	ə ʊ ɡ ə l ə ɹ
 ogonek	o ʊ ɡ ə n ɛ k
 ogre	o ʊ ɡ ɚ
 ogress	o ʊ ɡ ɹ ɛ s
-ogress	ə ʊ ɡ ɹ ə s
 ogun	ə ʊ ɡ ə n
 oh	o ʊ
 ohana	ə h ɑː n ə
@@ -44124,6 +44672,7 @@ ophiuchus	ɑ f i j uː k ə s
 ophthalmia	ɑ p θ æ l m i ə
 ophthalmic	ɑ f θ æ l m ɪ k
 ophthalmic	ɑ p θ æ l m ɪ k
+ophthalmitis	ɒ f θ æ l m a ɪ t ɪ s
 ophthalmologist	ɑ f θ æ l m ɑ l ə d͡ʒ ɪ s t
 ophthalmologist	ɑ f θ ə l m ɑ l ə d͡ʒ ɪ s t
 ophthalmologist	ɑ p θ ə l m ɑ l ə d͡ʒ ɪ s t
@@ -44201,6 +44750,7 @@ optimistic	ɑ p t ɪ m ɪ s t ɪ k
 optimize	ɑ p t ɪ m a ɪ z
 optimum	ɑ p t ɪ m ə m
 option	ɑ p ʃ ə n
+optional	ɑ p ʃ ə n ə l
 optoacoustic	ɑ p t o ʊ ə k u s t ɪ k
 optocoupler	ɑ p t o ʊ k ʌ p l ɚ
 optoelectronics	ɑ p t o ʊ ɪ l ɛ k t ɹ ɑ n ɪ k s
@@ -44223,8 +44773,7 @@ oracle	ɒ ɹ ə k ə l
 oracle	ɔ ɹ ə k ə l
 oracular	ɔ ɹ æ k j u l ɚ
 oracular	ɔ ɹ æ k j ə l ɚ
-oral	o ɹ ə l
-oral	ɑ ɹ ə l
+oral	ɔ ɹ ə l
 orally	ɔː ɹ ə l i
 orang	o ʊ r æ ŋ
 orang	ɔ r æ ŋ
@@ -44444,6 +44993,8 @@ orthopraxy	ɔː ɹ θ ə p ɹ æ k s i
 orthopyroxene	ɔ ɹ θ o ʊ p a ɪ ɹ ɑ k s i n
 orthoquartzite	ɔ ɹ θ o ʊ k w ɔ ɹ t s a ɪ t
 orthorhombic	ɔː ɹ θ ə ɹ ɒ m b ɪ k
+orthosexual	ɔː ɹ θ ə s ɛ k s j u ə l
+orthosexual	ɔː ɹ θ ə s ɛ k ʃ u ə l
 ortiz	ɔ ɹ t i s
 ortiz	ɔ ɹ t i z
 ortolan	ɔ ɹ t ə l æ n
@@ -44511,6 +45062,7 @@ ossicone	ɒ s ɪ k ə ʊ n
 ossifier	ɒ s ɪ f a ɪ ə ɹ
 ossifrage	ɒ s ɪ f ɹ ɪ d͡ʒ
 ossify	ɑ s ə f a ɪ
+ossining	ɑ s ɪ n ɪ ŋ
 ossuarium	ɒ s j u ɛ ə ɹ i ə m
 ostensible	ɑ s t ɛ n s ɪ b ə l
 ostensibly	ɑː s t ɛ n s ə b l i
@@ -44532,6 +45084,8 @@ ostiary	ɒ s t i ə ɹ i
 ostiary	ɒ s t͡ʃ ə ɹ i
 ostinato	ɒ s t ɪ n ɑ t o ʊ
 ostler	ɑː s l ɚ
+ostracean	ɒ s t ɹ e ɪ ʃ i ə n
+ostracean	ɒ s t ɹ e ɪ ʃ ə n
 ostracize	ɑ s t ɹ ə s a ɪ z
 ostracon	ɑ s t ɹ ə k ɑ n
 ostreaceous	ɒ s t ɹ i e ɪ ʃ ə s
@@ -44541,6 +45095,7 @@ ostrich	ɔ s t ɹ ɪ d͡ʒ
 ostrich	ɔ s t ɹ ɪ t͡ʃ
 ostrichism	ɑ s t ɹ i t͡ʃ ɪ z ə m
 ostrobogulous	ɑː s t ɹ ə b ɑː ɡ j ə l ə s
+ostrogoth	ɒ s t r ə ɡ ɒ θ
 oswaldtwistle	ɒ z ə l t w ɪ z ə l
 oswego	ɒ s w iː ɡ o ʊ
 otago	ə t ɑ ɡ o ʊ
@@ -44608,6 +45163,9 @@ ounce	a ʊ n s
 ounces	a ʊ n s ɪ z
 ouphe	a ʊ f
 ouphe	uː f
+ouppy	o ʊ ʌ p i
+ouppy	u p i
+ouppy	ʌ p i
 our	a ʊ ɚ
 our	æ ɔ ə
 our	ɑ ɹ
@@ -44825,10 +45383,10 @@ overreact	o ʊ v ə ɹ ɹ i æ k t
 overreactive	o ʊ v ə ɹ ɹ i æ k t ɪ v
 overreactor	o ʊ v ə ɹ ɹ i æ k t ɚ
 overridden	o ʊ v ɚ ɹ ɪ d ə n
-override	o ʊ v ə ɹ ɹ a ɪ d
+override	o ʊ v ɚ ɹ a ɪ d
 overriding	ə ʊ v ə ɹ ɹ a ɪ d ɪ ŋ
 overrode	ə ʊ v ə ɹ ə ʊ d
-overrule	ə ʊ v ə ɹ ɹ uː l
+overrule	o ʊ v ɚ ɹ u l
 overrun	o ʊ v ɚ ɹ ʌ n
 oversaw	o ʊ v ɚ s ɔ
 oversea	ə ʊ v ə ɹ s iː
@@ -44845,7 +45403,7 @@ overshoot	o ʊ v ɚ s h u t
 overshorten	o ʊ v ɚ ʃ ɔ ɹ t ə n
 overshot	o ʊ v ɚ ʃ ɑ t
 overside	ə ʊ v ə ɹ s a ɪ d
-oversight	o ʊ v ə ɹ s a ɪ t
+oversight	o ʊ v ɚ s a ɪ t
 oversit	ə ʊ v ə ɹ s ɪ t
 overskirt	ə ʊ v ə s k ɜː t
 overslaugh	ə ʊ v ə ɹ s l ɔː
@@ -44928,6 +45486,7 @@ owie	a ʊ w iː
 owing	o ʊ ɪ ŋ
 owl	a ʊ l
 owler	a ʊ l ɚ
+owlet	a ʊ l ə t
 owlful	a ʊ l f l̩
 owlful	a ʊ l f ʊ l
 owling	a ʊ l ɪ ŋ
@@ -45076,6 +45635,7 @@ paedobaptism	p ɛ d o ʊ b æ p t ɪ z ə m
 paedomorphic	p i d ə m ɔ ɹ f ɪ k
 paedomorphic	p ɛ d ə m ɔ ɹ f ɪ k
 paedophile	p e d ə f ɑ e l
+paedophile	p iː d ə f a ɪ l
 paedopsychology	p i d o ʊ p s a ɪ k ɑ l ə d͡ʒ i
 paedopsychology	p i d o ʊ s a ɪ k ɑ l ə d͡ʒ i
 paekakariki	p a ɪ k ɑː k ɑː ɹ iː k iː
@@ -45108,6 +45668,7 @@ paginate	p æ d͡ʒ ə n e ɪ t
 pagination	p æ d͡ʒ ə n e ɪ ʃ ə n
 paging	p e ɪ d͡ʒ ɪ ŋ
 pagings	p e ɪ d͡ʒ ɪ ŋ z
+pagnol	p ɑː n j ɔː l
 pagoclone	p e ɪ ɡ ə k l ə ʊ n
 pagoda	p ə ɡ o ʊ d ə
 pah	p ɑː
@@ -45149,6 +45710,7 @@ paisa	p a ɪ s ə
 paisano	p a ɪ s ɑ n o ʊ
 paisano	p a ɪ z ɑ n o ʊ
 paise	p a ɪ s ə
+paise	p e ɪ z
 paisley	p e ɪ z l i
 pajama	p ə d͡ʒ æ m ə
 pajama	p ə d͡ʒ ɑː m ə
@@ -45350,6 +45912,7 @@ pandour	p æ n d ɔː ɹ
 pandour	p æ n d ʊ ə ɹ
 pane	p e ɪ n
 paned	p e ɪ n d
+paneer	p ə n iː ɹ
 panegyric	p æ n ə d͡ʒ a ɪ ɹ ɪ k
 panegyric	p æ n ə d͡ʒ ɪ ɹ ɪ k
 panegyrically	p æ n ə d͡ʒ ɪ ɹ ə k ə l i
@@ -45479,11 +46042,13 @@ papilla	p ə p ɪ l ə
 papillon	p æ p i ɒ n
 papillon	p æ p ɪ l ɒ n
 papillon	p ə p ɪ l i ə n
+papio	p e ɪ p iː o ʊ
 papish	p e ɪ p ɪ ʃ
 papoose	p ə p uː s
 pappardelle	p æ p ɑ ɹ d ɛ l e ɪ
 pappy	p æ p i
 paprika	p æ p ɹ iː k ə
+paprika	p æ p ɹ ɪ k ə
 paprika	p ə p ɹ iː k ə
 papula	p æ p j ʊ l ə
 papyri	p æ p ɚ a ɪ
@@ -45513,6 +46078,7 @@ paracrine	p æ ɹ ə k ɹ ɪ n
 parade	p ə r ɑ d
 parade	p ə ɹ e ɪ d
 parades	p ə ɹ e ɪ d z
+paradiastole	p ɛ r ə d a ɪ æ s t ə l i
 paradiddle	p æ ɹ ə d ɪ d ə l
 paradigm	p e ɪ ɹ ə d a ɪ m
 paradigm	p æ ɹ ə d a ɪ m
@@ -45541,6 +46107,7 @@ paragoge	p æ ɹ ə ɡ ə ʊ d͡ʒ i
 paragon	p æ ɹ ə ɡ ɑ n
 paragon	p æ ɹ ə ɡ ɔ n
 paragon	p æ ɹ ə ɡ ə n
+paragraph	p æ ɹ ə ɡ ɹ æ f
 paragraph	p ɛ ɹ ə ɡ ɹ æ f
 paragraphs	p ɛ ɹ ə ɡ ɹ æ f s
 paraguay	p æ ɹ ə ɡ w e ɪ
@@ -45644,6 +46211,7 @@ parenthetically	p æ ɹ ə n θ ɛ t ɪ k l i
 parenting	p ɛ ə ɹ ə n t ɪ ŋ
 parents	p æ ɹ ə n t s
 parents	p ɛ ɹ ə n t s
+pareo	p ɑː ɹ i ə ʊ
 parergy	p æ ɹ ə ɹ d͡ʒ i
 paresthesis	p ə ɹ iː s θ ɪ s ɪ s
 paretic	p ə ɹ ɛ t ɪ k
@@ -45804,6 +46372,7 @@ paschal	p a s k ə l
 pasco	p æ s k ə ʊ
 pash	p æ ʃ
 pasha	p ɑ ʃ ə
+pashes	p æ ʃ ɪ z
 pashto	p æ ʃ t ə ʊ
 pashto	p ʌ ʃ t ə ʊ
 pasifika	p ʌ s ɪ f ɪ k ʌ
@@ -45828,8 +46397,6 @@ passengers	p æ s ə n d͡ʒ ɚ z
 passepied	p æ s p i e ɪ
 passer	p æ s ə ɹ
 passerine	p æ s ə ɹ a ɪ n
-passerine	p æ s ə ɹ iː n
-passerine	p æ s ə ɹ ə n
 passes	p æ s ɪ z
 passify	p æ s ə f a ɪ
 passify	p æ s ɪ f a ɪ
@@ -45844,7 +46411,7 @@ passively	p æ s ɪ v l i
 passivity	p æ s ɪ v ɪ t i
 passless	p æ s l ə s
 passport	p æ s p ɔ ɹ t
-password	p æ s w ɜː ɹ d
+password	p æ s w ɝ d
 passé	p æ s e ɪ
 past	p æ s t
 pasta	p ɑ s t ə
@@ -45877,6 +46444,7 @@ pasts	p æ s t s
 pasture	p æ s t ɚ
 pasture	p æ s t͡ʃ ɚ
 pasty	p e ɪ s t i
+pasty	p æ s t i
 pat	p æ t
 patagium	p æ t ə d͡ʒ a ɪ ə m
 patagium	p ə t e ɪ d͡ʒ i ə m
@@ -46029,6 +46597,7 @@ pawpaw	p ɔː p ɔː
 pawprint	p ɔː p ɹ ɪ n t
 paws	p ɑː z
 paws	p ɔː z
+pawtucket	p ə t ʌ k ɪ t
 pax	p æ k s
 paxis	p æ k s ɪ s
 paxlovid	p æ k s l o ʊ v ɪ d
@@ -46126,7 +46695,7 @@ pecten	p ɛ k t ə n
 pecten	p ɛ k t ɪ n
 pectin	p ɛ k t ɪ n
 pectinate	p ɛ k t ə n e ɪ t
-pectoral	p ɛ k t ɔ ɹ ə l
+pectoral	p ɛ k t o ɹ ə l
 pectoral	p ɛ k t ə ɹ ə l
 peculation	p ɛ k j ʊ l e ɪ ʃ ə n
 peculiar	p ə k j uː l j ʊ ə ɹ
@@ -46289,6 +46858,7 @@ pendragon	p ɛ n d ɹ æ ɡ ə n
 pends	p ɛ n d z
 pendulum	p ɛ n d͡ʒ ə l ə m
 pendulum	p ɪ n d͡ʒ ə l ə m
+penelope	p ɪ n ɛ l ə p i
 peneplain	p iː n ɪ p l e ɪ n
 peneplain	p ɛ n ɪ p l e ɪ n
 penes	p i n i z
@@ -46315,6 +46885,7 @@ peninitial	p ɛ n ɪ n ɪ ʃ ə l
 peninsula	p ə n ɪ n s ə l ə
 peninsular	p ə n ɪ n s ə l ə ɹ
 penis	p i n ɪ s
+penises	p i n ɪ s ɪ z
 penitent	p ɛ n ɪ t ə n t
 penitential	p ɛ n ɪ t ɛ n ʃ ə l
 penitentiary	p ɛ n ɪ t ɛ n ʃ ə ɹ i
@@ -46592,6 +47163,7 @@ perniones	p ɝ n i o ʊ n i z
 perniosis	p ɝ n i o ʊ s ɪ s
 pernoctate	p ɚ n ɑ k t e ɪ t
 pernoctation	p ɜ ɹ n ɑ k t e ɪ ʃ ə n
+pernod	p ɛ ɹ n o ʊ
 peroneal	p ə ɹ o ʊ n i ə l
 peroneal	p ɛ ɹ o ʊ n iː ə l
 peronei	p ɛ ɹ ə n i a ɪ
@@ -46652,11 +47224,12 @@ personable	p ɜː ɹ s ə n ə b ə l
 personae	p ɜː ɹ s ə ʊ n a i
 personage	p ɝ s ə n ɪ d͡ʒ
 personages	p ɝ s ə n ɪ d͡ʒ ɪ z
-personal	p ɜ ɹ s n ə l
+personal	p ɝ s n ə l
 personal	p ɝ s ə n ə l
 personality	p ɝ s ə n æ l ɪ t i
 personalization	p ɝ s ə n ə l a ɪ z e ɪ ʃ ə n
-personally	p ɜː s n ə l i
+personally	p ɝ s n ə l i
+personally	p ɝ s ə n ə l i
 personator	p ɜː ɹ s ə n e ɪ t ə ɹ
 personhood	p ɝ s ə n h ʊ d
 personification	p ɚ s ɑ n ə f ə k e ɪ ʃ ə n
@@ -46752,7 +47325,7 @@ peterborough	p iː t ə ɹ b ɹ ə
 peterson	p i t ɚ s ə n
 peterview	p iː t ɚ v j uː
 pethidine	p ɛ θ ɪ d iː n
-petiole	p ɛ d i o ʊ l
+petiole	p ɛ t i o ʊ l
 petit	p ə t i
 petit	p ə t i t
 petite	p ə t iː t
@@ -46782,6 +47355,7 @@ petroleum	p ə t ɹ o ʊ l i ə m
 petrology	p ə t ɹ ɑ l ə d͡ʒ i
 petronel	p ɛ t ɹ ə n ə l
 petropavl	p ɛ t ɹ ə p ɑː v ə l
+petrophilic	p ɛ t ɹ ə f ɪ l ɪ k
 petrosal	p ə t ɹ o ʊ s ə l
 pets	p ɛ t s
 petter	p ɛ t ə ɹ
@@ -46889,6 +47463,7 @@ phatic	f æ t ɪ k
 phaëthon	f e ɪ ə t ə n
 phaëthon	f e ɪ ə θ ə n
 pheasant	f ɛ z ə n t
+pheic	f e ɪ k
 phelonion	f ə l ə ʊ n i ə n
 phelps	f ɛ l p s
 phencyclidine	f ɛ n s a ɪ k l ɪ d iː n
@@ -47127,6 +47702,7 @@ phthalic	f θ æ l ɪ k
 phthisis	f θ a ɪ s ɪ s
 phthisis	t a ɪ s ɪ s
 phthonus	θ o ʊ n ə s
+phub	f ʌ b
 phugoid	f j uː ɡ ɔ ɪ d
 phuket	p u k ɛ t
 phumdi	f u m d i
@@ -47168,6 +47744,8 @@ phytoplankton	f a ɪ t o ʊ p l æ ŋ k t ə n
 phytoplankton	f a ɪ t ə p l æ ŋ k t ə n
 pi	p a ɪ
 piaget	p j a ʒ ɛ
+pianguan	p i j ə n ɡ w ɑ n
+pianguan	p i ə n ɡ w ɑ n
 pianist	p i æ n ɪ s t
 pianist	p i ə n ɪ s t
 pianny	p a ɪ æ n i
@@ -47201,6 +47779,7 @@ piccy	p ɪ k i
 pice	p a ɪ s
 picene	p a ɪ s iː n
 piceous	p ɪ s i ə s
+picidae	p ɪ s ə d iː
 pick	p ɪ k
 pickaxe	p ɪ k æ k s
 picked	p ɪ k t
@@ -47433,7 +48012,7 @@ pinçage	p ɪ n s ɑ ʒ
 pioglitazone	p a ɪ ə ɡ l ɪ t ə z o ʊ n
 piolet	p iː ə l e ɪ
 pion	p a ɪ ɒ n
-pioneer	p a ɪ ə n ɪ ə ɹ
+pioneer	p a ɪ ə n ɪ ɹ
 pip	p ɪ p
 pipe	p a ɪ p
 piped	p a ɪ p t
@@ -47705,6 +48284,7 @@ plasterly	p l æ s t ə ɹ l i
 plasterly	p l ɑː s t ə ɹ l i
 plasterwork	p l æ s t ɚ w ɝ k
 plastic	p l æ s t ɪ k
+plastician	p l æ s t ɪ ʃ ə n
 plastron	p l æ s t ɹ ə n
 plat	p l æ t
 plate	p l e ɪ t
@@ -47792,6 +48372,7 @@ pleb	p l ɛ b
 plebe	p l i b
 plebeian	p l i b iː ə n
 plebeian	p l ɛ b iː ə n
+plebiscite	p l ɛ b ɪ s a ɪ t
 plebiscitum	p l i b ə s a ɪ t ə m
 plebiscitum	p l ɛ b ə s a ɪ t ə m
 plebs	p l ɛ b z
@@ -48053,6 +48634,7 @@ poison	p ɔ ɪ z ə n
 poisoned	p ɔ ɪ z n̩ d
 poisonous	p ɔ ɪ z n ə s
 poisonous	p ɔ ɪ z ə n ə s
+poissarde	p w a s ɑ ɹ d
 poisson	p w ɑː s ɒ n
 poissonier	p w ə s o ʊ n j e
 poitevinite	p ɔ ɪ t ə v ɪ n a ɪ t
@@ -48091,6 +48673,7 @@ polarize	p o ʊ l ə ɹ a ɪ z
 polary	p o ʊ l ə ɹ i
 pole	p o ʊ l
 polecat	p ə ʊ l k æ t
+polemarch	p ɑ l ə m ɑ ɹ k
 polemic	p ə l iː m ɪ k
 polemic	p ə l ɛ m ɪ k
 polemical	p ə l ɛ m ɪ k ə l
@@ -48138,6 +48721,8 @@ pollard	p ɑ l ɚ d
 polled	p o ʊ l d
 pollen	p ɑ l ə n
 pollicate	p ɒ l ɪ k e ɪ t
+pollinate	p ɒ l ɪ n e ɪ t
+pollination	p ɒ l ɪ n e ɪ ʃ ə n
 pollinator	p ɒ l ɪ n e ɪ t ə ɹ
 pollinivore	p ɑ l ɪ n ə v ɔː ɹ
 pollinosis	p ɑ l ə n o ʊ s ɪ s
@@ -48166,6 +48751,7 @@ polyadenous	p ɑ l i æ d ɪ n ə s
 polyarch	p ɑ l i ɑ ɹ k
 polyaxial	p ɑ l ɪ æ k s i ə l
 polychaete	p ɒ l ɪ k iː t
+polychoron	p ɔ l ɪ k o ʊ ɹ ɔ n
 polychrest	p ɒ l ɪ k ɹ ɛ s t
 polychromatic	p ɑ l i k ɹ ə m æ t ɪ k
 polycrisis	p ɒ l i k r a ɪ s ɪ s
@@ -48213,6 +48799,7 @@ polynya	p ɑ l ə n j ɑ
 polynya	p ə l ɪ n j ə
 polyp	p ɑ l ɪ p
 polypantheism	p ɒ l i p æ n θ i ɪ z ə m
+polyphemus	p ɒ l ɪ f iː m ə s
 polyphiloprogenitive	p ɒ l ɪ f ɪ l ə p ɹ ə d͡ʒ ɛ n ɪ t ɪ v
 polyptoton	p ɑ l ə p t o ʊ t ɑ n
 polyptych	p ɒ l ɪ p t ɪ k
@@ -48462,6 +49049,8 @@ portugal	p ɔ ɹ t u ɡ ɑː l
 portugal	p ɔ ɹ t͡ʃ ə ɡ ə l
 portuguese	p ɔ ɹ t͡ʃ ə ɡ i z
 pory	p ɔ ɹ i
+pos	p o ʊ z
+pos	p ɑ z
 pose	p o ʊ z
 posed	p o ʊ z d
 posedown	p ə ʊ z d a ʊ n
@@ -48672,6 +49261,7 @@ prague	p ɹ ɑː ɡ
 prahok	p ɹ ə h ɑ k
 praia	p ɹ a ɪ ə
 prairial	p ɹ ɛ ɹ j ɑ l
+prairies	p ɹ ɛ ə ɹ i z
 praise	p ɹ e ɪ z
 praised	p ɹ e ɪ z d
 praiser	p ɹ e ɪ z ə ɹ
@@ -48754,7 +49344,7 @@ precedentially	p ɹ ɛ s ə d ɛ n ʃ ə l i
 preceding	p ɹ iː s iː d ɪ ŋ
 preceding	p ɹ ɪ s iː d ɪ ŋ
 precept	p ɹ iː s ɛ p t
-preceptor	p ɹ iː s ɛ p t ə ɹ
+preceptor	p ɹ i s ɛ p t ɚ
 preceptory	p ɹ ɪ s ɛ p t ə ɹ i
 precinct	p ɹ i s ɪ ŋ k t
 preciosity	p ɹ ɛ ʃ i ɑ s ə t i
@@ -48783,9 +49373,11 @@ preconsonantal	p ɹ i k ɒ n s ə n æ n t ə l
 precosmic	p ɹ ɪ k ɒ z m ɪ k
 precounsel	p ɹ iː k a ʊ n s ə l
 precrastination	p ɹ iː k ɹ æ s t ɪ n e ɪ ʃ ə n
+precurse	p ɹ ɪ k ɜ ɹ s
 precursive	p ɹ iː k ɜː ɹ s ɪ v
 precursive	p ɹ ɪ k ɜː ɹ s ɪ v
 precursor	p ɹ iː k ɜ ɹ s ə ɹ
+precursor	p ɹ ɪ k ɜ ɹ s ə ɹ
 predal	p ɹ iː d ə l
 predate	p ɹ iː d e ɪ t
 predate	p ɹ ə d e ɪ t
@@ -48830,7 +49422,7 @@ preengage	p r iː ɪ n ɡ e ɪ d͡ʒ
 preeternity	p ɹ iː ɪ t ɜː ɹ n ɪ t i
 preface	p ɹ ɛ f ə s
 preface	p ɹ ɛ f ɪ s
-prefect	p ɹ ɪ f ɛ k t
+prefect	p ɹ iː f ɛ k t
 prefecture	p ɹ i f ɛ k t͡ʃ ə ɹ
 prefer	p ɹ ɪ f ɝ
 preferable	p ɹ ɛ f ə ɹ ə b ə l
@@ -48865,6 +49457,8 @@ premalignant	p ɹ i m ə l ɪ ɡ n ə n t
 premarin	p ɹ ɛ m ə ɹ ɪ n
 premature	p ɹ i m ə t ʊ ɹ
 premature	p ɹ i m ə t͡ʃ ʊ ɹ
+prematurely	p ɹ iː m ə t j ʊ ə ɹ l i
+prematurely	p ɹ ɛ m ə t j ʊ ə ɹ l i
 premeditate	p r iː m ɛ d ɪ t e ɪ t
 premenstrual	p ɹ i m ɛ n s t ɹ ə w ə l
 premenstrual	p ɹ i m ɛ n z t ɹ ə w ə l
@@ -48899,11 +49493,9 @@ prepared	p ɹ ɪ p ɛ ɹ d
 preparing	p ɹ ɪ p ɛ ɹ ɪ ŋ
 prepend	p ɹ ɪ p ɛ n d
 prepense	p ɹ ɪ p ɛ n s
-preplied	p ɹ ɪ p l a ɪ d
-preplies	p ɹ ɪ p l a ɪ z
-preply	p ɹ iː p l a ɪ
 preponderance	p ɹ ə p ɑ n d ə ɹ ə n s
 preponderance	p ɹ ə p ɑ n d ɹ ə n s
+preported	p ɹ ɪ p ɔ ɹ t ɪ d
 prepose	p ɹ iː p ə ʊ z
 preposition	p ɹ iː p ə z ɪ ʃ ə n
 preposition	p ɹ ɛ p ə z ɪ ʃ ə n
@@ -48936,6 +49528,7 @@ presbyter	p ɹ e s b ɪ t ɚ
 presbyter	p ɹ e z b ɪ t ɚ
 presbyterian	p ɹ e z b ɪ t ɪ ɹ i ə n
 presbytery	p ɹ ɛ z b ɪ t ɛ ɹ i
+prescience	p ɹ ɛ ʃ ɪ n s
 prescient	p ɹ iː ʃ i ə n t
 prescient	p ɹ ɛ ʃ i ə n t
 prescious	p ɹ ɛ s i ə s
@@ -49204,8 +49797,11 @@ prizings	p ɹ a ɪ z ɪ ŋ z
 prndl	p ɹ ɪ n d l̩
 pro	p ɹ o ʊ
 proa	p ɹ o ʊ ə
-proactive	p ɹ ə ʊ æ k t ɪ v
+proactive	p ɹ o ʊ æ k t ɪ v
+proactively	p ɹ o ʊ æ k t ɪ v l i
 prob'ly	p ɹ ɒ b l i
+probability	p ɹ ɑ b ə b ɪ l ə t i
+probability	p ɹ ɑ b ə b ɪ l ɪ t i
 probable	p ɹ ɑ b ə b l̩
 probably	p ɹ ɑ b l i
 probably	p ɹ ɑ b ə b l i
@@ -49350,7 +49946,7 @@ progesterone	p ɹ o ʊ d͡ʒ ɛ s t ə ɹ o ʊ n
 prognathous	p r ɑ ɡ n e ɪ θ ə s
 prognathous	p r ɑ ɡ n ə θ ə s
 prognoses	p ɹ ɑ ɡ n o ʊ s i z
-prognoses	p ɹ ɑ ɡ n o ʊ z ə s
+prognoses	p ɹ ɑ ɡ n o ʊ z ɪ z
 prognosis	p ɹ ɑ ɡ n o ʊ s i z
 prognosis	p ɹ ɑ ɡ n o ʊ s ɪ s
 prognostic	p ɹ ɒ ɡ n ɒ s t ɪ k
@@ -49413,7 +50009,7 @@ prolific	p ɹ ə l ɪ f ɪ k
 prolix	p ɹ o ʊ l ɪ k s
 prolixity	p ɹ ə l ɪ k s ɪ t i
 prolixity	p ɹ ə ʊ l ɪ k s ɪ t i
-prolly	p r ɔ l i
+prolly	p r ɑ l i
 prolly	p ɹ ɒ l i
 prologue	p ɹ o ʊ l ɑ ɡ
 prologue	p ɹ o ʊ l ɔ ɡ
@@ -49704,6 +50300,7 @@ provision	p ɹ ə v ɪ ʒ ə n
 provisional	p ɹ ə v ɪ ʒ ə n ə l
 provisions	p ɹ ə v ɪ ʒ ə n z
 proviso	p ɹ ə v a ɪ z o ʊ
+provisor	p ɹ ə v a ɪ z ə ɹ
 provisory	p ɹ ə v a ɪ z ə ɹ i
 provo	p ɹ o ʊ v o ʊ
 provocate	p ɹ ə v ɑː k e ɪ t
@@ -49786,6 +50383,7 @@ pschent	s k ɛ n t
 psephism	s iː f ɪ z ə m
 psephism	s ɛ f ɪ z ə m
 psephocracy	p s i f ɑ k ɹ ə s i
+psephology	s ɪ f ɑ l ə d͡ʒ i
 pseud	s uː d
 pseudepigrapha	s uː d ə p ɪ ɡ ɹ ə f ə
 pseudepigraphous	s j uː d ɪ p ɪ ɡ ɹ ə f ə s
@@ -49825,6 +50423,7 @@ psilophyte	s a ɪ l ə f a ɪ t
 psilosis	s a ɪ l o ʊ s ɪ s
 psilosopher	p s ɪ l ɑ s ə f ɚ
 psithurism	s ɪ θ j ʊ ə ɹ ɪ z ə m
+psittacosis	s i t ə k o ʊ s ɪ s
 psoas	s o ʊ æ s
 psoas	s o ʊ ə s
 psora	s ɔː ɹ ə
@@ -49903,6 +50502,7 @@ pubby	p ʌ b i
 pube	p j uː b
 pubes	p j uː b i z
 pubes	p j uː b z
+pubescence	p j uː b ɛ s ə n s
 pubescent	p j ʊ b ɛ s ə n t
 pubic	p j uː b ɪ k
 pubikini	p j uː b ɪ k iː n i
@@ -50031,6 +50631,7 @@ pultaceous	p ʌ l t e ɪ ʃ ə s
 pulverulent	p ʌ l v ɛ ɹ j ə l ə n t
 puma	p j uː m ə
 puma	p uː m ə
+pumicate	p j uː m ɪ k e ɪ t
 pumice	p ʌ m ɪ s
 pummel	p ʌ m ə l
 pump	p ʌ m p
@@ -50106,6 +50707,7 @@ punxsutawney	p ʌ ŋ k s ə t ɔː n i
 puny	p j u n i
 pup	p ʌ p
 pupa	p j uː p ə
+pupal	p j uː p ə l
 pupe	p j u p
 pupil	p j uː p ə l
 pupils	p j uː p ə l z
@@ -50159,7 +50761,8 @@ purported	p ə ɹ p o ʊ ɹ t ɪ d
 purported	p ə ɹ p ɔ ɹ t ɪ d
 purpose	p ɝ p ə s
 purposedly	p ɜː ɹ p ə s ɪ d l i
-purposeful	p ɜː ɹ p ə s f ə l
+purposeful	p ɝ p ə s f ə l
+purposefully	p ɝ p ə s f ə l i
 purposely	p ɝ p ə s l i
 purposes	p ɝ p ə s ɪ z
 purposive	p ɚ p ə s ɪ v
@@ -50323,6 +50926,7 @@ python	p a ɪ θ ɔ n
 pythonista	p a ɪ θ ə n ɪ s t ə
 pythons	p a ɪ θ ɑ n z
 pyx	p ɪ k s
+pyxis	p ɪ k s ɪ s
 pâté	p æ t e ɪ
 pædomorphic	p iː d ə m ɔ ɹ f ɪ k
 pædomorphic	p ɛ d ə m ɔ ɹ f ɪ k
@@ -50369,6 +50973,7 @@ qingdao	t͡ʃ ɪ ŋ d a ʊ
 qinghai	t͡ʃ ɪ ŋ h a ɪ
 qinghaosu	t͡ʃ ɪ ŋ h a ʊ s uː
 qingpu	t͡ʃ ɪ ŋ p u
+qingsongite	t͡ʃ ɪ ŋ s ɒ ŋ a ɪ t
 qinpu	t͡ʃ ɪ n p uː
 qipao	t͡ʃ iː p a ʊ
 qiqihar	t͡ʃ i t͡ʃ i h ɑ ɹ
@@ -50445,8 +51050,6 @@ quahog	k w ɔ h ɔ ɡ
 quahog	k w ə h ɑ ɡ
 quahog	k w ə h ɔ ɡ
 quaich	k w e ɪ k
-quail	k w e ɪ l
-quail	k w e ɪ ə l
 quailed	k w e ɪ l d
 quailing	k w e ɪ l ɪ ŋ
 quailings	k w e ɪ l ɪ ŋ z
@@ -50481,12 +51084,17 @@ quandary	k w ɑ n d ɹ i
 quant	k w ɒ n t
 quantal	k w ɑ n t ə l
 quantal	k w ɔ n t ə l
+quantifier	k w ɑ n t ə f a ɪ ɚ
 quantify	k w ɑː n t ə f a ɪ
 quantile	k w ɒ n t a ɪ l
 quantiles	k w ɒ n t a ɪ l z
 quantitative	k w ɑ n t ɪ t e ɪ t ɪ v
 quantities	k w ɑ n t ɪ t i z
 quantity	k w ɑ n t ɪ t i
+quantivalence	k w ɑ n t ɪ v l ə n s
+quantivalence	k w ɑ n t ɪ v ə l ə n s
+quantivalency	k w ɑ n t ɪ v l ə n s i
+quantivalency	k w ɑ n t ɪ v ə l ə n s i
 quantum	k w ɑ n t ə m
 quaoar	k w ɑː w ɑ ɹ
 quarantine	k w ɔ ɹ ə n t i n
@@ -50560,7 +51168,7 @@ queendom	k w iː n d ə m
 queenly	k w iː n l i
 queensland	k w iː n z l ə n d
 queenslander	k w i n z l ə n d ɚ
-queer	k w iː ɹ
+queer	k w ɪ ɹ
 queerdar	k w i ɹ d ɑ ɹ
 quefrency	k w i f ɹ ə n s i
 quelea	k w i l i ə
@@ -50572,6 +51180,7 @@ quentin	k w ɛ n t ɪ n
 quercetin	k w ɜː ɹ s ɪ t ɪ n
 quercine	k w ɝ s a ɪ n
 quercine	k w ɝ s ɪ n
+quercitin	k w ɜ ɹ s ɪ t ɪ n
 querent	k w ɚ ɛ n t
 querist	k w ɪ ə ɹ ɪ s t
 quern	k w ɝ n
@@ -50679,6 +51288,7 @@ quinnat	k w ɪ n ə t
 quinoa	k i n o ʊ ə
 quinoa	k i n w ɑ
 quinolone	k w ɪ n ə l o ʊ n
+quinone	k w ɪ n ə ʊ n
 quinquagenarian	k w ɪ ŋ k w ə d͡ʒ ə n ɛ ɹ i ə n
 quinquagenary	k w ɪ ŋ k w æ d͡ʒ ə n ɛ ɹ i
 quinquagenary	k w ɪ ŋ k w ə d͡ʒ ɛ n ə ɹ i
@@ -50696,8 +51306,9 @@ quintal	k w ɪ n l
 quintal	k w ɪ n t l
 quinte	k w ɪ n t i
 quintessence	k w ɪ n t ɛ s ə n s
-quintessential	k w ɪ n t ə s ɛ n ʃ ə l
-quintessentially	k w ɪ n t ɛ s ɛ n t͡ʃ ə l i
+quintessence	k w ɪ n t ɛ s ɪ n s
+quintessential	k w ɪ n t ɪ s ɛ n ʃ ə l
+quintessentially	k w ɪ n t ɪ s ɛ n ʃ ə l i
 quintet	k w ɪ n t ɛ t
 quintillion	k w ɪ n t ɪ l j ə n
 quintillionth	k w ɪ n t ɪ l i ə n θ
@@ -50708,6 +51319,7 @@ quip	k w ɪ p
 quippy	k w ɪ p i
 quipu	k i p u
 quirinus	k w ɪ ɹ a ɪ n ə s
+quirk	k w ɝ k
 quirkyalone	k w ɝ k i ə l o ʊ n
 quirl	k w ɝ l
 quirn	k w ɜː ɹ n
@@ -50733,6 +51345,7 @@ quiz	k w ɪ z
 quizzaciously	k w ɪ z e ɪ ʃ ə s l i
 quizzical	k w ɪ z ɪ k ə l
 qujing	t͡ʃ uː d͡ʒ ɪ ŋ
+qulin	k j uː l ɪ n
 qumran	k ʊ m ɹ æ n
 quo	k w o ʊ
 quoad	k w o ʊ æ d
@@ -50780,6 +51393,7 @@ rabat	ɹ ɑː b æ t
 rabat	ɹ ɑː b ɑː t
 rabat	ɹ ə b æ t
 rabato	ɹ ə b ɑː t ə ʊ
+rabaul	ɹ ə b a ʊ l
 rabbet	ɹ æ b ɪ t
 rabbi	ɹ æ b a ɪ
 rabbie	ɹ æ b i
@@ -50810,6 +51424,7 @@ racer	ɹ e ɪ s ə ɹ
 races	ɹ e ɪ s ɪ z
 racetrack	ɹ e ɪ s t ɹ æ k
 rach	ɹ e ɪ t͡ʃ
+rach	ɹ æ t ʃ
 rachel	ɹ e ɪ t͡ʃ ə l
 rachis	ɹ e ɪ k ɪ s
 rachitis	ɹ ə k ʌ ɪ t ɪ s
@@ -51019,6 +51634,7 @@ rang	ɹ æ ŋ
 range	ɹ e ɪ n d͡ʒ
 ranger	ɹ e ɪ n d͡ʒ ɚ
 ranges	ɹ e ɪ n d͡ʒ ɪ z
+rangifer	r æ n d ʒ ɪ f ə ɹ
 rangiora	ɹ a ŋ ɡ i ɔː ɹ ə
 rangle	ɹ æ ŋ ɡ l̩
 rangoon	ɹ æ ŋ ɡ uː n
@@ -51026,6 +51642,7 @@ rangy	ɹ e ɪ n d͡ʒ i
 rani	ɹ ɑː n iː
 ranitidine	ɹ ə n ɪ t ɪ d i n
 rank	ɹ æ ŋ k
+ranking	ɹ æ ŋ k ɪ ŋ
 rankism	ɹ æ ŋ k ɪ z ə m
 rankle	ɹ æ ŋ k ə l
 ranks	ɹ æ ŋ k s
@@ -51049,6 +51666,7 @@ rape	ɹ e ɪ p
 raper	ɹ e ɪ p ə ɹ
 rapey	ɹ e ɪ p i
 raphae	ɹ e ɪ f iː
+raphanus	r æ f ə n ə s
 raphe	ɹ e ɪ f i
 rapid	ɹ æ p ɪ d
 rapidity	ɹ ə p ɪ d ɪ t i
@@ -51074,7 +51692,7 @@ rapture	ɹ æ p t͡ʃ ɚ
 rapturous	ɹ æ p t͡ʃ ə ɹ ə s
 rapunzel	ɹ ə p ʌ n z ə l
 raquel	ɹ ɑː k ɛ l
-rare	ɹ ɛ ə ɹ
+rare	ɹ ɛ ɚ
 rare	ɹ ɛ ɹ
 rarely	ɹ ɛ ə ɹ l i
 rarissima	ɹ æ ɹ ɪ s ɪ m ə
@@ -51189,6 +51807,7 @@ razorback	ɹ e ɪ z ɚ b æ k
 razz	ɹ æ z
 razzmatazz	ɹ æ z m ə t æ z
 raï	ɹ a ɪ
+raï	ɹ ʌ iː
 rbar	ɹ iː b ɑ ɹ
 re	ɹ e ɪ
 re	ɹ iː
@@ -51208,7 +51827,6 @@ reactionary	ɹ i æ k ʃ ɪ n ɛ ɚ i
 reactive	ɹ iː æ k t ɪ v
 reactor	ɹ i æ k t ɚ
 read	ɹ i d
-read	ɹ iː d
 read	ɹ ɛ d
 readable	ɹ iː d ə b ə l
 reader	ɹ i d ɚ
@@ -51279,6 +51897,8 @@ reard	ɹ ɛ ə ɹ d
 reard	ɹ ɪ ə ɹ d
 reared	ɹ ɪ ɹ d
 rearguard	ɹ ɪ ə ɹ ɡ ɑ ɹ d
+rearview	ɹ i ɹ v j uː
+rearview	ɹ ɪ ɹ v j uː
 rearward	ɹ i ɹ w ɝ d
 reason	ɹ iː z ə n
 reasonable	ɹ iː z n ə b ə l
@@ -51336,6 +51956,7 @@ recant	ɹ ə k æ n t
 recap	ɹ iː k æ p
 recapitulation	ɹ iː k ə p ɪ t͡ʃ ə l e ɪ ʃ ə n
 recce	ɹ ɛ k i
+recede	ɹ ɪ s iː d
 receipt	ɹ ɪ s iː t
 receivability	ɹ ə s i v ɑ b ɪ l ɪ t i
 receive	ɹ ɪ s iː v
@@ -51431,6 +52052,7 @@ reconstitute	ɹ i k ɑ n s t ɪ t j u t
 reconstituting	ɹ i k ɑ n s t ɪ t j u t ɪ ŋ
 reconstructivist	ɹ iː k ə n s t ɹ ʌ k t ɪ v ɪ s t
 reconvoke	ɹ i k ə n v o ʊ k
+record	ɹ ɛ k ɔː ɹ d
 record	ɹ ɛ k ɚ d
 record	ɹ ɪ k ɔ ɹ d
 recordation	ɹ i k ɔ ɹ d e ɪ ʃ ə n
@@ -51498,14 +52120,14 @@ redder	ɹ ɛ d ɚ
 reddest	ɹ ɛ d ɪ s t
 reddish	ɹ ɛ d ɪ ʃ
 reddishness	ɹ ɛ d ɪ ʃ n ə s
-reddit	r ɛ d ɪ t
+reddit	ɹ ɛ d ɪ t
 reddition	ɹ ə d ɪ ʃ ə n
 redditor	ɹ ɛ d ɪ t ə ɹ
 rede	ɹ iː d
 redebug	ɹ iː d iː b ʌ ɡ
 redeem	ɹ ɪ d iː m
 redeliver	ɹ iː d ɪ l ɪ v ə ɹ
-redemption	ɹ ɪ d ɛ m ʃ ə n
+redemption	ɹ ɪ d ɛ m p ʃ ə n
 redemptory	ɹ ɪ d ɛ m p t ə ɹ i
 redesign	ɹ iː d ɪ z a ɪ n
 redesmouth	ɹ iː d z m ə θ
@@ -51627,6 +52249,7 @@ reflective	ɹ ɪ f l ɛ k t ɪ v
 reflet	ɹ ə f l e ɪ
 reflexible	ɹ ɪ f l ɛ k s ɪ b ə l
 reflexive	ɹ ə f l ɛ k s ɪ v
+refluent	ɹ ɛ f l u ə n t
 reflux	ɹ iː f l ʌ k s
 refold	ɹ iː f o ʊ l d
 reform	ɹ iː f ɔ ɹ m
@@ -51751,6 +52374,7 @@ regurgitate	ɹ ɪ ɡ ɝ d͡ʒ ə t e ɪ t
 rehab	ɹ iː h æ b
 rehal	ɹ e ɪ h ə l
 rehearsal	ɹ ɪ h ɝ s l̩
+rehearse	ɹ ɪ h ɝ s
 rehome	ɹ iː h ə ʊ m
 reich	ɹ a ɪ k
 reid	ɹ iː d
@@ -51781,6 +52405,7 @@ reinter	ɹ iː ɪ n t ɝ
 reird	ɹ i ɚ d
 reisz	ɹ a ɪ s
 reit	r iː t
+reit	ɹ iː t
 reiterant	ɹ i ɪ t ɝ ə n t
 reiterate	ɹ i ɪ t ə ɹ e ɪ t
 reiver	ɹ iː v ə ɹ
@@ -51962,6 +52587,7 @@ renaissance	ɹ ɛ n ə s ɑ n s
 renal	ɹ iː n ə l
 renaldo	ɹ ɪ n æ l d ə ʊ
 renaldo	ɹ ɪ n ɑ l d ə ʊ
+renarrative	ɹ iː n æ ɹ ə t ɪ v
 renascent	ɹ ɪ n e ɪ s ə n t
 renascent	ɹ ɪ n æ s ə n t
 renata	ɹ ə n ɑː t ʌ
@@ -52107,6 +52733,7 @@ represented	ɹ ɛ p ɹ ɪ z ɛ n t ɪ d
 representing	ɹ ɛ p ɹ ɪ z ɛ n t ɪ ŋ
 repress	ɹ ə p ɹ ɛ s
 repressed	ɹ i p ɹ ɛ s t
+repressed	ɹ ɪ p ɹ ɛ s t
 reprieve	ɹ ɪ p ɹ iː v
 reprimand	ɹ ɛ p ɹ ɪ m æ n d
 reprinted	ɹ iː p ɹ ɪ n t ɪ d
@@ -52159,6 +52786,7 @@ requested	ɹ ɪ k w ɛ s t ɪ d
 requeue	ɹ iː k j uː
 requicken	r iː k w ɪ k ə n
 requiem	ɹ ɛ k w i ə m
+requiem	ɹ ɛ k w i ɛ m
 requiescat	ɹ ɛ k w i ɛ s k æ t
 requin	ɹ i k w ɪ n
 require	ɹ ɪ k w a ɪ ɹ
@@ -52181,6 +52809,7 @@ reroute	ɹ i ɹ u t
 rerun	ɹ i ɹ ʌ n
 res	ɹ e ɪ z
 res	ɹ ɛ z
+resched	ɹ i s k ɛ d͡ʒ
 reschedule	ɹ i s k ɛ d͡ʒ u l
 reschedule	ɹ i s k ɛ d͡ʒ u ə l
 reschedule	ɹ i s k ɛ d͡ʒ ə l
@@ -52191,8 +52820,8 @@ rescrutiny	ɹ iː s k ɹ uː t ɪ n i
 rescue	ɹ ɛ s k j uː
 rescued	ɹ ɛ s k j uː d
 rese	ɹ iː z
-research	ɹ i s ɚ t͡ʃ
 research	ɹ i s ɝ t͡ʃ
+research	ɹ ɪ s ɝ t͡ʃ
 researcher	ɹ i s ɚ t͡ʃ ɚ
 researches	ɹ iː s ɚ t͡ʃ ɪ z
 researches	ɹ ɪ s ɝ t͡ʃ ɪ z
@@ -52262,6 +52891,7 @@ resolved	ɹ ɪ z ɑ l v d
 resonant	ɹ ɛ z ə n ə n t
 resonate	ɹ ɛ z ə n e ɪ t
 resorbable	ɹ ɪ z ɔː ɹ b ə b ə l
+resorcinol	ɹ ə z ɔː ɹ s ɪ n ɒ l
 resort	ɹ iː s ɔ ɹ t
 resound	ɹ i s a ʊ n d
 resound	ɹ ə s a ʊ n d
@@ -52271,6 +52901,8 @@ resoundingly	ɹ ɪ z a ʊ n d ɪ ŋ l i
 resource	ɹ i s ɔ ɹ s
 resource	ɹ ɪ s ɔ ɹ s
 resource	ɹ ɪ z ɔ ɹ s
+resources	ɹ i s ɔ ɹ s ɪ z
+resources	ɹ ɪ z ɔ ɹ s ɪ z
 respect	ɹ ɪ s p ɛ k t
 respectability	ɹ ɪ s p ɛ k t ə b ɪ l ɪ t i
 respected	ɹ ɪ s p ɛ k t ɪ d
@@ -52292,13 +52924,15 @@ respite	ɹ ɛ s p ɪ t
 resplendence	ɹ ɪ s p l ɛ n d ə n s
 resplendent	ɹ ɪ s p l ɛ n d ə n t
 respond	ɹ ə s p ɑ n d
+respond	ɹ ɪ s p ɑ n d
 responded	ɹ ə s p ɑ n d ɪ d
+responded	ɹ ɪ s p ɑ n d ɪ d
 respondee	ɹ ɪ s p ɒ n d iː
 responder	ɹ ə s p ɑ n d ɚ
 response	ɹ ɪ s p ɑ n s
 responseless	ɹ ɪ s p ɑ n s l ə s
 responseless	ɹ ɪ s p ɑ n s l ɪ s
-responsibility	ɹ ɪ s p ɒ n s ə b ɪ l ɪ t i
+responsibility	ɹ ɪ s p ɑ n s ə b ɪ l ə t i
 responsible	ɹ ɪ s p ɑ n s ə b l̩
 responsive	ɹ ɪ s p ɑ n s ɪ v
 responsiveness	ɹ ɪ s p ɒ n s ɪ v n ɪ s
@@ -52411,6 +53045,7 @@ retinal	ɹ ɛ t n ə l
 retinal	ɹ ɛ t ə n æ l
 retinal	ɹ ɛ t ə n ɔ l
 retinal	ɹ ɛ t ə n ə l
+retinopathy	ɹ ɛ t ɪ n ɑː p ə θ i
 retinue	ɹ ɛ t ɪ n j uː
 retire	ɹ i t a ɪ ɚ
 retire	ɹ ə t a ɪ ɹ
@@ -52508,7 +53143,7 @@ reverberate	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ t
 reverberation	ɹ i v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ə v ɜː ɹ b ə ɹ e ɪ ʃ ə n
 reverberation	ɹ ɪ v ɜː ɹ b ə ɹ e ɪ ʃ ə n
-reverberative	ɹ ə v ɝ b ə ɹ ə ɪ t ɪ v
+reverberative	ɹ ə v ɝ b ə ɹ e ɪ t ɪ v
 revere	ɹ ə v iː ɹ
 revered	ɹ ɪ v ɪ ə d
 reverence	ɹ ɛ v ə ɹ ə n s
@@ -52523,11 +53158,13 @@ reversal	ɹ ɪ v ɜː ɹ s ə l
 reverse	ɹ ɪ v ɝ s
 reversible	ɹ ə v ɜː ɹ s ɪ b ə l
 reversion	ɹ ə v ɚ ʒ ə n
+reversion	ɹ ɪ v ɚ ʒ ə n
 reversion	ɹ ɪ v ɜː ʃ ə n̩
 reversion	ɹ ɪ v ɜː ʒ ə n̩
 reversionary	ɹ ə v ɝ ʒ ə n ɛ ɹ i
 revert	ɹ i v ɝ t
 revert	ɹ iː v ɝ t
+revert	ɹ ɪ v ɝ t
 revertent	ɹ ɪ v ɜː ɹ t ə n t
 revertible	ɹ ɪ v ɝ t ɪ b l̩
 revictual	ɹ iː v ɪ t ə l
@@ -52729,7 +53366,6 @@ rictus	ɹ ɪ k t ə s
 rictus	ɹ ɪ k t ʊ s
 rid	ɹ ɪ d
 riddance	ɹ ɪ d ə n s
-ridden	ɹ ɪ d n̩
 riddle	ɹ ɪ d ə l
 riddled	ɹ ɪ d ə l d
 ride	ɹ a ɪ d
@@ -52965,8 +53601,9 @@ rochelle	ɹ o ʊ ʃ ɛ l
 rochester	ɹ ɑ t͡ʃ ɛ s t ɚ
 rock	ɹ ɑ k
 rockabilly	ɹ ɑː k ə b ɪ l i
+rockall	ɹ ɑ k ɔ l
 rocker	ɹ ɒ k ə ɹ
-rockery	ɹ ɒ k ə ɹ i
+rockery	ɹ ɑ k ɚ i
 rocket	ɹ ɑ k ɪ t
 rockfish	ɹ ɑ k f ɪ ʃ
 rocking	ɹ ɑ k ɪ ŋ
@@ -53065,7 +53702,10 @@ romanian	ɹ ə m e ɪ n i ə n
 romanichal	ɹ ɑ m ɪ n i t͡ʃ æ l
 romanization	ɹ ə ʊ m ə n a ɪ z e ɪ ʃ ə n
 romans	ɹ o ʊ m ə n z
+romansch	ɹ o ʊ m æ n ʃ
+romansch	ɹ o ʊ m ɑ n ʃ
 romantic	ɹ o ʊ m æ n t ɪ k
+romanticism	ɹ ə ʊ m æ n t ɪ s ɪ z ə m
 romaphobia	ɹ o ʊ m ə f o ʊ b i ə
 romaphobia	ɹ ə ʊ m ə f ə ʊ b i ə
 romaunt	ɹ ə m ɔː n t
@@ -53142,7 +53782,7 @@ roraima	ɹ ə ʊ ɹ a ɪ m ə
 roral	ɹ ɔː ɹ ə l
 roration	r ə r e ɪ ʃ ə n
 rore	ɹ ɔ ɹ
-rorqual	ɹ ɒ ɹ k w ə l
+rorqual	ɹ ɔ ɹ k w ə l
 rort	ɹ ɔː ɹ t
 rorty	ɹ ɔː t i
 rory	ɹ o ə ɹ i
@@ -53228,7 +53868,7 @@ roubaisian	ɹ o ʊ b e ɪ ʒ ə n
 roubaix	ɹ u b e ɪ
 rouble	ɹ uː b ə l
 rouf	ɹ ɔː f
-rouge	ɹ uː ʒ
+rouge	ɹ u ʒ
 rouged	ɹ uː ʒ d
 rough	ɹ ʌ f
 roughage	ɹ ʌ f ɪ d͡ʒ
@@ -53266,6 +53906,7 @@ roussillon	ɹ uː s iː j ə n
 roust	ɹ a ʊ s t
 rout	ɹ a ʊ t
 route	ɹ a ʊ t
+route	ɹ u t
 route	ɹ uː t
 router	ɹ a ʊ t ɚ
 router	ɹ u t ɚ
@@ -53342,6 +53983,7 @@ rubescent	ɹ uː b ɛ s ə n t
 rubicon	ɹ u b ə k ɑ n
 rubicund	ɹ u b ə k ə n d
 rubidomycin	ɹ u b ɪ d o ʊ m a ɪ s n̩
+rubigo	ɹ uː b a ɪ ɡ ə ʊ
 rubin	ɹ uː b ɪ n
 ruble	ɹ uː b ə l
 rubric	ɹ uː b ɹ ɪ k
@@ -53408,7 +54050,7 @@ rule	ɹ uː l
 ruled	ɹ uː l d
 ruler	ɹ u l ɚ
 rulership	ɹ uː l ə ɹ ʃ ɪ p
-rules	ɹ uː l z
+rules	ɹ u l z
 ruling	ɹ uː l ɪ ŋ
 rulley	ɹ ʌ l i
 ruly	ɹ uː l i
@@ -53445,7 +54087,7 @@ runned	ɹ ʌ n d
 runnel	ɹ ʌ n l
 runnel	ɹ ʌ n ə l
 runner	ɹ ʌ n ɚ
-running	ɹ ʌ n ɪ ŋ
+running	ɹ ʌ n i ŋ
 runny	ɹ ʌ n i
 runout	ɹ ʌ n a ʊ t
 runs	ɹ ʌ n z
@@ -53483,6 +54125,8 @@ russet	ɹ ʌ s ɪ t
 russia	ɹ ʌ ʃ ə
 russian	ɹ ʌ ʃ ə n
 russias	ɹ ʌ ʃ ə s
+russify	ɹ uː s ɪ f a ɪ̯
+russify	ɹ ʌ s ɪ f a ɪ̯
 russki	ɹ u s k i
 russo	ɹ u s o ʊ
 russophilia	ɹ ʌ s ə f ɪ l i ə
@@ -53532,6 +54176,7 @@ rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ɒ l ɪ t ə
 rzeczpospolita	ʒ ɛ t͡ʃ p ɒ s p ə l a ɪ t ə
 rzeszów	ʒ ɛ ʃ uː f
 réaumur	ɹ e ɪ ə ʊ m j ʊ ə ɹ
+résumé	ɹ ɛ z ə m e ɪ
 röntgen	ɹ ɜː n t ɡ ə n
 rösti	ɹ ɔ s t i
 rösti	ɹ ʊ ʃ t i
@@ -53774,6 +54419,7 @@ salination	s æ l ə n e ɪ ʃ ə n
 saline	s e ɪ l iː n
 salinely	s ə l iː n l i
 salinification	s ə l ɪ n ə f ə k e ɪ ʃ ə n
+saliniform	s ə l ɪ n ɪ f ɒ ɹ m
 salinity	s e ɪ l ɪ n ə t i
 salipenter	s æ l ɪ p ɛ n t ɚ
 salique	s e ɪ l ɪ k
@@ -53783,6 +54429,7 @@ salish	s e ɪ l ɪ ʃ
 salishan	s e ɪ l ɪ ʃ ə n
 saliva	s ə l a ɪ v ə
 salivant	s æ l ə v ə n t
+salivarium	s æ l ɪ v ɛ ɹ iː ə m
 salivary	s æ l ɪ v ɛ ɹ i
 salivate	s æ l ɪ v e ɪ t
 salivous	s ə l a ɪ v ə s
@@ -53877,6 +54524,10 @@ sammamish	s ə m æ m ɪ ʃ
 sammy	s æ m i
 samnite	s æ m n a ɪ t
 samoa	s ə m o ʊ ə
+samogitia	s æ m o ʊ ɡ i ʃ ə
+samogitia	s æ m ə ɡ i ʃ ə
+samogitian	s æ m o ʊ ɡ i ʃ ə n
+samogitian	s æ m ə ɡ i ʃ ə n
 samos	s e ɪ m ɒ s
 samosata	s ə m ɒ s ə t ə
 samothracian	s æ m o ʊ θ ɹ e ɪ ʃ i ə n
@@ -53998,6 +54649,7 @@ sapphic	s æ f ɪ k
 sapphire	s æ f a ɪ̯ ɚ
 sapphism	s æ f ɪ z m̩
 sappho	s æ f ə ʊ
+sappie	s æ p i
 sappy	s æ p i
 saprophyte	s æ p ɹ ə ʊ f a ɪ t
 sapsucker	s æ p s ʌ k ə ɹ
@@ -54090,7 +54742,7 @@ sat	s æ t
 sat	ɛ s e ɪ̯ t i
 sata	s e ɪ t ə
 sata	s æ t ə
-satan	s e ɪ ʔ n̩
+satan	s e ɪ t n̩
 satanic	s e ɪ t æ n ɪ k
 satanism	s e ɪ t ə n ɪ z m
 satay	s æ t e ɪ
@@ -54353,12 +55005,14 @@ sceptic	s k ɛ p t ɪ k
 sceptral	s ɛ p t ɹ ə l
 sceptre	s ɛ p t ɚ
 scetavajasse	ʃ e ɪ t ə v a ɪ ɑː s e ɪ
+schachter	ʃ æ k t ɚ
 schadenfreude	ʃ ɑː d ə n f ɹ ɔ ɪ d ə
 schaerbeek	s k ɑ ɹ b e ɪ k
 schappe	ʃ æ p
 schappe	ʃ ɑ p ə
 scharnhorst	ʃ ɑː ɹ n h ɔː ɹ s t
 schatz	ʃ æ t s
+sched	s k ɛ d͡ʒ
 schediaphilia	s k ɛ d i ə f ɪ l i ə
 schedule	s k ɛ d͡ʒ u l
 schedule	s k ɛ d͡ʒ u ə l
@@ -54422,6 +55076,7 @@ schloop	ʃ l uː p
 schloopy	ʃ l uː p i
 schlub	ʃ l ʌ b
 schlubby	ʃ l ʌ b i
+schlump	ʃ l ʌ m p
 schmaltz	ʃ m ɒ l t s
 schmaltzy	ʃ m ɒ l t s i
 schmear	ʃ m ɪ ə ɹ
@@ -54431,7 +55086,7 @@ schmidt	ʃ m ɪ t
 schmo	ʃ m ə ʊ
 schmooze	ʃ m uː z
 schmuck	ʃ m ʌ k
-schmutz	ʃ m ʌ t s
+schmutz	ʃ m ʊ t s
 schnapper	ʃ n æ p ɚ
 schnapps	ʃ n æ p s
 schnapps	ʃ n ɑ p s
@@ -54490,7 +55145,7 @@ sciatica	s a ɪ æ t ɪ k ə
 science	s a ɪ ə n s
 scientific	s a ɪ ə n t ɪ f ɪ k
 scientifiction	s a ɪ ə n t ɪ f ɪ k ʃ ə n
-scientist	s a ɪ ə n t ɪ s t
+scientist	s a ɪ ə n t ə s t
 scif	s k ɪ f
 scilicet	s ɪ l ɪ s ɛ t
 scimitar	s ɪ m ɪ t ɑː ɹ
@@ -54590,7 +55245,6 @@ scots	s k ɒ t s
 scotsman	s k ɑ t s m ə n
 scott	s k ɒ t
 scottish	s k ɑ t ɪ ʃ
-scotus	s k o ʊ t ə s
 scoundrel	s k a ʊ̯ n d ɹ ə l
 scour	s k a ʊ ɚ
 scour	s k a ʊ ɹ
@@ -54767,7 +55421,7 @@ sealocked	s i l ɑ k t
 seals	s iː l z
 seam	s iː m
 seaman	s iː m ə n
-seamen	s iː m ə n
+seamen	s iː m ɛ n
 seaming	s iː m ɪ ŋ
 seams	s iː m z
 seamus	ʃ e ɪ m ə s
@@ -54993,6 +55647,7 @@ selene	s ə l i n i
 selenium	s ə l iː n i ə m
 selenium	s ɪ l iː n i ə m
 selenolatry	s ɛ l ɪ n ɒ l ə t ɹ i
+selenophobia	s ə l i n ə f o ʊ b i ə
 seletracetam	s ɛ l ɪ t ɹ æ s ɪ t æ m
 seleucia	s ə l u ʃ i ə
 seleucia	s ə l u ʃ ə
@@ -55111,6 +55766,7 @@ senedd	s ɛ n ɛ ð
 senegal	s ɛ n ɪ ɡ ɑː l
 senegal	s ɛ n ɪ ɡ ɔː l
 senesce	s ə n ɛ s
+senescence	s ɪ n ɛ s ə n s
 seneschal	s ɛ n ə ʃ ə l
 senex	s ɛ n ɛ k s
 senhor	s ɪ n j ɔː ɹ
@@ -55239,6 +55895,7 @@ sequester	s ɪ k w ɛ s t ɚ
 sequestrate	s iː k w ə s t ɹ e ɪ t
 sequestrator	s iː k w ə s t ɹ e ɪ t ə ɹ
 sequin	s iː k w ɪ n
+sequined	s iː k w ɪ n d
 sequitur	s ɜ k w ə t ɚ
 sequitur	s ɜ k w ə t ʊ ɹ
 sequoia	s ɪ k w ɔ ɪ ə
@@ -55275,7 +55932,6 @@ seriema	s ɛ ɹ ɪ iː m ə
 series	s i ɹ i z
 series	s ɪ ɹ i z
 serif	s ə ɹ i f
-serif	s ɛ ɹ ə f
 serif	s ɛ ɹ ɪ f
 seriocomical	s ɪ ə ɹ i ə ʊ k ɒ m ɪ k ə l
 serious	s ɪ ɚ i ə s
@@ -55289,13 +55945,13 @@ sermocinator	s ɜː ɹ m ɒ s ɪ n e ɪ t ə ɹ
 sermon	s ɝ m ə n
 sermountain	s ɝ m a ʊ n t ə n
 serodisclosure	s ɪ ə ɹ ə ʊ d ɪ s k l ə ʊ ʒ ə ɹ
+serosal	s ɪ ɹ o ʊ z ə l
 serotinal	s ə ɹ ɒ t ɪ n ə l
 serotonin	s ɛ ɹ ə t o ʊ n ɪ n
 serow	s ə ɹ o ʊ
 serpens	s ɚ p ə n z
 serpent	s ɝ p ə n t
 serpentine	s ɝ p ə n t a ɪ n
-serpentine	s ɝ p ə n t i n
 serpet	s ɜː ɹ p ɪ t
 serpette	s ɜː ɹ p ɛ t
 serrano	s ə ɹ ɑː n ə ʊ
@@ -55352,6 +56008,7 @@ setebos	s ɛ t ɛ b ʌ s
 seth	s ɛ θ
 setiferous	s iː t ɪ f ə ɹ ə s
 setiform	s iː t ə f ɔ ɹ m
+setiger	s iː t ɪ d ʒ ə ɹ
 setim	s iː t ɪ m
 setpoint	s ɛ t p ɔ ɪ n t
 setpoints	s ɛ t p ɔ ɪ n t s
@@ -55532,6 +56189,7 @@ shamefully	ʃ e ɪ m f ə l i
 shames	ʃ e ɪ m z
 shamisen	ʃ æ m ɪ s ɛ n
 shamois	ʃ æ m i
+shamone	ʃ ʌ m ə ʊ n
 shampers	ʃ æ m p ə ɹ z
 shampoo	ʃ æ m p uː
 shamrock	ʃ æ m ɹ ɑ k
@@ -55564,7 +56222,7 @@ shapeshifter	ʃ e ɪ p ʃ ɪ f t ɚ
 shapiro	ʃ ə p a ɪ ɹ o ʊ
 shapiro	ʃ ə p ɪ ɹ o ʊ
 shard	ʃ ɑ ɹ d
-share	ʃ ɛ ə ɹ
+share	ʃ ɛ ɚ
 shareable	ʃ ɛ ə ɹ ə b ə l
 sharebait	ʃ ɛ ɹ b e ɪ t
 shared	ʃ ɛ ɹ d
@@ -55632,6 +56290,7 @@ sheathbill	ʃ iː θ b ɪ l
 sheathe	ʃ i ð
 sheathed	ʃ iː ð d
 sheathed	ʃ iː θ t
+sheaths	ʃ iː ð z
 sheathy	ʃ iː θ i
 sheave	ʃ iː v
 sheba	ʃ iː b ə
@@ -55651,13 +56310,14 @@ sheepish	ʃ iː p ɪ ʃ
 sheepishly	ʃ iː p ɪ ʃ l i
 sheeple	ʃ iː p ə l
 sheepshank	ʃ i p ʃ æ ŋ k
-sheer	ʃ i ɹ
+sheer	ʃ ɪ ɹ
 sheers	ʃ ɪ ɹ z
 sheesh	ʃ iː ʃ
 sheet	ʃ i t
 sheets	ʃ i t s
 sheffield	ʃ ɛ f iː l d
 sheik	ʃ e ɪ k
+sheik	ʃ i k
 sheikdom	ʃ e ɪ k d ə m
 sheikdom	ʃ iː k d ə m
 sheila	ʃ iː l ə
@@ -55688,6 +56348,7 @@ shemagh	ʃ ə m ɑː ɡ
 shemaiah	ʃ ɛ m ɛ j ɑː
 shemale	ʃ i m e ɪ l
 shemales	ʃ i m e ɪ l z
+shen	ʃ ɛ n
 shenanigan	ʃ ə n æ n ɪ ɡ ə n
 shenanigans	ʃ ə n æ n ə ɡ ɪ n z
 shend	ʃ ɛ n d
@@ -55904,7 +56565,7 @@ shooting	ʃ uː t ɪ ŋ
 shootout	ʃ uː t a ʊ t
 shoots	ʃ uː t s
 shop	ʃ ɑ p
-shopkeeper	ʃ ɒ p k iː p ə
+shopkeeper	ʃ ɒ p k iː p ɚ
 shoplet	ʃ ɑ p l ə t
 shoplift	ʃ ɒ p l ɪ f t
 shopper	ʃ ɑ p ɚ
@@ -55983,8 +56644,8 @@ shreddy	ʃ ɹ ɛ d i
 shrek	ʃ ɹ ɛ k
 shrew	ʃ ɹ uː
 shrewd	ʃ ɹ uː d
-shrewsbury	ʃ ɹ uː z b ɹ ɪ
-shrewsbury	ʃ ɹ ə ʊ z b ɹ ɪ
+shrewsbury	ʃ ɹ o ʊ z b ə ɹ i
+shrewsbury	ʃ ɹ u z b ə ɹ i
 shriek	ʃ ɹ iː k
 shrieky	ʃ ɹ iː k i
 shrieval	ʃ ɹ iː v ə l
@@ -56047,6 +56708,9 @@ shunt	ʃ ə n t
 shunt	ʃ ʌ n t
 shuntak	ʃ ʌ n t æ k
 shunto	ʃ ʊ n t o ʊ
+shuriken	ʃ uː ɹ ɪ k ə n
+shuriken	ʃ ɝ ɪ k ə n
+shuriken	ʃ ʊ ə ɹ ɪ k ə n
 shush	ʃ ʊ ʃ
 shush	ʃ ʌ ʃ
 shuswap	ʃ uː ʃ w ɑː p
@@ -56090,11 +56754,14 @@ sic	s ɪ k
 siccawei	s ɪː k ɑː w e ɪ
 siccawei	s ɪː k ə w e ɪ
 sice	s a ɪ s
+sicel	s ɪ k ə l
+sicel	s ɪ s ə l
 sich	s iː t͡ʃ
 sichuan	s ɛ t͡ʃ w ɑ n
 sichuan	s ɛ ʃ w ɑ n
 sichuan	s ɪ t͡ʃ w ɑ n
 sicilia	s ɪ s ɪ l j ə
+sicily	s ɪ s ɪ l i
 sick	s ɪ k
 sickbed	s ɪ k b ɛ d
 sicken	s ɪ k ə n
@@ -56113,6 +56780,7 @@ siddur	s ɪ d ʊ ə
 side	s a ɪ d
 sideboob	s a ɪ d b u b
 sideburns	s a ɪ d b ɚ n z
+sidecar	s a ɪ d k ɑ ɹ
 sidekick	s a ɪ d k ɪ k
 sideline	s a ɪ d l a ɪ n
 sidequest	s a ɪ d k w ɛ s t
@@ -56302,6 +56970,7 @@ simply	s ɪ m p l i
 simpson	s ɪ m p s ə n
 simul	s ɪ m ə l
 simulacrum	s i m j ə l e ɪ k ɹ ə m
+simulant	s ɪ m j ʊ l ə n t
 simular	s ɪ m j ʊ l ə ɹ
 simulate	s ɪ m j ə l e ɪ t
 simulate	s ɪ m j ə l ə t
@@ -56598,11 +57267,13 @@ skoliosexual	s k o ʊ l i o ʊ s ɛ k ʃ u ə l
 skookum	s k uː k ə m
 skoosh	s k u ʃ
 skopje	s k ɔ p j ɛ
+skopostheorie	s k ə ʊ p ə ʊ s t e ɪ ə ɹ iː
 skoracki	s k ə ɹ æ k i
 skosh	s k o ʊ ʃ
 skosh	s k ɑ ʃ
 skraeling	s k ɹ e ɪ l ɪ ŋ
 skrike	s k ɹ a ɪ k
+skrunkly	s k ɹ ʌ ŋ k l i
 sku	s k j uː
 sku	s k uː
 sku	ɛ s k e ɪ j uː
@@ -56714,6 +57385,7 @@ sleazy	s l iː z i
 sleb	s l ɛ b
 sled	s l ɛ d
 sledge	s l ɛ d͡ʒ
+sledgehammer	s l ɛ d͡ʒ h æ m ɚ
 sledger	s l ɛ d͡ʒ ə ɹ
 sleek	s l iː k
 sleekly	s l iː k l i
@@ -56816,12 +57488,14 @@ sloot	s l uː ɪ t
 slop	s l ɒ p
 slope	s l o ʊ p
 sloping	s l o ʊ p ɪ ŋ
-sloppy	s l ɒ p i
+sloppy	s l ɑ p i
 slopy	s l ə ʊ p i
+slosh	s l ɒ ʃ
 sloshed	s l ɑ ʃ t
 sloshy	s l ɒ ʃ i
 slot	s l ɑ t
 sloth	s l ɔ θ
+slothen	s l ɔ θ ə n
 sloths	s l ɑ θ s
 slouch	s l a ʊ t͡ʃ
 slough	s l a ʊ
@@ -57008,6 +57682,7 @@ snacker	s n æ k ə ɹ
 snackery	s n æ k ə ɹ iː
 snackless	s n æ k l ə s
 snacky	s n æ k i
+snaefell	s n e ɪ f ɛ l
 snaffle	s n æ f ə l
 snafu	s n æ f uː
 snag	s n æ ɡ
@@ -57220,6 +57895,7 @@ sodalite	s o ʊ d ə l a ɪ t
 sodality	s o ʊ d æ l ɪ t i
 sodar	s o ʊ d ɑ ɹ
 sodden	s ɑ d ə n
+sodiasm	s ə ʊ d ɪ ə z ə m
 sodium	s o ʊ d i ə m
 sodom	s ɑ d ə m
 sodomise	s ɒ d ə m a ɪ z
@@ -57260,9 +57936,10 @@ soho	s ɔ ʊ h ɔ ʊ
 soho	s ə ʊ h ə ʊ
 soigneur	s w ʌ n j ɝ
 soigné	s w ɑ n j e ɪ
-soil	s ɔ ɪ l
+soil	s ɔ ɪ l̩
 soilage	s ɔ ɪ l ɪ d͡ʒ
 soiree	s w ɑː ɹ e ɪ
+soja	s ə ʊ d ʒ ə
 sojourn	s o ʊ d͡ʒ ɚ n
 sojourner	s o ʊ d͡ʒ ɝ n ɚ
 soju	s o ʊ d͡ʒ uː
@@ -57296,6 +57973,7 @@ solely	s o ʊ l l i
 solemn	s ɑ l ə m
 solemnity	s ə l ɛ m n ɪ t i
 solemnly	s ɑ l ə m l i
+solen	s ə ʊ l ə n
 solent	s ə ʊ l ə n t
 soleus	s o ʊ l i ə s
 solfège	s ɒ l f e ɪ ʒ
@@ -57397,6 +58075,7 @@ songhai	s ɒ ŋ ɡ a ɪ
 songket	s ɒ ŋ k ɛ t
 songline	s ɒ ŋ l a ɪ n
 songs	s ɑ ŋ z
+songs	s ɔ ŋ z
 songster	s ɒ ŋ s t ə ɹ
 songstress	s ɑ ŋ ɡ s t ɹ ɪ s
 songy	s ɑ ŋ i
@@ -57419,7 +58098,7 @@ sooey	s uː i
 sook	s u k
 sook	s uː k
 sook	s ʊ k
-soon	s uː n
+soon	s u n
 soondae	s uː n d e ɪ
 sooner	s u n ɚ
 soopolallie	s uː p ə l æ l i
@@ -57643,7 +58322,7 @@ spankingly	s p æ ŋ k ɪ ŋ l i
 spanky	s p æ ŋ k i
 spanner	s p æ n ɚ
 spar	s p ɑ ɹ
-spare	s p ɛ ə ɹ
+spare	s p ɛ ɚ
 spared	s p ɛ ɹ d
 sparerib	s p ɛ ɚ ɹ ɪ b
 sparfloxacin	s p ɑ ɹ f l ɑ k s ə s ɪ n
@@ -57658,6 +58337,7 @@ sparring	s p ɑː ɹ ɪ ŋ
 sparrow	s p æ ɹ o ʊ
 sparrow	s p ɛ ɹ o ʊ
 sparse	s p ɑː ɹ s
+sparsentan	s p ɑː ɹ s ɛ n t æ n
 sparta	s p ɑː ɹ t ə
 spartacus	s p ɑː ɹ t ə k ə s
 spartan	s p ɑː ɹ t ə n
@@ -57668,6 +58348,8 @@ spasmodic	s p æ z m ɑ d ɪ k
 spastic	s p æ s t ɪ k
 spat	s p æ t
 spatchcock	s p æ t͡ʃ k ɑ k
+spatchcocked	s p æ t͡ʃ k ɑ k t
+spatchcocking	s p æ t͡ʃ k ɑ k ɪ ŋ
 spate	s p e ɪ t
 spathal	s p e ɪ ð ə l
 spathe	s p e ɪ ð
@@ -57786,6 +58468,7 @@ spending	s p ɛ n d ɪ ŋ
 spendthrift	s p ɛ n d θ ɹ ɪ f t
 spenser	s p ɛ n s ə ɹ
 spent	s p ɛ n t
+sperage	s p ɛ ɹ ɪ d ʒ
 sperate	s p ɪ ə ɹ ə t
 sperge	s p ɜː ɹ d͡ʒ
 sperm	s p ɜː ɹ m
@@ -57845,6 +58528,7 @@ spider	s p a ɪ̯ d ɚ
 spiderling	s p a ɪ d ɚ l ɪ ŋ
 spiderweb	s p a ɪ̯ d ə w ɛ b
 spidey	s p a ɪ d i
+spie	s p a ɪ
 spiedie	s p iː d i
 spiel	s p iː l
 spiel	ʃ p iː l
@@ -57920,11 +58604,15 @@ spiritualism	s p ɪ ɹ ɪ t͡ʃ u ə l ɪ z ə m
 spiritualism	s p ɪ ɹ ɪ t͡ʃ ə l ɪ z ə m
 spirituality	s p ɪ ɹ ə t͡ʃ u æ l ə t ɪ
 spirochete	s p a ɪ ɹ ə k i t
+spirocheticidal	s p a ɪ r o ʊ k i t ɪ s a ɪ d ə l
 spirochetocidal	s p a ɪ r o ʊ k i t ə s a ɪ d ə l
+spirochetolysis	s p a ɪ r o ʊ k i t ɒ l ɪ s ɪ s
+spirochetolytic	s p a ɪ r o ʊ k i t ə l ɪ t ɪ k
+spirochetostatic	s p a ɪ r o ʊ k i t ə s t æ t ɪ k
 spirometer	s p a ɪ ɹ ɑ m ə t ɚ
 spironolactone	s p a ɪ ɹ ə n o ʊ l æ k t o ʊ n
+spironolactone	s p ɪ ɚ ə n ə l æ k t o ʊ n
 spironolactone	s p ɪ ɹ o ʊ n ə l æ k t o ʊ n
-spironolactone	s p ɪ ɹ ə n ə l æ k t o ʊ n
 spirulina	s p a ɪ ɹ ə l iː n ə
 spirulina	s p ɪ ɹ j ʊ l iː n ə
 spirulina	s p ɪ ɹ ə l iː n ə
@@ -57997,6 +58685,7 @@ spondylosis	s p ɒ n d ɪ l ə ʊ s ɪ s
 sponge	s p ʌ n d͡ʒ
 sponger	s p ʌ n d͡ʒ ɚ
 spongy	s p ʌ n d͡ʒ i
+sponk	s p ɒ ŋ k
 sponsor	s p ɑ n s ə ɹ
 spontaneous	s p ɑ n t e ɪ n i ə s
 spontaneously	s p ɑ n t e ɪ n i ə s l i
@@ -58047,6 +58736,8 @@ spouge	s p uː d͡ʒ
 spousal	s p a ʊ s ə l
 spousal	s p a ʊ z ə l
 spouse	s p a ʊ s
+spouses	s p a ʊ s ɪ z
+spouses	s p a ʊ z ɪ z
 spout	s p a ʊ t
 spouty	s p a ʊ t i
 sprachbund	s p ɹ ɑ k b ʊ n d
@@ -58067,7 +58758,7 @@ spread	s p ɹ ɛ d
 spreadable	s p ɹ ɛ d ə b ə l
 spreader	s p ɹ ɛ d ɚ
 spreading	s p ɹ ɛ d ɪ ŋ
-spreadsheet	s p r ɛ d ʃ iː t
+spreadsheet	s p ɹ ɛ d ʃ i t
 spreath	s p ɹ iː θ
 spree	s p ɹ e ɪ
 spree	s p ɹ iː
@@ -58248,7 +58939,6 @@ stabbed	s t æ b d
 stabbing	s t æ b ɪ ŋ
 stabenow	s t æ b ɪ n a ʊ
 stabiliment	s t ə b ɪ l ɪ m ə n t
-stability	s t ə b ɪ l ɪ d i
 stability	s t ə b ɪ l ɪ t i
 stabilization	s t e ɪ b ə l a ɪ z e ɪ ʃ ə n
 stabilization	s t e ɪ b ə l ɪ z e ɪ ʃ ə n
@@ -58286,7 +58976,7 @@ staid	s t e ɪ d
 stain	s t e ɪ n
 stained	s t e ɪ n d
 stainer	s t e ɪ n ɚ
-stair	s t ɛ ə ɹ
+stair	s t ɛ ɚ
 staircase	s t ɛ ɹ k e ɪ s
 staired	s t ɛ ɹ d
 stairs	s t ɛ ɹ z
@@ -58378,7 +59068,7 @@ starbucks	s t ɑː ɹ b ʌ k s
 starch	s t ɑ ɹ t͡ʃ
 stardom	s t ɑ ɹ d ə m
 stardust	s t ɑ ɹ d ʌ s t
-stare	s t ɛ ə ɹ
+stare	s t ɛ ɚ
 stared	s t ɛ ɹ d
 starey	s t ɛ ə ɹ i
 starfish	s t ɑː ɹ f ɪ ʃ
@@ -58407,6 +59097,7 @@ starvation	s t ɑ ɹ v e ɪ ʃ ə n
 starve	s t ɑ ɹ v
 starven	s t ɑ ɹ v ə n
 starving	s t ɑ ɹ v ɪ ŋ
+stary	s t ɛ ə ɹ ɪ
 stash	s t æ ʃ
 stasi	s t ɑː z i
 stasi	ʃ t ɑː z i
@@ -58448,6 +59139,8 @@ statler	s t æ t l ə ɹ
 statoid	s t e ɪ t ɔ ɪ d
 statuary	s t æ t͡ʃ u ɛ ə ɹ i
 statue	s t æ t͡ʃ u
+statuette	s t æ t j u ɛ t
+statuette	s t æ t ʃ u ɛ t
 statuminate	s t ə t j uː m ɪ n e ɪ t
 statuminate	s t ə t uː m ɪ n e ɪ t
 stature	s t æ t͡ʃ ɚ
@@ -58509,7 +59202,8 @@ steenbok	s t iː n b ɒ k
 steens	s t iː n z
 steep	s t iː p
 steepy	s t iː p i
-steer	s t ɪ ə ɹ
+steer	s t ɪ ɚ
+steer	s t ɪ ɹ
 steerageway	s t i ɹ ɪ d͡ʒ w e ɪ
 steerer	s t ɪ ə ɹ ə ɹ
 steerless	s t ɪ ɹ l ə s
@@ -58658,7 +59352,8 @@ stilbestrol	s t ɪ l b ɛ s t ɹ ɔ l
 stilbon	s t ɪ l b ɒ n
 stile	s t a ɪ l
 stiletto	s t ɪ l ɛ t o ʊ
-still	s t ɪ ɫ
+still	s t ɪ l
+stillborn	s t ɪ l b ɔː ɹ n
 stillicide	s t ɪ l ɪ s ʌ ɪ d
 stillness	s t ɪ l n ə s
 stilt	s t ɪ l t
@@ -58667,6 +59362,7 @@ stilton	s t ɪ l t ə n
 stilus	s t a ɪ l ə s
 stime	s t a ɪ m
 stimmy	s t ɪ m i
+stimulant	s t ɪ m j ʊ l ə n t
 stimulate	s t ɪ m j ʊ l e ɪ t
 stimulated	s t ɪ m j ʊ l e ɪ t ɪ d
 stimuli	s t ɪ m j ə l a ɪ̯
@@ -58900,7 +59596,7 @@ streel	s t ɹ iː l
 street	s t ɹ i t
 streetlet	s t ɹ iː t l ə t
 streets	s t ɹ iː t s
-strength	s t ɹ ɛ ŋ k θ
+strength	s t ɹ ɛ ŋ θ
 strengthen	s t ɹ ɛ n θ ə n
 strengthen	s t ɹ ɛ ŋ k θ ə n
 strengthen	ʃ t͡ʃ ɹ e ɪ ŋ k θ ə n
@@ -59183,6 +59879,7 @@ subglacial	s ʌ b ɡ l e ɪ ʃ i ə l
 subglacial	s ʌ b ɡ l e ɪ ʃ ə l
 subgroup	s ʌ b ɡ ɹ uː p
 subindication	s ʌ b ɪ n d ɪ k e ɪ ʃ ə n
+subitize	s ʌ b ɪ t a ɪ z
 subito	s uː b ɪ t ə ʊ
 subjacency	s ə b d͡ʒ e ɪ s ə n s i
 subject	s ə b d͡ʒ ɛ k t
@@ -59232,6 +59929,7 @@ subperiosteal	s ʌ b p ɛ ɹ i ɒ s t ɪ ə l
 subpoena	s ə p iː n ə
 subpoenable	s ə p i n ə b ə l
 subprime	s ʌ b p ɹ a ɪ m
+subq	s ʌ b k j uː
 subreption	s ʌ b ɹ ɛ p ʃ ə n
 subsaltation	s ʌ b s l t e ɪ ʃ n
 subsaltation	s ʌ b s ə l t e ɪ ʃ n
@@ -59253,6 +59951,7 @@ subsidiary	s ʌ b s ɪ d i ə ɹ i
 subsidiary	s ʌ b s ɪ d ə ɹ i
 subsidiary	s ʌ b s ɪ d͡ʒ ə ɹ i
 subsidize	s ʌ b s ɪ d a ɪ z
+subsidy	s ʌ b s ɪ d i
 subsist	s ə b s ɪ s t
 subsistence	s ə b s ɪ s t ə n s
 subspecies	s ʌ b s p iː ʃ iː z
@@ -59609,7 +60308,7 @@ superinstantaneous	s uː p ɚ ɪ n s t ə n t e ɪ n i ə s
 superintend	s uː p ə ɹ ɪ n t ɛ n d
 superintendent	s j uː p ə ɹ ɪ n t ɛ n d ə n t
 superintendent	s uː p ə ɹ ɪ n t ɛ n d ə n t
-superior	s ʊ p ɪ ɹ i ə ɹ
+superior	s ʊ p ɪ ɹ i ɚ
 superirresistible	s u p ɚ ɪ ɹ ɪ z ɪ s t ə b ə l
 superkick	s uː p ɚ k ɪ k
 superlative	s u p ɝː l ə t ɪ v
@@ -59723,6 +60422,8 @@ suprasegmental	s uː p ɹ ə s ɛ ɡ m ɛ n t ə l
 suprasternal	s uː p ɹ ə s t ɜː n ə l
 supratrochlear	s u p ɹ ə t ɹ ɑ k l i ɚ
 supremacy	s u p ɹ ɛ m ə s i
+suprematism	s j uː p ɹ ɛ m ə t ɪ z ə m
+suprematist	s j uː p ɹ ɛ m ə t ɪ s t
 supreme	s u p ɹ i m
 supreme	s ə p ɹ iː m
 supremo	s uː p ɹ iː m ə ʊ
@@ -59766,6 +60467,7 @@ surimi	s ʊ ə ɹ iː m i
 surimi	s ʊ ə ɹ ɪ m i
 suriname	s ʊ ɹ ɪ n æ m
 suriname	s ʊ ɹ ɪ n ɑ m
+surinamese	s ʊ ə ɹ ɪ n ə m iː z
 surjection	s ɜː ɹ d͡ʒ ɛ k ʃ ə n
 surmise	s ɚ m a ɪ z
 surmount	s ɚ m a ʊ n t
@@ -59785,7 +60487,6 @@ surprising	s ə p ɹ a ɪ z ɪ ŋ
 surprising	s ɚ p ɹ a ɪ z ɪ ŋ
 surreal	s ə ɹ iː ə l
 surrect	s ə ɹ ɛ k t
-surrender	s ə ɹ ɛ n d ə ɹ
 surreptition	s ə ɹ ɛ p t ɪ ʃ ə n
 surreptition	s ʌ ɹ ə p t ɪ ʃ ə n
 surreptitious	s ə ɹ ɛ p t ɪ ʃ ə s
@@ -59816,6 +60517,7 @@ sus	s ʌ s
 susa	s uː z ə
 susceptibility	s ə s ɛ p t ə b ɪ l ɪ t i
 susceptible	s ə s ɛ p t ɪ b l̩
+suscitate	s ʌ s ɪ t e ɪ t
 sushen	s uː ʃ ʌ n
 sushi	s u ʃ i
 sushi	s uː ʃ i
@@ -59928,7 +60630,6 @@ swash	s w ɒ ʃ
 swastika	s w ɑ s t ə k ə
 swastika	s w ɑ s t ɪ k ə
 swat	s w ɑ t
-swat	s w ɔ t
 swatch	s w ɑ t͡ʃ
 swatch	s w ɔ t͡ʃ
 swatchel	s w ɒ t͡ʃ ə l
@@ -60093,6 +60794,8 @@ symbiotic	s ɪ m b a ɪ ɑ t ɪ k
 symbiotic	s ɪ m b i ɑ t ɪ k
 symblepharon	s ɪ m b l ɛ f ə ɹ ɑ n
 symbol	s ɪ m b ə l
+symbolically	s ɪ m b ɑː l ɪ k l ɪ
+symbolically	s ɪ m b ɒ l ɪ k l ɪ
 symbolism	s ɪ m b ə l ɪ z ə m
 symbolize	s ɪ m b ə l a ɪ z
 symboloid	s ɪ m b ə l ɔ ɪ d
@@ -60132,6 +60835,7 @@ synchrocyclotron	s ɪ ŋ k ɹ ə ʊ s a ɪ k l ə t ɹ ɒ n
 synchronic	s ɪ ŋ k ɹ ɑ n ɪ k
 synchronous	s ɪ ŋ k ɹ ə n ə s
 synchrotron	s ɪ ŋ k ɹ ə ʊ t ɹ ɒ n
+synchysis	s ɪ n k ə s ɪ s
 syncline	s ɪ n k l a ɪ n
 syncope	s ɪ ŋ k ə p i
 syncranterian	s ɪ ŋ k ɹ æ n t i ɹ i ə n
@@ -60238,6 +60942,7 @@ södertälje	s ʌ d ə r t ɛ l j ə
 t	t iː
 t'othersider	t ʌ ð ə ɹ s a ɪ d ə ɹ
 ta	t ɑː
+ta	t ə
 ta'en	t e ɪ n
 tab	t æ b
 tabard	t æ b ɑː ɹ d
@@ -60323,6 +61028,7 @@ taenifuge	t iː n ɪ f j uː d͡ʒ
 tafe	t e ɪ f
 taffaty	t æ f ə t i
 taffeta	t æ f ə t ə
+taffeta	t æ f ɪ t ə
 taffety	t æ f ə t i
 taffy	t æ f i
 tafsir	t æ f s ɪ ə r
@@ -60373,6 +61079,7 @@ taino	t a ɪ n o ʊ
 taint	t e ɪ n t
 tainted	t e ɪ n t ɪ d
 taipei	t a ɪ p e ɪ
+taiping	t a ɪ p ɪ ŋ
 taipingxi	t a ɪ p ɪ ŋ ʃ iː
 taiqian	t a ɪ t͡ʃ j æ n
 taiqian	t a ɪ t͡ʃ j ɛ n
@@ -60418,6 +61125,7 @@ tales	t e ɪ l z
 taliban	t æ l ɪ b æ n
 taliban	t æ l ɪ b ɑː n
 taliban	t ɑː l ɪ b ɑː n
+taliesin	t æ l i ɛ s ɪ n
 taligrade	t æ l ɪ ɡ ɹ e ɪ d
 talisman	t æ l ɪ s m æ n
 talisman	t æ l ɪ z m ə n
@@ -60453,8 +61161,8 @@ talmud	t æ l m ə d
 talmud	t æ l m ʊ d
 talmud	t ɑ l m ʊ d
 talmudic	t æ l m ʊ d ɪ k
-talmudic	t ɑ l m ʊ d ɪ k
 talon	t æ l ə n
+talpidae	t æ l p ɪ d iː
 talus	t e ɪ l ə s
 tam	t æ m
 tamada	t ɑ m ə d ɑ
@@ -60513,7 +61221,7 @@ tangential	t æ n d͡ʒ ɛ n t͡ʃ ə l
 tangentially	t æ n d͡ʒ ɛ n ʃ i ə l i
 tangentially	t æ n d͡ʒ ɛ n ʃ ə l i
 tangerine	t æ n d͡ʒ ə ɹ i n
-tangerine	t æ n d͡ʒ ɜ ɹ i n
+tangerine	t æ n d͡ʒ ə ɹ iː n
 tangible	t æ n d͡ʒ ə b ə l
 tangier	t æ ŋ ɪ ə
 tangle	t æ ŋ ɡ ə l
@@ -60538,6 +61246,8 @@ tannery	t æ n ə ɹ i
 tannin	t æ n ɪ n
 tanning	t æ n ɪ ŋ
 tannoy	t æ n ɔ ɪ
+tanpura	t æ m p ʊ ə ɹ ə
+tanpura	t ɑ m p ʊ ə ɹ ə
 tanru	t æ n ɹ uː
 tansy	t æ n z i
 tantalism	t æ n t ə l ɪ z ə m
@@ -60550,6 +61260,9 @@ tantara	t æ n t ə ɹ ɑː
 tante	t ɑ n t ə
 tantivy	t æ n t ɪ v i
 tanto	t ɑ n t o ʊ
+tantra	t æ n t ɹ ə
+tantra	t ɑː n t ɹ ə
+tantra	t ʌ n t ɹ ə
 tantric	t æ n t ɹ ɪ k
 tantrum	t æ n t ɹ ə m
 tanuki	t ɑ n u k i
@@ -60559,7 +61272,9 @@ tanzanian	t æ n z ə n i ə n
 tanzanite	t æ n z ə n a ɪ t
 tao	d a ʊ
 tao	t a ʊ
-taoiseach	t iː ʃ ə k
+taoiseach	t i ʃ i
+taoiseach	t i ʃ ə k
+taoisigh	t i ʃ i
 taotie	t a ʊ t j e ɪ
 tap	t æ p
 tapa	t ɑː p ə
@@ -60603,6 +61318,7 @@ taranto	t ə ɹ æ n t o ʊ
 taranto	t ɛ ɹ ə n t o ʊ
 tarantula	t ə ɹ æ n t͡ʃ ə l ə
 taraxacum	t ə ɹ æ k s ə k ə m
+tarboosh	t ɑ ɹ b u ʃ
 tardigrade	t ɑ ɹ d ɪ ɡ ɹ e ɪ d
 tardis	t ɑ ɹ d ɪ s
 tardlet	t ɑː ɹ d l ə t
@@ -60648,7 +61364,7 @@ tarry	t ɑː ɹ i
 tarsal	t ɑ ɹ s ə l
 tarsand	t ɑː ɹ s æ n d
 tarse	t ɑː ɹ s
-tarsier	t a ɹ s i ə ɹ
+tarsier	t ɑ ɹ s i ə ɹ
 tarsus	t ɑ ɹ s ə s
 tart	t ɑ ɹ t
 tartan	t ɑ ɹ t n̩
@@ -60729,6 +61445,7 @@ taupe	t o ʊ p
 taupo	t a ʊ p o ʊ
 taur	t ɑː r
 taur	t ɔː r
+taurida	t ɔː ɹ ɪ d ə
 taurine	t ɔː ɹ a ɪ n
 taurine	t ɔː ɹ iː n
 taurocholic	t ɔː ɹ ə k ɒ l ɪ k
@@ -60762,8 +61479,8 @@ taxis	t æ k s i z
 taxis	t æ k s ɪ s
 taxodium	t æ k s o ʊ d i ə m
 taxol	t æ k s ɒ l
-taxon	t æ k s ɑː n
-taxonomy	t æ k s ɑː n ə m i
+taxon	t æ k s ɑ n
+taxonomy	t æ k s ɑ n ə m i
 tay	t e ɪ
 tayabas	t æ j ɑ b ɑ s
 taylor	t e ɪ l ɚ
@@ -60795,6 +61512,7 @@ teachy	t iː t͡ʃ i
 teacup	t iː k ʌ p
 teade	t iː d
 teak	t iː k
+teaky	t iː k i
 teal	t iː l
 team	t iː m
 teammate	t iː m m e ɪ t
@@ -60813,8 +61531,8 @@ teared	t ɪ ə ɹ d
 teared	t ɪ ɹ d
 tearful	t ɪ ɹ f ə l
 tearful	t ɪ ɹ f ʊ l
-tearing	t ɛ ə ɹ ɪ ŋ
-tearing	t ɪ ə ɹ ɪ ŋ
+tearing	t ɛ ɹ ɪ ŋ
+tearing	t ɪ ɹ ɪ ŋ
 tears	t ɛ ɹ z
 tears	t ɪ ɹ z
 tearsheet	t ɛ ə ʃ iː t
@@ -60848,6 +61566,7 @@ technique	t ɛ k n iː k
 techno	t ɛ k n o ʊ
 technobabble	t ɛ k n o ʊ b æ b ə l
 technocracy	t ɛ k n ɒ k ɹ ə s i
+technological	t ɛ k n ə l ɑ d͡ʒ ɪ k ə l
 technologist	t ɛ k n ɑ l ə d͡ʒ ɪ s t
 technology	t ɛ k n ɑ l ə d͡ʒ i
 technopeasant	t ɛ k n ə ʊ p ɛ z ə n t
@@ -60865,6 +61584,7 @@ teddy	t ɛ d i
 tedge	t ɛ d͡ʒ
 tedious	t i d i ə s
 tedious	t i d͡ʒ ə s
+tedisome	t i d i s ə m
 tee	t iː
 teegeeack	t iː ɡ i æ k
 teek	t iː k
@@ -60874,6 +61594,7 @@ teeming	t iː m ɪ ŋ
 teen	t iː n
 teenager	t iː n e ɪ d͡ʒ ə ɹ
 teens	t iː n z
+teensy	t i n s i
 teeny	t iː n i
 teenybopper	t i n i b ɑ p ɚ
 teep	t iː p
@@ -60918,6 +61639,7 @@ telary	t iː l ə ɹ i
 tele	t ɛ l i
 telecabin	t ɛ l ɪ k æ b ɪ n
 telecine	t ɛ l ə s ɪ n e ɪ
+telega	t ɪ l e ɪ ɡ ə
 telegraphist	t ə l ɛ ɡ ɹ æ f ɪ s t
 telegraphist	t ɛ l ə ɡ ɹ æ f ɪ s t
 telegraphy	t ə l ɛ ɡ ɹ ə f i
@@ -60993,8 +61715,8 @@ temp	t ɛ m p
 tempeh	t ɛ m p e ɪ
 temper	t ɛ m p ɚ
 tempera	t ɛ m p ə ɹ ə
-temperament	t ɛ m p ə ɹ m ə n t
-temperament	t ɛ m p ə ɹ ə m ə n t
+temperament	t ɛ m p ɚ m ə n t
+temperament	t ɛ m p ɚ ə m ə n t
 temperament	t ɛ m p ɹ ə m ə n t
 temperance	t ɛ m p ə ɹ ə n s
 temperate	t ɛ m p ə ɹ ə t
@@ -61066,6 +61788,7 @@ tenet	t ɛ n ɪ t
 tenge	t ɛ ŋ ɡ e ɪ
 tengrism	t ɛ ŋ ɡ ɹ ɪ z ə m
 tengwar	t ɛ ŋ ɡ w ɑ ɹ
+teniposide	t ɛ n ɪ p ə s a ɪ d
 tennessee	t ɛ n ə s iː
 tennessine	t ɛ n ə s iː n
 tennis	t ɛ n ɪ s
@@ -61089,6 +61812,7 @@ tensores	t ɛ n s ɔ ɹ i z
 tent	t ɛ n t
 tent	t ɪ n t
 tentacle	t ɛ n t ə k ə l
+tentacle	t ɛ n t ɪ k ə l
 tentacular	t ɛ n t æ k j uː l ə ɹ
 tentative	t ɛ n t ə t ɪ v
 tentatively	t ɛ n t ə t ɪ v l i
@@ -61166,6 +61890,7 @@ terminological	t ɜ ɹ m ə n ə l ɒ d͡ʒ ɪ k ə l
 terminologist	t ɛː ɹ m ɪ n ɑ l ɑ d͡ʒ ɪ s t
 terminology	t ɚ m ə n ɑ l ə d͡ʒ i
 termitarium	t ɜ ɹ m ɪ t ɛ ə ɹ i ə m
+termless	t ɝ m l ɪ s
 terms	t ɝ m z
 tern	t ɝ n
 ternary	t ɝ n ə ɹ i
@@ -61193,6 +61918,8 @@ terrestrial	t ə ɹ ɛ s t ɹ i ə l
 terrestrious	t ə ɹ ɛ s t ɹ i ə s
 terret	t ɛ ɹ ɪ t
 terrible	t ɛ ɚ b ə l
+terrible	t ɛ ɹ ə b ə l
+terrible	t ɛ ɹ ɪ b ə l
 terrible	t ɝ b ə l
 terribler	t ɛ ɹ ɪ b ə l ə ɹ
 terribly	t ɛ ɹ ɪ b l i
@@ -61324,6 +62051,7 @@ texture	t ɛ k s t͡ʃ ə ɹ
 texture	t ɛ k ʃ t͡ʃ ə ɹ
 textured	t ɛ k s t͡ʃ ɚ d
 textured	t ɛ k ʃ t͡ʃ ɚ d
+tezosentan	t ɛ z ə ʊ s ɛ n t æ n
 th'	ð
 th'	ð ə
 th'are	ð ɑː ɹ
@@ -61367,12 +62095,14 @@ thanjavur	θ ʌ n d͡ʒ ɑ v ʊ ɹ
 thank	θ æ ŋ k
 thanked	θ æ ŋ k t
 thankful	θ æ ŋ k f ə l
+thanks	ð æ ŋ k s
 thanks	θ æ ŋ k s
 thanksgiving	θ æ ŋ k s ɡ ɪ v ɪ ŋ
 thanky	θ æ ŋ k i
 thao	θ a ʊ
 that	ð æ t
 that'd	ð æ d
+that'd	ð æ t ə d
 that're	ð ə t ɚ
 that's	ð æ t s
 that've	ð ə t ə v
@@ -61413,6 +62143,7 @@ theine	t e ɪ iː n
 theine	θ e ɪ iː n
 theine	θ iː iː n
 theinism	θ iː ɪ n ɪ z ə m
+their	ð ɚ
 their	ð ɛ ɚ
 theirs	ð ɛ ɚ z
 theirs	ð ɛ ɹ z
@@ -61432,6 +62163,7 @@ thematic	θ ɪ m æ t ɪ k
 thematise	θ iː m ə t a ɪ z
 thembo	ð ɛ m b o ʊ
 theme	θ iː m
+themis	θ iː m ɪ s
 themself	ð ɛ m s ɛ l f
 themselves	ð ə m s ɛ l v z
 themselves	ð ɛ m s ɛ l v z
@@ -61458,6 +62190,7 @@ theological	θ i ə l ɑ d͡ʒ ɪ k l
 theology	θ i ɒ l ə d͡ʒ i
 theomachist	θ i ɑ m æ k ɪ s t
 theomachy	θ i ɑ m ə k i
+theophilus	θ iː ɒ f ɪ l ə s
 theophylline	θ i ɑ f ə l ɪ n
 theopneust	θ ɪ ə p n j uː s t
 theorbo	θ i ɔ ɹ b o ʊ
@@ -61494,10 +62227,11 @@ thereatop	ð ɛ ə ɹ ə t ɒ p
 therebehind	ð ɛ ə b ɪ h a ɪ n d
 thereby	ð ɛ ɹ b a ɪ
 therefor	ð ɛ ə ɹ f ɔ ɹ
-therefore	ð ɛ ə ɹ f ɔ ɹ
+therefore	ð ɛ ɚ f ɔ ɹ
 therefrom	ð e ə f ɹ ɒ m
 therein	ð e ə ɹ ɪ n
 theremin	θ ɛ ə ɹ ə m ɪ n
+theremin	θ ɛ ɹ ɪ m ɪ n
 thereof	ð ɛ ɹ ʌ v
 thereout	ð ɛ ə ɹ a ʊ t
 thereto	ð ɛ ɚ t uː
@@ -61668,6 +62402,7 @@ thoroughly	θ ʌ ɹ ə l i
 thoroughness	θ ɜ ɹ o ʊ n ə s
 thoroughness	θ ʌ ɹ o ʊ n ə s
 thorp	θ ɔ ɹ p
+thorpe	θ ɔ ɹ p
 those	ð o ʊ z
 those're	ð o ʊ z ɚ
 those've	ð o ʊ z ə v
@@ -61873,10 +62608,13 @@ tiberius	t ɪ b ɛ ɹ i ʊ s
 tibet	t ə b e t
 tibet	t ɪ b e t
 tibetan	t ɪ b ɛ t n̩
+tibia	t ɪ b i ə
 tibial	t ɪ b i ə l
+tibicos	t ɪ b iː k o ʊ s
 tic	t ɪ k
+tical	t iː k ə l
 tical	t ɪ k ɑː l
-tical	t ɪ k ə l
+tical	t ɪ k ɔː l
 ticarcillin	t a ɪ k ɑ ɹ s ɪ l ɪ n
 tice	t a ɪ s
 tich	t ɪ t͡ʃ
@@ -61894,6 +62632,7 @@ ticklishness	t ɪ k l ɪ ʃ n ɛ s
 ticks	t ɪ k s
 ticrynafen	t ɪ k ɹ ɪ n ə f ɛ n
 tics	t ɪ k s
+tid	t ɪ d
 tidal	t a ɪ d ə l
 tidbit	t ɪ d b ɪ t
 tiddly	t ɪ d l i
@@ -62151,6 +62890,7 @@ tlaloc	t l ə l o ʊ k
 tlaxcala	t l ɑː s k ɑː l ə
 tlaxcala	t l ɑː ʃ k ɑː l ə
 tlayuda	t l ɑ j u d ə
+tlemcen	t l ɛ m s ɛ n
 tlingit	k l ɪ ŋ k ɪ t
 tlingit	t l ɪ ŋ ɡ ɪ t
 tmesis	m iː s ɪ s
@@ -62235,6 +62975,7 @@ tokenize	t o ʊ k ə n a ɪ z
 toki	t o ʊ k i
 toki	t ə ʊ k i
 tokin	t ə ʊ k ɪ n
+tokkaebi	t o ʊ k e ɪ b i
 tokomaru	t ə ʊ k ə ʊ m ɑː ɹ uː
 tokophobia	t ə ʊ k ə f ə ʊ b i ə
 tokoroa	t ə ʊ k ə ʊ ɹ ə ʊ ə
@@ -62275,7 +63016,6 @@ toman	t o ʊ m ə n
 toman	t ʊ m ə n
 toman	t ʌ m ə n
 tomato	t ə m e ɪ t o ʊ
-tomato	t ə m ɑː t o ʊ
 tomb	t u m
 tombal	t uː m b ə l
 tombal	t uː m ə l
@@ -62338,7 +63078,7 @@ too	t u
 toodeloo	t uː d ə l uː
 tooele	t uː ɛ l ə
 took	t ʊ k
-tool	t uː l
+tool	t u l
 toolbox	t uː l b ɑ k s
 tools	t uː l z
 toomey	t uː m i
@@ -62374,6 +63114,7 @@ tophet	t o ʊ f ɪ t
 topi	t ə ʊ p i
 topiary	t o ʊ p i ɛ ə ɹ i
 topic	t ɑ p ɪ k
+topical	t ɑ p ɪ k ə l
 topics	t ɑ p ɪ k s
 topmost	t ɑ p m o ʊ s t
 topography	t ə p ɑ ɡ ɹ ə f i
@@ -62433,7 +63174,7 @@ torsion	t o r ʒ ə n
 torsion	t o r ʒ ɪ n
 torsk	t ɔ ɹ s k
 torso	t ɔ ɹ s o ʊ
-tort	t ɔ ɹ t
+tort	t o ɹ t
 torte	t ɔ ɹ t
 tortellini	t ɔ ɹ t ə l i n i
 tortfeasance	t ɔ ə ɹ t f iː z ə n s
@@ -62443,11 +63184,11 @@ tortile	t ɔː t a ɪ l
 tortilla	t ɔ ɹ t i j ə
 tortilla	t ɔ ɹ t i ə
 tortious	t ɔ ɹ ʃ ə s
-tortoise	t ɔː ɹ t ə s
 tortoiseshell	t ɔː ɹ t ə s ʃ ɛ l
 tortoiseshell	t ɔː ɹ t ə ʃ ɛ l
 tortola	t o ɹ t o ʊ l ə
 tortoni	t ɔ ɹ t o ʊ n i
+torts	t o ɹ t s
 tortuous	t ɔ ɹ t͡ʃ u ə s
 torture	t ɔ ɹ t͡ʃ ɚ
 tortured	t ɔ ɹ t͡ʃ ɚ d
@@ -62467,6 +63208,7 @@ tossy	t ɒ s i
 tot	t ɑ t
 total	t o ʊ t ə l
 totalitarian	t o ʊ t ə l ɪ t ɛ ɹ i ə n
+totality	t o ʊ t æ l ɪ t i
 totally	t o ʊ t ə l i
 totalness	t ə ʊ t ə l n ə s
 totchos	t ɑ t͡ʃ o ʊ z
@@ -62615,7 +63357,6 @@ trader	t ɹ e ɪ d ɚ
 trades	t ɹ e ɪ d z
 tradescantia	t ɹ æ d ɪ s k æ n t i ə
 trading	t ɹ e ɪ d ɪ ŋ
-tradition	t ɹ ə d ɪ ʃ n̩
 tradition	t ɹ ə d ɪ ʃ ə n
 traditional	t ɹ ə d ɪ ʃ n ə l
 traditional	t ɹ ə d ɪ ʃ ə n ə l
@@ -62647,6 +63388,7 @@ trainees	t ɹ e ɪ n i z
 trainer	t ɹ e ɪ n ɚ
 trainiac	t ɹ e ɪ n i æ k
 training	t ɹ e ɪ n ɪ ŋ
+traino	t ɹ e ɪ n o ʊ
 trains	t ɹ e ɪ n z
 traipse	t ɹ e ɪ p s
 traipse	t͡ʃ ɹ e ɪ p s
@@ -62690,7 +63432,7 @@ tranquil	t ɹ æ ŋ k w ɪ l
 tranquility	t r æ ŋ k w ɪ l ɪ t i
 tranquilize	t ɹ æ ŋ k w ɪ l a ɪ z
 tranquilizing	t ɹ æ ŋ k w ɪ l a ɪ z ɪ ŋ
-tranquillity	t r æ ŋ k w ɪ l ɪ t i
+tranquillity	t ɹ æ ŋ k w ɪ l ɪ t i
 trans	t ɹ æ n z
 transact	t ɹ æ n z æ k t
 transaction	t ɹ æ n z æ k ʃ ə n
@@ -62920,6 +63662,7 @@ treechange	t ɹ i t͡ʃ e ɪ n d͡ʒ
 treehouse	t ɹ iː h a ʊ s
 treemapping	t ɹ iː m æ p ɪ ŋ
 treen	t ɹ iː n
+treeness	t ɹ iː n ɪ s
 treenware	t ɹ iː n w ɛ ə ɹ
 trees	t ɹ iː z
 treey	t ɹ i i
@@ -62976,6 +63719,8 @@ trepidation	t ɹ ɛ p ɪ d e ɪ ʃ ə n
 trespass	t ɹ ɛ s p æ s
 tress	t ɹ ɛ s
 tressel	t ɹ ɛ s ə l
+tressure	t ɹ ɛ s j ʊ ə ɹ
+tressure	t ɹ ɛ ʃ ə ɹ
 tressy	t ɹ ɛ s i
 trestle	t ɹ ɛ s ə l
 trestolone	t ɹ ɛ s t ə l o ʊ n
@@ -63050,6 +63795,7 @@ tricks	t ɹ ɪ k s
 tricky	t ɹ ɪ k i
 triclosan	t ɹ ɪ k l ə s æ n
 tricot	t ɹ i k o ʊ
+tricrotous	t ɹ a ɪ k ɹ ə t ə s
 tricuspid	t ɹ a ɪ k ʌ s p ɪ d
 tricycle	t ɹ a ɪ s ɪ k ə l
 tridem	t ɹ a ɪ d ə m
@@ -63147,6 +63893,7 @@ triplicity	t ɹ ɪ p l ɪ s ɪ t i
 tripod	t ɹ a ɪ p ɑ d
 tripoli	t ɹ ɪ p ə l i
 tripolitan	t ɹ ɪ p ɒ l ɪ t ə n
+tripolitania	t ɹ ɪ p ə l ɪ t e ɪ n i ə
 tripped	t ɹ ɪ p t
 tripping	t ɹ ɪ p ɪ ŋ
 trippy	t ɹ ɪ p i
@@ -63256,13 +64003,13 @@ trophæal	t ɹ o ʊ f i ə l
 tropic	t ɹ ɒ p ɪ k
 tropical	t ɹ o ʊ p ɪ k ə l
 tropical	t ɹ ɑ p ɪ k ə l
-tropical	t ɹ ɒ p ɪ k ə l
 tropicalize	t ɹ ɑ p ɪ k ə l a ɪ z
 tropicamide	t ɹ ə p ɪ k ə m a ɪ d
 tropicbird	t ɹ ɒ p ɪ k b ɜ ɹ d
 tropisetron	t ɹ o ʊ p ɪ s ə t ɹ ɑ n
 tropism	t ɹ o ʊ p ɪ z ə m
 tropologize	t ɹ ə p ɒ l ə d͡ʒ a ɪ z
+tropomorphic	t ɹ o ʊ p ə m ɔ ɹ f ɪ k
 tropomyosin	t ɹ o ʊ p ə m a ɪ ə s ɪ n
 tropomyosin	t ɹ ɑ p ə m a ɪ ə s ɪ n
 troppo	t ɹ ɒ p ə ʊ
@@ -63355,7 +64102,6 @@ truthfully	t ɹ uː θ f ə l i
 truths	t ɹ uː ð z
 truths	t ɹ uː θ s
 try	t ɹ a ɪ
-try	t͡ʃ ɹ a ɪ
 tryhard	t ɹ a ɪ h ɑ ɹ d
 trying	t ɹ a ɪ ɪ ŋ
 tryke	t ɹ a ɪ k
@@ -63390,6 +64136,7 @@ tsatlee	t s æ t l iː
 tsatske	t s ɑ t s k ə
 tschinke	t͡ʃ ɪ ŋ k ə
 tse	s i
+tsenacommacah	s ɛ n ə k ɒ m ə k ə
 tsetse	s i t s i
 tsetse	t i t s i
 tsetse	t s i t s i
@@ -63417,6 +64164,8 @@ tsuridashi	t s uː ɹ i d ɑː ʃ i
 tsuriotoshi	t s uː ɹ i o ʊ t o ʊ ʃ i
 tsuris	t s uː ɹ ɪ s
 tsuris	t s ʊ ɹ ɪ s
+tsushima	s uː ʃ iː m ə
+tsushima	t s uː ʃ iː m ə
 tsutaezori	t s uː t ɑː e ɪ z ɔː ɹ i
 tsutsugamushi	t s u t s u ɡ æ m uː ʃ iː
 tsuyuharai	t s uː j uː h ɑː ɹ a ɪ
@@ -63435,6 +64184,7 @@ tubby	t ʌ b i
 tube	t j uː b
 tubelight	t j uː b l a ɪ t
 tuber	t u b ɚ
+tuberculosis	t u b ɚ k j ʊ l o ʊ s ɪ s
 tuberose	t u b ə ɹ o ʊ z
 tuberous	t j uː b ə ɹ ə s
 tubes	t uː b z
@@ -63462,6 +64212,7 @@ tufty	t ʌ f t i
 tug	t ʌ ɡ
 tugboat	t ʌ ɡ b o ʊ t
 tugged	t ʌ ɡ d
+tuggeranong	t ʌ ɡ ɹ ə n ɒ ŋ
 tugging	t ʌ ɡ ɪ ŋ
 tugs	t ʌ ɡ z
 tui	t uː i
@@ -63516,7 +64267,6 @@ tuna	t u n ə
 tundish	t ʌ n d ɪ ʃ
 tundra	t ʌ n d ɹ ə
 tune	t j u n
-tune	t u n
 tuned	t j uː n d
 tuner	t uː n ɚ
 tunes	t j uː n s
@@ -63532,7 +64282,10 @@ tunicle	t j uː n ɪ k ə l
 tuning	t j uː n ɪ ŋ
 tunis	t uː n ə s
 tunisia	t u n i ʒ ə
+tunisian	t uː n ɪ z i ə n
+tunisian	t uː n ɪ ʒ ə n
 tunnel	t ʌ n ə l
+tunny	t ʌ n i
 tunxi	t ʊ n ʃ iː
 tuoba	t w o ʊ b ɑː
 tup	t ʌ p
@@ -63559,6 +64312,7 @@ turbulence	t ɝ b j ə l ə n s
 turbulent	t ɝ b j ə l ə n t
 turd	t ɝ d
 turdetani	t ʊ ə ɹ d ɛ t ɑ n i
+turdetanian	t ɜː ɹ d ɪ t e ɪ n i ə n
 turdmuffin	t ɜː ɹ d m ʌ f ɪ n
 turducken	t ɝ d ʌ k ə n
 tureen	t j u ɹ i n
@@ -63583,7 +64337,6 @@ turkwoman	t ɜ ɹ k w ʊ m ə n
 turlet	t ɝː l ɪ t
 turmeric	t uː m ə ɹ ɪ k
 turmeric	t ɜ ɹ m ə ɹ ɪ k
-turn	t ɝ n
 turnaround	t ɜː ɹ n ə ɹ a ʊ n d
 turncoat	t ɝ n k o ʊ t
 turned	t ɝ n d
@@ -63608,6 +64361,7 @@ turret	t ʌ ɹ ɪ t
 turribant	t ɜː ɹ ɪ b ə n t
 turribant	t ʌ ɹ ɪ b ə n t
 turriff	t ɜ ɹ ɪ f
+turritella	t ʌ ɹ ɪ t ɛ l ə
 turron	t ə ɹ ɒ n
 turtle	t ɝ t l̩
 tuscaloosa	t ʌ s k ə l uː s ə
@@ -63724,6 +64478,7 @@ twincest	t w ɪ n s ɛ s t
 twine	t w a ɪ n
 twinge	t w ɪ n d͡ʒ
 twink	t w ɪ ŋ k
+twinkhon	t w ɪ ŋ k h ʌ n
 twinkle	t w ɪ ŋ k ə l
 twinkling	t w ɪ ŋ k l ɪ ŋ
 twins	t w ɪ n z
@@ -63761,6 +64516,7 @@ tyebble	t͡ʃ ɛ b ə l
 tyek	t j ɛ k
 tying	t a ɪ ɪ ŋ
 tyke	t a ɪ k
+tykhana	t a ɪ k ɑː n ə
 tylenol	t a ɪ l ə n ɑ l
 tyler	t a ɪ l ɚ
 tympan	t ɪ m p ə n
@@ -63919,7 +64675,7 @@ ulster	ʌ l s t ɚ
 ulsterette	ʌ l s t ə ɹ ɛ t
 ulterior	ʌ l t ɪ ɚ i ɚ
 ultimate	ʌ l t ə m ɪ t
-ultimately	ʌ l t ɪ m ə t l i
+ultimately	ʌ l t ə m ə t l i
 ultimation	ʌ l t ɪ m e ɪ ʃ ə n
 ultimatum	ʌ l t ɪ m e ɪ t ə m
 ultra	ʌ l t ɹ ə
@@ -63976,6 +64732,7 @@ umich	j u m ɪ ʃ
 umlaut	u m l a ʊ t
 umlaut	ʊ m l a ʊ t
 ummah	ʊ m ə
+umno	ʌ m n o ʊ
 ump	ʌ m p
 umpteenth	ʌ m p t iː n θ
 umwelt	ʊ m v ɛ l t
@@ -64097,6 +64854,7 @@ unclutch	ʌ n k l ʌ t͡ʃ
 uncoif	ʌ n k w ɑː f
 uncoif	ʌ n k ɔ ɪ f
 uncoil	ʌ n k ɔ ɪ ə l
+uncollectible	ʌ n k ə l ɛ k t ɪ b l̩
 uncomfortable	ʌ n k ʌ m f t ɚ b ə l
 uncomfortable	ʌ n k ʌ m f ɚ t ə b ə l
 uncommon	ʌ n k ɒ m ə n
@@ -64127,8 +64885,8 @@ uncrook	ʌ n k ɹ ʊ k
 unction	ʌ ŋ k ʃ ə n
 unctional	ʌ ŋ k t͡ʃ n ə l
 unctional	ʌ ŋ k t͡ʃ ə n ə l
-unctuous	ʌ n k t j u ə s
-unctuous	ʌ n k t͡ʃ u ə s
+unctuous	ʌ ŋ k t ʃ ə s
+unctuous	ʌ ŋ k t ʃ ə w ə s
 unctuousness	ʌ ŋ k t͡ʃ u ə s n ə s
 und	ʌ n d
 undead	ʌ n d ɛ d
@@ -64151,6 +64909,9 @@ undercarriage	ʌ n d ɚ k ɛ ɹ ɪ d͡ʒ
 undercook	ʌ n d ɚ k ʊ k
 undercover	ʌ n d ə ɹ k ʌ v ə ɹ
 undercurrent	ʌ n d ɚ k ʌ ɹ ə n t
+underestimate	ʌ n d ɚ ɛ s t ɪ m e ɪ t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ə t
+underestimate	ʌ n d ɚ ɛ s t ɪ m ɪ t
 underfire	ʌ n d ɚ f a ɪ ə ɹ
 underfired	ʌ n d ɚ f a ɪ ə ɹ d
 underfiring	ʌ n d ɚ f a ɪ ə ɹ ɪ ŋ
@@ -64172,6 +64933,7 @@ underlip	ʌ n d ɚ l ɪ p
 underlook	ʌ n d ɚ l ʊ k
 underly	ʌ n d ə ɹ l a ɪ
 underly	ʌ n d ə ɹ l i
+undermine	ʌ n d ɚ m a ɪ n
 underneath	ʌ n d ɚ n i ð
 underneath	ʌ n d ɚ n i θ
 underpants	ʌ n d ə ɹ p æ n t s
@@ -64197,6 +64959,7 @@ undertime	ʌ n d ə ɹ t a ɪ̯ m
 undertime	ʌ n d ɚ t a ɪ̯ m
 undertone	ʌ n d ə ɹ t ə ʊ n
 undertook	ʌ n d ə ɹ t ʊ k
+underutilize	ʌ n d ɚ j uː t ɪ l a ɪ z
 undervalue	ʌ n d ə ɹ v æ l j u
 underverse	ʌ n d ə ɹ v ɜː ɹ s
 underwater	ʌ n d ɚ w ɔ t ə ɹ
@@ -64255,6 +65018,7 @@ unenabled	ʌ n ə n e ɪ b ə l d
 unencumbered	ʌ n ɪ n k ʌ m b ɚ d
 unenthusiastic	ʌ n ɛ n θ j uː z i æ s t ɪ k
 unequal	ʌ n iː k w ə l
+unequivocal	ʌ n ɪ k w ɪ v ə k ə l
 unergative	ʌ n ɝ ɡ ə t ɪ v
 unergatives	ʌ n ɜː ɹ ɡ ə t ɪ v z
 unesco	j uː n ɛ s k o ʊ
@@ -64326,6 +65090,7 @@ uniat	j uː n iː ɪ t
 uniate	j u n i e ɪ t
 uniate	j u n i ɪ t
 unible	j uː n ɪ b ə l
+unicameral	j u n ɪ k æ m ə ɹ ə l
 unicate	j uː n ɪ k ə t
 unicef	j u n ə s ɛ f
 unicellular	j uː n ɪ s ɛ l j ʊ l ə ɹ
@@ -64353,6 +65118,7 @@ uninformed	ʌ n ɪ n f ɔ ɹ m d
 uninspired	ʌ n ɪ n s p a ɪ ə d
 uninspiring	ʌ n ɪ n s p a ɪ ɹ ɪ ŋ
 unintelligent	ʌ n ə n t ɛ l ə d͡ʒ ə n t
+unintelligible	ʌ n ɪ n t ɛ l ɪ d͡ʒ ɪ b ə l
 unintended	ʌ n ɪ n t ɛ n d ɪ d
 unintentional	ʌ n ɪ n t ɛ n ʃ ə n ə l
 uninvite	ʌ n ɪ n v a ɪ t
@@ -64369,6 +65135,8 @@ unique	j uː n iː k
 unique	j ə n iː k
 uniquity	j u n ɪ k w ɪ t i
 unisex	j u n ə s ɛ k s
+unison	j u n ɪ s ə n
+unison	j u n ɪ z ə n
 unit	j uː n ɪ t
 unite	j u n a ɪ t
 unite	j ʊ n a ɪ t
@@ -64389,6 +65157,7 @@ univocal	j uː n ɪ v o ʊ k ə l
 univocal	j uː n ɪ v ə k ə l
 univocity	j uː n ɪ v ɒ s ɪ t i
 unix	j uː n ɪ k s
+unjam	ʌ n d͡ʒ æ m
 unjust	ʌ n d͡ʒ ʌ s t
 unjustly	ʌ n d͡ʒ ʌ s t l i
 unked	ʌ n k ɛ d
@@ -64404,6 +65173,8 @@ unknown	ʌ n n o ʊ n
 unlaid	ʌ n l e ɪ d
 unlead	ʌ n l ɛ d
 unlearn	ʌ n l ɝ n
+unlearned	ʌ n l ɝ n d
+unlearned	ʌ n l ɝ n ɪ d
 unleash	ʌ n l i ʃ
 unless	ə n l ɛ s
 unless	ɪ n l ɛ s
@@ -64454,6 +65225,7 @@ unnoticed	ʌ n n o ʊ t ɪ s t
 unnun	ʌ n n ʌ n
 unoared	ʌ n ɔː ɹ d
 unobtainium	ʌ n ə b t e ɪ n i ə m
+unobtrusive	ʌ n ə b t ɹ u s ɪ v
 unobtrusively	ʌ n ə b t ɹ uː s ɪ v l i
 unorthodox	ʌ n ɔ ɹ θ ə d ɑ k s
 unoverridden	ʌ n o ʊ v ɚ ɹ ɪ d ə n
@@ -64494,6 +65266,7 @@ unrecognizable	ʌ n ɹ ɛ k ə n a ɪ z ə b ə l
 unrecognizable	ʌ n ɹ ɛ k ə ɡ n a ɪ z ə b ə l
 unrecuring	ʌ n ɹ ɪ k j ʊ ə ɹ ɪ ŋ
 unredressable	ʌ n ɹ ɪ d ɹ ɛ s ə b ə l
+unreliable	ʌ n ɹ ə l a ɪ ə b ə l
 unreluctant	ʌ n ɹ ɪ l ʌ k t ə n t
 unrequited	ʌ n ɹ ə k w a ɪ t ɪ d
 unrest	ʌ n ɹ ɛ s t
@@ -64612,13 +65385,15 @@ unwittingly	ʌ n w ɪ t ɪ ŋ l i
 unwonted	ʌ n w ɑ n t ɪ d
 unwontedly	ʊ n w o ʊ n t ɪ d l i
 unworthy	ʌ n w ɝ ð i
-unwound	ʌ n w ɑ ʊ n d
+unwound	ʌ n w a ʊ̯ n d
+unwound	ʌ n w uː n d
 unwrap	ʌ n ɹ æ p
 unwroken	ʌ n ɹ ə ʊ k ə n
 unyoke	ʌ n j o ʊ k
 uotsuri	uː o ʊ t s ʊ ə ɹ i
 up	ʌ p
 upanayana	uː p ə n ɑː j ə n ə
+upazila	uː p ɒ d͡ʒ ɪ l ə
 upbar	ʌ p b ɑː ɹ
 upbind	ʌ p b a ɪ n d
 upbraid	ʌ p b ɹ e ɪ d
@@ -64839,12 +65614,14 @@ uterus	j uː t ə ɹ ə s
 uther	j uː θ ə ɹ
 uther	uː θ ə ɹ
 utica	j uː t ɪ k ə
+util	j uː t ɪ l
 utilitarian	j u t ɪ l ə t ɛ ɹ i ə n
 utilitarianist	j u t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianist	j ʊ t ɪ l ɪ t ɛː ɹ i ə n ɪ s t
 utilitarianly	j u t ɪ l ɪ t e ɪ ɹ i ə n l i
 utility	j uː t ɪ l ɪ t i
 utility	j ə t ɪ l ɪ t i
+utilize	j uː t ɪ l a ɪ z
 utmost	ʌ t m o ʊ̯ s t
 utonian	j uː t o ʊ n i ə n
 utopia	j u t o ʊ p i ə
@@ -64971,6 +65748,7 @@ valency	v e ɪ l ə n s i
 valent	v e ɪ l ə n t
 valentine	v a l ə n t a ɪ n
 valentine	v æ l ə n t a ɪ n
+valeria	v ə l ɪ ə ɹ i ə
 valet	v æ l e ɪ
 valet	v æ l ɪ t
 valetudinarian	v æ l ə t uː d ə n ɛ ɹ i ə n
@@ -64983,6 +65761,7 @@ valid	v æ l ɪ d
 validate	v æ l ɪ d e ɪ t
 validation	v æ l ə d e ɪ ʃ ə n
 validify	v ə l ɪ d ɪ f a ɪ
+valinemia	v e ɪ l ɪ n iː m i ə
 valise	v ə l iː z
 valium	v æ l i ə m
 valium	v æ l j ə m
@@ -64999,10 +65778,12 @@ vallejo	v ə l e ɪ ə ʊ
 valletta	v ə l ɛ t ə
 valley	v æ l i
 valleys	v æ l i z
+vallum	v æ l ə m
 valnemulin	v æ l n ɛ m j ʊ l ɪ n
 valor	v æ l ɚ
 valorize	v æ l ə r a ɪ z
 valour	v æ l ɚ
+valparaíso	v ɑ l p ɑ ɹ a ɪ iː s o ʊ
 valproate	v æ l p ɹ o ʊ e ɪ t
 valsartan	v æ l s ɑ ɹ t æ n
 valsartan	v æ l s ɑ ɹ t ə n
@@ -65159,6 +65940,7 @@ vaxxer	v æ k s ɚ
 ve	v i
 veal	v iː l
 vector	v ɛ k t ɚ
+vectorize	v ɛ k t ə ɹ a ɪ z
 vecuronium	v ɛ k j ə ɹ o ʊ n i ə m
 veda	v e ɪ d ə
 vedette	v ə d ɛ t
@@ -65180,7 +65962,6 @@ vegas	v e ɪ ɡ ə z
 vegeburger	v ɛ d͡ʒ iː b ɜː ɹ ɡ ə ɹ
 vegetable	v ɛ d͡ʒ ə t ə b ə l
 vegetable	v ɛ t͡ʃ t ə b ə l
-vegetables	v ɛ d͡ʒ t ə b ə l z
 vegetables	v ɛ d͡ʒ ə t ə b ə l z
 vegetables	v ɛ t͡ʃ t ə b ə l z
 vegetarian	v ɛ d͡ʒ ɪ t ɛ ɹ i ə n
@@ -65264,6 +66045,7 @@ venezuela	v ɛ n ɛ z w e ɪ l ə
 venezuela	v ɛ n ɪ z w e ɪ l ə
 vengeance	v ɛ n d͡ʒ ə n s
 vengeful	v e n ʒ f ə l
+vengence	v iː n iː n s
 venial	v iː n i ə l
 venice	v ɛ n ɪ s
 venicia	v ə n iː ʃ ə
@@ -65351,6 +66133,7 @@ verklempt	f ɚ k l ɛ m t
 verlan	v ɛ ə ɹ l ɑː n
 vermeer	v ɚ m ɛ ə ɹ
 vermeer	v ɚ m ɪ ə ɹ
+vermetid	v ɜː ɹ m ə t ɪ d
 vermiculate	v ɚ m ɪ k j ə l e ɪ t
 vermiculate	v ɚ m ɪ k j ə l ə t
 vermiculation	v ɚ m ɪ k j u l e ɪ ʃ ə n
@@ -65419,7 +66202,8 @@ vertices	v ɝ t ɪ s iː s
 vertiginous	v ɜː ɹ t ɪ d͡ʒ ɪ n ə s
 vertigo	v ɝ t ɪ ɡ o ʊ
 verts	v ɜː ɹ t s
-vervaeke	v ɝ v iː k i
+vervaeke	v ɚ v iː k i
+vervaeke	v ɝ v e ɪ k i
 vervain	v ɚ v e ɪ n
 verve	v ɝ v
 vervelle	v ɜ ɹ v ɛ l
@@ -65431,6 +66215,8 @@ vesical	v iː s ɪ k ə l
 vesical	v ɛ s ɪ k ə l
 vesicle	v iː s ɪ k ə l
 vesicle	v ɛ s ɪ k ə l
+vesicobullous	v ɛ s ɪ k o ʊ b ʊ l ə s
+vesicocele	v ɛ s ɪ k o ʊ s i l
 vespasian	v ɛ s p e ɪ z i ə n
 vespasian	v ɛ s p e ɪ ʒ i ə n
 vesper	v ɛ s p ɚ
@@ -65468,13 +66254,15 @@ veterinarian	v ɛ ʔ n̩ ɛ ɹ i j ə n
 veterinary	v ɛ t ə ɹ ɪ n ɛ ɹ i
 veterinary	v ɛ t ɪ n ɛ ɹ i
 veterinary	v ɛ t ɹ ɪ n ɛ ɹ i
-vetiver	v ɛ t ɪ v ə
+vetiver	v ɛ t ə v ɚ
+vetiver	v ɛ t ɪ v ɚ
 vetkousie	f e ɪ t k o ʊ s i
 vetkousie	f ɛ t k o ʊ s i
 veto	v iː t o ʊ
 vetoed	v iː t ə ʊ d
 vets	v ɛ t s
 vetter	v ɛ t ɚ
+vetustity	v ə t u s t ɪ t i
 veuglaire	v ə ɡ l ɛ ə ɹ
 veurne	v ɜː ɹ n ə
 vevay	v iː v iː
@@ -65704,7 +66492,9 @@ viognier	v i o ʊ n j e ɪ
 viol	v a ɪ ə l
 viola	v a ɪ o ʊ l ə
 viola	v a ɪ ə l ə
+viola	v a ɪ ə ʊ l ə
 viola	v i o ʊ l ə
+viola	v i ə ʊ l ə
 viola	v ɪ o ʊ l ə
 violate	v a ɪ ə l e ɪ t
 violated	v a ɪ ə l e ɪ t ɪ d
@@ -65727,6 +66517,8 @@ viossa	v i ɒ s ə
 viossa	v ɪ j o ʊ̯ s ə
 vip	v ɪ p
 viper	v a ɪ p ɚ
+viraginous	v ɪ ɹ æ d͡ʒ ə n ə s
+viraginous	v ɪ ɹ æ d͡ʒ ɪ n ə s
 virago	v ɪ ɹ ɑː ɡ ə ʊ
 viral	v a ɪ ɹ ə l
 virally	v a ɪ ɹ ə l i
@@ -65763,6 +66555,7 @@ virtual	v ɝ t͡ʃ u ə l
 virtualize	v ɜː ɹ t j u ə l a ɪ z
 virtualize	v ɜː ɹ t͡ʃ u ə l a ɪ z
 virtue	v ɝ t͡ʃ u
+virtuosity	v ɜː ɹ t j u ɒ s ɪ t i
 virtuoso	v ɝ t͡ʃ u o ʊ s o ʊ
 virtuous	v ɝ t͡ʃ u ə s
 virulence	v ɪ ɹ j ə l ə n s
@@ -65781,7 +66574,7 @@ visard	v ɪ z ə ɹ d
 visayas	v ɪ s a ɪ ə z
 viscacha	v ɪ s k ɑ t͡ʃ ə
 viscachera	v ɪ s k ɑ t͡ʃ ɛ ɹ ə
-visceral	v ɪ s ə ɹ ə l
+visceral	v ɪ s ɚ ə l
 viscerotonic	v ɪ s ə ɹ ə ʊ t ɒ n ɪ k
 viscose	v ɪ s k ə ʊ s
 viscosity	v ɪ s k ɑ s ɪ t i
@@ -65794,6 +66587,7 @@ visibility	v ɪ z ə b ɪ l ə t i
 visibility	v ɪ z ə b ɪ l ɪ t i
 visibility	v ɪ z ɪ b ɪ l ɪ t i
 visible	v ɪ z ə b ə l
+visibly	v ɪ z ə b l i
 visibly	v ɪ z ɪ b l i
 vision	v ɪ ʒ ə n
 visionary	v ɪ ʒ ə n ɛ ɹ i
@@ -65835,6 +66629,7 @@ vitrify	v ɪ t ɹ ɪ f a ɪ
 vitrine	v ə t ɹ iː n
 vitrine	v ɪ t ɹ iː n
 vitriol	v ɪ t ɹ i ə l
+vitrophyre	v ɪ t ɹ ə f a ɪ ə ɹ
 vituperate	v ə t j u p ə ɹ e ɪ t
 vituperate	v ə t j u p ə ɹ ə t
 vituperation	v a ɪ t j u p ə ɹ e ɪ ʃ ə n
@@ -66184,6 +66979,7 @@ wallis	w ɒ l ɪ s
 wallonia	w ə l ə ʊ n ɪ ə
 wallop	w ɑ l ə p
 walls	w ɔ l z
+walm	w ɑː m
 walm	w ɔː m
 walmartian	w ɔː l m ɑː ɹ ʃ ə n
 walnut	w ɑ l n ə t
@@ -66258,6 +67054,7 @@ want	w ɒ n t
 want	w ɔ n t
 want	w ʌ n t
 wantcha	w ʌ n t͡ʃ ə
+wanted	w ɑ n t ɪ d
 wanting	w ɑ n t ɪ ŋ
 wantok	w ɑ n t ɑ k
 wantokism	w ɑ n t ɒ k ɪ z ə m
@@ -66345,7 +67142,6 @@ was	w ʌ z
 was't	w ɒ z t
 wasabi	w ə s ɑː b i
 wase	w e ɪ s
-wash	w ɑ ʃ
 wash	w ɔ ɹ ʃ
 wash	w ɔ ʃ
 washcloth	w ɔ ʃ k l ɔ θ
@@ -66397,6 +67193,7 @@ waterily	w ɔː t ɹ ɪ l i
 waterloo	w ɑ t ɚ l uː
 waterloo	w ɔ t ɚ l uː
 waterlooville	w ɔː t ə ɹ l uː v ɪ l
+watermelon	w ɑ t ə ɹ m ɛ l ə n
 watermelon	w ɔ t ə ɹ m ɛ l ə n
 waters	w ɔ t ɚ z
 watershed	w ɔ t ɚ ʃ ɛ d
@@ -66578,6 +67375,7 @@ weimar	v a ɪ m ɑ ɹ
 weimar	w a ɪ m ɑ ɹ
 weimaraner	v a ɪ m ə ɹ ɑː n ə ɹ
 weimarization	v a ɪ m ɑ ɹ a ɪ z e ɪ ʃ ə n
+weiqi	w e ɪ t ʃ iː
 weir	w ɪ ɹ
 weird	w i ɚ d
 weird	w ɪ ɚ d
@@ -66649,8 +67447,7 @@ wereleopard	w ɛ ɹ l ɛ p ɚ d
 wereleopard	w ɪ ɹ l ɛ p ɚ d
 werelion	w ɛ ɹ l a ɪ ə n
 werelion	w ɪ ɹ l a ɪ ə n
-weren't	w ɝ n t
-weren't	w ɝ ə n t
+weren't	w ɝ n̩ t
 wererat	w ɛ ɹ æ t
 wererat	w ɪ ɹ æ t
 weretiger	w ɛ ɹ t a ɪ ɡ ɚ
@@ -66658,6 +67455,8 @@ weretiger	w ɪ ɹ t a ɪ ɡ ɚ
 werewolf	w ɛ ə ɹ w ʊ l f
 werewolf	w ɜ ɹ w ʊ l f
 werewolf	w ɪ ə ɹ w ʊ l f
+wergeld	w ɛ ə ɹ ɡ ɛ l d
+wergeld	w ɜː ɹ ɡ ɛ l d
 wert	w ɝ t
 wes	w ɛ s
 wes	w ɛ z
@@ -66740,6 +67539,7 @@ what	w ʌ t
 what	ʍ ʌ t
 what'd	w ʌ d
 what'd	w ʌ t ə d
+what'd	w ʌ t ɪ d
 what'll	h w ɒ t ə l
 what'll	h w ʌ t ə l
 what's	w ɑ t s
@@ -66747,6 +67547,7 @@ what's	w ʌ t s
 what's	ʍ ɑ t s
 what's	ʍ ʌ t s
 whataboutery	w ɒ t ə b a ʊ t ə ɹ i
+whataboutism	w ə t ə b a ʊ t ɪ z ə m
 whatcha	w ʌ t͡ʃ j ə
 whatcha	w ʌ t͡ʃ ə
 whatchamacallit	w ʌ t͡ʃ m ə k ɑ l ɪ t
@@ -66947,6 +67748,8 @@ whitebeam	w a ɪ t b i m
 whiteboard	w a ɪ t b ɔː d
 whitechurch	w a ɪ t t͡ʃ ɜː ɹ t͡ʃ
 whitechurch	ʍ a ɪ t t͡ʃ ɜː ɹ t͡ʃ
+whitehall	w a ɪ t h ɔː l
+whitehall	ʍ a ɪ t h ɔː l
 whitelash	h w a ɪ t l æ ʃ
 whiten	h w a ɪ t n̩
 whiteness	w a ɪ t n ə s
@@ -66983,7 +67786,7 @@ whitwick	ʍ ɪ t w ɪ k
 whitworth	w ɪ t w ɜː r θ
 whitworth	w ɪ t ɜː r θ
 whiz	w ɪ z
-who	h uː
+who	h u
 who'da	h uː d ə
 who's	h uː z
 who's	ʍ uː z
@@ -67137,10 +67940,10 @@ wiktionary	w ɪ k t͡ʃ ə n ɛ ə ɹ i
 wiktionary	w ɪ k ʃ ə n ɛ ə ɹ i
 wilco	w ɪ l k o ʊ
 wild	w a ɪ l d
-wild	w a ɪ ə l d
 wildcat	w a ɪ ə l d k æ t
 wilde	w a ɪ l d
 wildebeest	w ɪ l d ə b i s t
+wilden	w a ɪ l d ə n
 wilder	w a ɪ l d ɚ
 wilder	w ɪ l d ɚ
 wilderness	w ɪ l d ɚ n ə s
@@ -67273,6 +68076,7 @@ winne	w ɪ n
 winner	w ɪ n ɚ
 winnie	w ɪ n i
 winning	w ɪ n ɪ ŋ
+winningest	w ɪ n ɪ ŋ ɪ s t
 winnings	w ɪ n ɪ ŋ z
 winnipeg	w ɪ n ə p ɛ ɡ
 winnipegger	w ɪ n ə p ɛ ɡ ə ɹ
@@ -67352,6 +68156,7 @@ with't	w ɪ θ t
 withal	w ɪ ð ɑ l
 withdraught	w ɪ θ d ɹ æ f t
 withdraw	w ɪ ð d ɹ ɔ
+withdraw	w ɪ θ d ɹ ɔ
 withdrawal	w ɪ ð d ɹ ɔː ə l
 withdrawal	w ɪ θ d ɹ ɔː ə l
 withdrawn	w ɪ ð d ɹ ɔː n
@@ -67373,8 +68178,9 @@ withheld	w ɪ ð h ɛ l d
 withheld	w ɪ θ h ɛ l d
 withhold	w ɪ ð h o ʊ l d
 withhold	w ɪ θ h o ʊ l d
-withholding	w ɪ ð h o ʊ l d i ŋ
-withholding	w ɪ θ h o ʊ l d i ŋ
+withholding	w ɪ ð h o ʊ l d ɪ ŋ
+withholding	w ɪ θ h o ʊ l d ɪ ŋ
+withiel	w ɪ ð j ə l
 withies	w ɪ ð i z
 withies	w ɪ θ i z
 within	w ɪ ð ɪ n
@@ -67413,6 +68219,9 @@ wizardly	w ɪ z ɚ d l i
 wizen	w ɪ z ə n
 wizened	w i z ə n d
 wizened	w ɪ z ə n d
+wlan	d ʌ b ə l j u l æ n
+wlan	w a ɪ j ə ɹ l ə s l æ n
+wlan	w a ɪ ɹ l ə s l æ n
 wo	w o
 wo	w ɔː
 woad	w o ʊ d
@@ -67421,6 +68230,7 @@ woah	w o ʊ
 woak	w o ʊ k
 wobbegong	w ɒ b ɪ ɡ ɒ ŋ
 wobble	w ɑ b l̩
+wobbly	w ɑ b ə l i
 woburn	w ə ʊ b ə ɹ n
 wodehouse	w ʊ d h a ʊ s
 wodehousian	w ʊ d h a ʊ s i ə n
@@ -67569,23 +68379,24 @@ wop	w ɒ p
 worcester	w ʊ s t ɚ
 worcesterberry	w ʊ s t ə ɹ b ɛ ɹ i
 worcestershire	w ɪ s t ɚ ʃ a ɪ ɚ
-worcestershire	w ɪ s t ɚ ʃ i ɹ
+worcestershire	w ɪ s t ɚ ʃ ɪ ɹ
 worcestershire	w ʊ s t ɚ ʃ a ɪ ɚ
-worcestershire	w ʊ s t ɚ ʃ i ɹ
 worcestershire	w ʊ s t ɚ ʃ ɚ
+worcestershire	w ʊ s t ɚ ʃ ɪ ɹ
 word	w ɝ d
 wordbook	w ɝ d b ʊ k
 wordform	w ɝ d f ɔ ɹ m
 wordforms	w ɝ d f ɔ ɹ m z
 words	w ɝ d z
 wordsmith	w ɝ d s m ɪ θ
+wordsmithing	w ɝ d s m ɪ θ ɪ ŋ
 wordster	w ɝ d s t ɚ
 wordy	w ɝ d i
 wore	w ɔ ɹ
-work	w ɔ ɪ̯ k
-work	w ɜ ɹ k
+work	w ɜ ɪ̯ k
 work	w ɜː k
 work	w ɜː ɹ k
+work	w ɝ k
 workaday	w ɜː ɹ k ə d e ɪ
 workamping	w ɝ k k æ m p ɪ ŋ
 workbench	w ɝ k b ɛ n t͡ʃ
@@ -67593,6 +68404,7 @@ worked	w ɝ k t
 worker	w ɝ k ɚ
 workers	w ɝ k ɚ z
 workflow	w ɝ k f l o ʊ
+workforce	w ɝ k f o ɹ s
 working	w ɝ k ɪ ŋ
 workington	w ɜː ɹ k ɪ ŋ t ə n
 workiversary	w ɝ k ə v ɝ s ə ɹ i
@@ -67627,8 +68439,8 @@ worrisome	w ʌ ɹ i s ə m
 worry	w ə ʊ ɹ i
 worry	w ɝ i
 worry	w ʌ ɹ i
-worrywart	w ɝ i w ɔ ɹ t
-worrywart	w ʌ ɹ i w ɔ ɹ t
+worrywart	w ɚ i w o ɹ t
+worrywart	w ʌ ɹ i w o ɹ t
 worsbrough	w ɜː ɹ z b ɹ ə
 worse	w ɝ s
 worsen	w ɝ s n̩
@@ -67641,7 +68453,7 @@ worsley	w ɜː ɹ z l i
 worst	w ɝ s t
 worsted	w ɝ s t ɪ d
 worsted	w ʊ s t ɪ d
-wort	w ɔ r t
+wort	w o ɹ t
 wort	w ɝ t
 wortcunning	w ɝ t k ʌ n ɪ ŋ
 worth	w ɝ θ
@@ -67649,6 +68461,8 @@ worthless	w ɝ θ l ə s
 worthwhileness	w ɜː ɹ θ w a ɪ l n ə s
 worthwhileness	w ɜː ɹ θ ʍ a ɪ l n ə s
 worthy	w ɝ ð i
+worts	w o ɹ t s
+worts	w ɝ t s
 worty	w ɝ t i
 wot	w ɑ t
 wotcher	w ɒ t͡ʃ ə
@@ -67722,7 +68536,7 @@ wrestling	ɹ ɛ s l ɪ ŋ
 wrestling	ɹ ɛ s l̩ ɪ ŋ
 wrests	ɹ ɛ s t s
 wretch	ɹ ɛ t͡ʃ
-wretched	ɹ ɛ t͡ʃ ɪ d
+wretched	ɹ ɛ t͡ʃ ə d
 wretchedness	ɹ ɛ t͡ʃ ɪ d n ə s
 wrexham	ɹ ɛ k s ə m
 wrig	ɹ ɪ ɡ
@@ -67738,6 +68552,10 @@ wrinkled	ɹ ɪ ŋ k l̩ d
 wrinkledness	ɹ ɪ ŋ k ə l d n ə s
 wrinkliness	ɹ ɪ ŋ k ə l i n ə s
 wrinkly	ɹ ɪ ŋ k ə l i
+wriothesley	r a ɪ z l i
+wriothesley	r a ɪ ə θ s l i
+wriothesley	r ɒ t s l i
+wriothesley	r ɛ z l i
 wrist	ɹ ɪ s t
 wristband	ɹ ɪ s t b æ n d
 wristlet	ɹ ɪ s t l ə t
@@ -67755,7 +68573,6 @@ writhle	ɹ ɪ ð ə l
 writhled	ɹ ɪ ð ə l d
 writing	ɹ a ɪ t ɪ ŋ
 writings	ɹ a ɪ t ɪ ŋ z
-written	ɹ ɪ t ə n
 wrizled	ɹ ɪ z ə l d
 wrizzled	ɹ ɪ z ə l d
 wroclaw	v ɹ ɔ t s l ɑ f
@@ -67794,6 +68611,8 @@ wug	w ʌ ɡ
 wuhan	uː h ɑː n
 wuhan	w uː h ɑː n
 wuhu	w uː h uː
+wujiang	w u d͡ʒ j æ ŋ
+wujiang	w u d͡ʒ j ɑ ŋ
 wujiaqu	w uː d͡ʒ i ɑː t͡ʃ uː
 wulumuqi	w uː l uː m uː t͡ʃ iː
 wumao	w uː m a ʊ
@@ -67950,6 +68769,7 @@ xerocracy	z iː ɹ ɑ k ɹ ə s i
 xeromorphic	z ɪ ə ɹ ə m ɔ ɹ f ɪ k
 xerophyte	z ɪ ə ɹ ə ʊ f a ɪ t
 xerox	z iː ə ɹ ɑ k s
+xertz	z ɝ t s
 xerxes	z ɝ k s iː z
 xhosa	k o ʊ s ə
 xhosa	k ɔ s ə
@@ -67996,6 +68816,7 @@ xizang	ʃ iː z ɑː ŋ
 xmas	k ɹ ɪ s m ə s
 xmas	ɛ k s m ə s
 xoanon	z o ʊ ə n ɑ n
+xography	ɛ k s ɒ ɡ ɹ ə f i
 xoloitzcuintle	ʃ o ʊ l o ʊ iː t s k w iː n t l e ɪ
 xoloitzcuintli	ʃ o ʊ l o ʊ ɪ t s k w ɪ n t l i
 xor	k s o ɹ
@@ -68174,6 +68995,7 @@ yaws	j ɔː z
 yay	j e ɪ
 yayan	j ɑː j ɑː n
 yayo	j e ɪ o ʊ
+yclad	ɪ k l æ d
 yclept	ɪ k l ɛ p t
 ye	j e ɪ
 ye	j iː
@@ -68243,6 +69065,7 @@ yes	j ɛ s
 yes'm	j ɛ s ə m
 yeses	j ɛ s ɪ z
 yeshiva	j ə ʃ iː v ə
+yesn't	j ɛ s ə n t
 yesses	j ɛ s ɪ z
 yessir	j ɛ s s ɝ
 yestaday	j ɛ s t ə d e ɪ
@@ -68368,7 +69191,6 @@ youngest	j ʌ ŋ ɡ ə s t
 youngin	j ʌ ŋ ɪ n
 youngling	j ʌ ŋ l ɪ ŋ
 youngster	j ʌ ŋ s t ɚ
-youngun	j ʌ ŋ ə n
 your	j ɔ ɹ
 your	j ɚ
 your	j ɝ
@@ -68463,6 +69285,7 @@ zach	z æ k
 zachary	z æ k ə ɹ i
 zack	z æ k
 zacks	z æ k s
+zaddy	z æ d i
 zadruga	z æ d ɹ uː ɡ ə
 zaffre	z æ f ə ɹ
 zafirlukast	z æ f ɪ ɹ l uː k æ s t
@@ -68492,12 +69315,14 @@ zamindar	z æ m ɪ n d ɑː ɹ
 zamindar	z ə m iː n d ɑː ɹ
 zamora	z ə m ɔ ɹ ə
 zamrock	z æ m ɹ ɑ k
+zamzummim	z a m z ʌ m m ɪ m
 zanamivir	z ə n æ m ɪ v ɪ ɹ
 zander	z æ n d ə ɹ
 zandra	z æ n d ɹ ə
 zangi	z æ ŋ ɡ iː
 zangid	z æ ŋ ɡ ɪ d
 zante	z æ n t i
+zantedeschia	z æ n t ɪ d ɛ s k i ə
 zany	z e ɪ n i
 zanzibar	z æ n z ɪ b ɑː ɹ
 zap	z æ p
@@ -68549,6 +69374,7 @@ zelina	z ɛ l i n ə
 zellige	z ɛ l iː d͡ʒ
 zelophehad	z ɪ l ɒ f ɪ h æ d
 zelus	z iː l ə s
+zemlyanka	z ɛ m l i ɑ ŋ k ə
 zenana	z ə n ɑː n ə
 zenith	z i n ɪ θ
 zenithal	z i n ɪ θ ə l
@@ -68567,7 +69393,7 @@ zerahiah	z ɛ ɹ ə h a ɪ ə
 zerbert	z ɜː ɹ b ə ɹ t
 zerg	z ɜː ɹ ɡ
 zerk	z ɝ k
-zermatt	z ɚ m ɑ t
+zermatt	z ɝ m ɑ t
 zero	z i ɹ o ʊ
 zero	z ɪ ɚ o ʊ
 zeroth	z i ɹ o ʊ θ
@@ -68718,6 +69544,8 @@ zomedy	z ɑ m ə d i
 zonal	z ə ʊ n ə l
 zone	z o ʊ n
 zongdu	d z ʊ ŋ d uː
+zongzi	t s ʊ ŋ t s ɪ
+zongzi	z ʊ ŋ z ɪ
 zonie	z o ʊ n i
 zonisamide	z o ʊ n ɪ s ə m a ɪ d
 zony	z o ʊ n i
@@ -68807,6 +69635,8 @@ zun	z ʊ n
 zunyi	d z uː n j iː
 zuojhen	d z w o ʊ d͡ʒ ʌ n
 zuoyun	d z w o ʊ j uː n
+zuppa	t s uː p ə
+zuppa	z uː p ə
 zurich	z ɜ ɹ ɪ k
 zurich	z ʊ ɹ ɪ k
 zwingli	s w ɪ ŋ ɡ l i
@@ -68851,7 +69681,9 @@ zzzs	z iː z
 æsir	e ɪ z ɪ ɹ
 éclair	ɪ k l ɛ ɹ
 éclat	e ɪ k l ɑː
+élan	e ɪ l æ n
 élan	e ɪ l ɑː n
+émigré	ɛ m ɪ ɡ ɹ e ɪ
 étatisme	e ɪ t ɑː t iː z m
 étatisme	ɛ t ɑ t ɪ z m
 étatisme	ɛ t ɑː t ɪ z ə m

--- a/data/scrape/tsv/eng_latn_us_narrow.tsv
+++ b/data/scrape/tsv/eng_latn_us_narrow.tsv
@@ -17,6 +17,7 @@ aa	ɑ ʔ ɑ
 abear	ə b ɛ ɚ
 abode	ʔ ə b o ʊː d̥̚
 accend	æ k s ɛ n d
+accessibility	ə k s ɛ s ə b ɪ l ə ɾ i
 accommodate	ə kʰ ɑ m ə d e ɪ t
 accommodator	ə k ɑ m ə d e ɪ t ɚ
 accordable	ə kʰ ɔ r ɾ ə b ɫ̩
@@ -40,10 +41,12 @@ addition	ə d ɪ ʃ n̩
 additive	æ ɾ ə t ɪ v
 additive	æ ɾ ə ɾ ɪ v
 adelaide	æ d ɜ l æ ɪ̯ d
+administrative	ə d m ɪ n ə s t ɹ e ɪ ɾ ɪ v
 aelita	a ɪ̯ l i ɾ ə
 aeronautics	ɛ ɹ o ʊ n ɑ ɾ ɪ k s
 aeronautics	ɛ ɹ o ʊ n ɔ ɾ ɪ k s
 aerose	i ɹ ə ʊ z
+aether	e ɪ θ ɚ
 afford	ə f o̞ ɹ d
 agglutinin	ə ɡ l uː ʔ n̩ ɪ n
 aha	ɑ h ɑ
@@ -52,7 +55,6 @@ alacrity	ə l æ k ɹ ɨ t i
 album	a ɫ b̚ m̩
 alder	ɑ l d ɚ
 alders	ɔ l d ɚ z
-alexander	æ l ɨ ɡ z æ n d ɚ
 algorithm	æ ɫ ɡ ə ɹ ɪ ð m̩
 alienation	e ɪ l i ə n e ɪ ʃ ə n
 alignment	ə ɫ a ɪ n m ə n t
@@ -64,6 +66,7 @@ allergy	æ l ɚ d͡ʒ i
 alliteration	ə l ɪ ɾ ə ɹ e ɪ ʃ ə n
 almanac	ɔ l m ə n æ k
 alpha	æ ɫ f ə
+always	ɑ ɫ w e ɪ z
 amatory	æ m ə t ɔ ɚ̯ i
 amatory	ɑː m ə t ə ɹ ɪ
 amazing	ə m e ɪ̯ z ɪ ŋ
@@ -71,9 +74,10 @@ amity	æ m ɪ ɾ i
 amphibious	æ m f ɪ b i ə s
 an	ɛ ə n
 analects	æ n ə l ɛ k t s
+anarchy	ɛ ə n ɑ ɹ k i
 andorra	æ n d o̞ ɹ ə
-andrew	eᵊ n d͡ʒ ɹ ʊ̈ u
-andrew	æ n d͡ʒ ɹ ʊ̈ u
+andrew	eᵊ n d̠ ɹ̠ ˔ʷ ʊ̈ u
+andrew	æ n d̠ ɹ̠ʷ ˔ ʊ̈ u
 angsts	e ɪ ŋ k s t s
 anselm	æ n s ɛ l m
 antarctica	æ ɾ̃ ɑ ɹ ɾ ɪ k ə
@@ -83,6 +87,7 @@ antimatter	æ n i m æ ɾ ɚ
 antimatter	æ n t i m æ ɾ ɚ
 antimatter	æ ɾ̃ i m æ ɾ ɚ
 antre	æ n ɾ ɚ
+aphorism	æ f ə ɹ ɪ z m̩
 app	ʔ æ ʔ p̚
 appear	ə pʰ ɪ ɹ
 apple	æ p ɫ̩
@@ -104,7 +109,7 @@ assertion	ə s ɝ ʃ n̩
 atend	ə tʰ ɛ n d
 atlanta	æ t l æ n ə
 atlanta	æ t l æ ɾ̃ ə
-attack	ə tʰ æ k
+atone	ə tʰ o ʊ̯ n
 attend	ə tʰ ɛ n d
 attic	æ ɾ ɪ k
 attitude	æ ɾ ɪ t u d
@@ -134,11 +139,6 @@ autumn	ɔ ɾ ɪ̈ m
 availability	ə v e ɪ l ə b ɪ l ɪ t ɪ
 avocado	æ v ə k ɑ ɾ o ʊ
 avocado	ɑ v ə k ɑ ɾ o ʊ
-aw	o ə
-aw	ɒ̃ː
-aw	ɔ ə
-aw	ɔ̃ː
-aw	ʊ ə
 awara	æ w ɑ ɹ ʌ
 awara	ɑ w ʌ ɹ ʌ
 ayuh	ˀe ɪ ʌˀ
@@ -160,6 +160,7 @@ bale	b e ə̯ ɫ
 bale	b e ɪ̯ ə ɫ
 balt	b ɑ l t
 balt	b ɔː l t
+banana	b ə n ɛ̃ ə̃ n ə
 bank	b e ɪ ŋ k
 bar	b ɑ ɹ
 bar	b ɑ ˞
@@ -171,7 +172,7 @@ barn	b ɑ ɻ n
 barn	b ɑː n
 barn	b ɒ ə n
 barrel	b æ ɹ ə ɫ
-barrel	b ɛ ɚ ɹ ə ɫ
+barrel	b ɛ ɚ ə ɫ
 barter	b ɑ ɹ ɾ ɚ
 basal	b e ɪ z ə ɫ
 bashful	b æ ʃ f ə ɫ
@@ -188,11 +189,12 @@ battle	b æ ɾ ɫ̩
 batty	b æ ɾ i
 baulk	b ɔ ɫ k
 bautzen	b a ʊ t s ə n
-beagle	b iː ɡ ə ɫ
+beagle	b̥ iː ɡ ə ɫ
 beared	b ɛ ɚ̯ d
 beared	b ɛː d
 beater	b i ɾ ɚ
 beatles	b iː ɾ ɫ̩ z
+beautiful	b j u ɾ ə f ə l
 beauty	b j u ɾ i
 bedding	b ɛ ɾ ɪ ŋ
 bedight	b ɪ d ʌ ɪ t
@@ -287,7 +289,6 @@ calculatable	kʰ æ ɫ k j ə l e ɪ̯ ɾ ə b l̩
 calculator	kʰ æ ɫ k j ə l e ɪ̯ ɾ ɚ
 calendar	kʰ æ l ə n d ɚ
 california	kʰ æ l ɪ f o̞ ɹ n j ə
-call	kʰ ɑ ɫ
 call	kʰ ɔ ɫ
 called	kʰ ɔ l d
 cam	k æ m
@@ -301,13 +302,13 @@ can	kʰ æ n
 can	kʰ ə n
 can	kʰ ɛ ə n
 canada	kʰ e ə n ə d ə
-canada	kʰ ɛ ə n ə d ə
+canada	kʰ ɛ ə n ə ɾ ə
 canadia	kʰ ə n e ɪ̯ ɾ i ə
 canadian	kʰ ə n e ɪ ɾ i ə n
 cap	kʰ æ p
 cap'n	k æ ʔ m̩
 capability	k e ɪ p ə b ɪ l ə t̬ i
-capital	k æ p ɪ t̬ ə l
+capital	k æ p ɪ ɾ ə l
 caramba	k a ɹ a m b a
 card	kʰ ɑ ɹ d
 care	kʰ e ə̯ ɻ
@@ -316,6 +317,7 @@ carload	kʰ ɑ ɹ l o ʊ d
 carton	kʰ ɑ ɹ ʔ n̩
 cat	kʰ æ t
 cat	kʰ æ t̚
+catering	k e ɪ ɾ ɚ ɪ ŋ
 cathedra	k ə θ iː d ɹ ə
 catty	kʰ æ ɾ i
 caught	kʰ o ə̯ t
@@ -326,6 +328,9 @@ caught	kʰ ɔ ə̯ t
 caught	kʰ ɔː t
 caught	kʰ ʊ ə̯ t
 caught	k̠ʰ oː t
+causal	kʰ ɒː z̥ ə l
+causality	kʰ ɒː z̥ æ l ɪ t ɪ
+causation	kʰ ɒː z̥ e ɪ ʃ ə n
 cause	kʰ ɒː z̥
 caused	kʰ ɑ̟ z d
 caused	kʰ ɒ z d
@@ -346,6 +351,7 @@ chalcanthite	~ kʰ e͡ə n ~
 chance	t͡ʃ ɑː n s
 chance	t͡ʃʰ a n s
 chance	t͡ʃʰ e ə n s
+chance	t͡ʃʰ eː n s
 chance	t͡ʃʰ æ n s
 chance	t͡ʃʰ æ n s ~ t͡ʃʰ a n s
 chance	t͡ʃʰ ɐː n s
@@ -369,6 +375,8 @@ chatty	t͡ʃ æ ɾ i
 chaver	h ɑ v ɛ ɹ
 cheated	t͡ʃ i ɾ ɨ d
 check	t͡ʃ ɛ k̚
+child	t͡ʃ a ɪ̯ ɫ d
+child	t͡ʃ a ɪ̯ ɫ̩ d
 children	t ʃ ɪ l ɹ ə n
 china	t͡ʃʰ a ɪ̯ n ə
 chitterlings	t͡ʃ ɪ ɾ ɚ l ɪ ŋ z
@@ -384,6 +392,7 @@ cital	s a ɪ d l̩
 citation	s a ɪ tʰ e ɪ ʃ n̩
 cited	s ɐ ɪ̯ ɾ ɨ d
 citing	s a ɪ̯ ɾ ɪ ŋ
+city	s ɪ tʰ iː
 city	s ɪ ɾ i
 clamming	k l a m ɘ n
 clay	k l̥ e ɪ
@@ -423,6 +432,7 @@ compare	k ə m p e ɚ
 compare	k ə m p e ɹ
 compare	k ə m p ɛ ɚ
 compare	k ə m p ɛ ɹ
+compatibility	k ə m p æ ɾ ə b ɪ l ə ɾ i
 comptroller	k ə m p t ɹ o ʊ l ə ɹ
 comptroller	k ə m t ɹ o ʊ l ə ɹ
 computer	k ə m pʰ j u ɾ ɚ
@@ -485,6 +495,8 @@ credited	k ɹ ɛ d ɪ t̬ ɪ d
 creep	kʰ ɹ iː p
 crisscross	k ɹ ɪ s k ɹ ɒ s
 crisscross	k ɹ ɪ s k ɹ ɔ s
+critical	k ɹ ɪ ɾ ɪ k ə l
+critically	k ɹ ɪ ɾ ɪ k l i
 crocodile	kʰ ɹ ɑ k ə d a ɪ ɫ
 croissant	kʰ ɹ ə s ɑ n t
 croton	k ɹ o ʊ̯ ʔ n̩
@@ -495,6 +507,7 @@ cuba	k j uː b ə
 cuban	k j u b ə n
 cuban	k j uː b ə n
 cuban	k j ʉː b ə n
+cuddleologist	k ʌ d l ɑ l ə d͡ʒ ɪ s t
 culprit	kʰ ʌ ɫ p ɹ̥ ɪ t
 cunt	kʰ ʌ̃ n t
 cursed	kʰ ɝ s t
@@ -526,6 +539,7 @@ dayouth	d a jː uː θ
 dayouth	d æ jː uː θ
 dayum	d e ə j ə m
 dayum	d æ̙ j ə m
+dean	d iː n
 dean	d ĩː n
 dehydrated	d ə h a ɪ d͡ʒ ɹ e ɪ d ə d
 deity	d e ɪ ə ɾ i
@@ -565,19 +579,20 @@ dispel	d ɪ s p ɛ ɫ
 dispensable	d ɪ s pʰ ɛ n s ə b ɫ̩
 dissemble	d ɪ s ɛ m b ə ɫ
 ditto	d ɪ ɾ o ʊ
-dna	d i ɛ n e ɪ
 dniester	d n ɪ e s t ə
 dniester	n iː s t ə
 dockize	d ɒ k ɑ ɪ̯ z
 dojo	d o ʊ̯ d͡ʒ o ʊ̯
 dole	d o ʊ̯ ɫ
+dollywood	d ɑ ɫ i w ʊ d
+dollywood	d ɒ ɫ i w ʊ d
 don't	d o ʊ̯ n
 don't	d õ ʊ̯̃ ʔ t̚
 don't	d õ ʔ
 dope	d o ʊ p
 double	d ʌ b ɫ
 dower	d a ʊ ɚ
-drag	d͡ʒ ɹ æ ɡ
+drag	d͡ɹ̝ ˗ʷ æˑ ɡ
 dragging	d͡ʒ ɹ æ ɡ ɪ ŋ
 dragon	d ɹ e ɪ ɡ ə n
 drain	d͡ʒ ɹ e ɪ n
@@ -601,6 +616,9 @@ drug	d̠͡ɹ̠ ˔ʷ ʌ ɡ
 drugs	d ɹ ʌ ɡ z
 drugs	d͡ʒ ɹ ʌ ɡ z
 drumlin	d ɹ ʌ m l ɪ n
+dry	d̠͡ɹ̠ ˔ a ɪ̯
+dry	d̠͡ɹ̠ ˔ʷ a ɪ̯
+dry	d͡ʒ ɹ a ɪ̯
 dryer	d͡ʒ ɹ a ɪ ɚ
 drying	d͡ʒ ɹ a ɪ ɪ ŋ
 dude	d ʉː u̯ d
@@ -652,6 +670,7 @@ exchange	ɛ k s t͡ʃʰ e ɪ n d͡ʒ
 exigency	ɛ ɡ z ɨ d ʒ ə n s i
 exosome	ɛ k s o ʊ̯ s o ʊ̯ m
 exosome	ɛ k s ə ʊ̯ s ə ʊ̯ m
+fanaticism	f ə n æ ɾ ɪ s ɪ z m̩
 farrand	f æ ɹ ə n d
 farrand	f æ ɹ ə n t
 fatal	f e ɪ ɾ ɫ̩
@@ -669,6 +688,7 @@ fence	f ɛ n t s
 fencer	f ɛ n s ɚ
 fettuccini	f ɛ ɾ ə t͡ʃʰ i n i
 feudal	f j u ɾ ɫ̩
+feudalism	f j u d ə l ɪ z m̩
 fiddle	f ɪ ɾ l̩
 fiddy	f ɪ ɾ i
 fight	f ʌ ɪ t
@@ -772,7 +792,7 @@ glass	ɡ l ɑː s
 glass	ɡ l ɛ ə s
 glitter	ɡ l ɪ ɾ ɚ
 glizzy	ɡ l ɪ z i
-glory	ɡ l ɔ ɹ i
+glory	ɡ l o ɹ i
 glottal	ɡ l ɑ t̬ l̩
 gmail	d͡ʒ iː m e ɪ l
 go	ɡ o ʊ
@@ -789,8 +809,6 @@ golden	ɡ ə ɫ d n̩
 gonna	ɡ o ʊ ɪ n ə
 good	ɡ ɪ̈ d
 good	ɡ ʊ̈ d
-goose	ɡ ʉ s
-goose	ɡ ʉː s
 gotta	ɡ ɑ ɾ ə
 gotten	ɡ ɑ t̚ n̩
 gotten	ɡ ɑ ʔ n̩
@@ -824,6 +842,7 @@ habitat	h æ b ɪ t æ ʔ
 hadith	h a d iː θ
 hah	h aː
 hail	h e ɪ̯ ɫ
+hair	h ɛ ɚ
 hang	h e ɪ ŋ
 hangnail	h e ɪ ŋ n e ɪ̯ ɫ
 hapa	h a p ɐ
@@ -878,8 +897,9 @@ humanist	ç uː m ə n ɪ s t
 humanity	h j u m æ n ɪ ɾ i
 humongous	ç u̟ː m ɐ ŋ ɡ ə s
 humongous	ç u̟ː m ʊ ŋ ɡ ə s
-humph	h ɪ̈ m f
-humph	h ʌ m f
+humph	h ə ɱ f
+humph	h ɱ̩ f
+humph	ɱ̊ ɱ̩ f
 humvee	h ʌ m β iː
 humvee	h ʌ ɱ v iː
 hunter	h ʌ ɾ̃ ɚ
@@ -908,8 +928,7 @@ illegitimate	ɪ l ɨ d͡ʒ ɪ ɾ ə m e ɪ t
 illegitimate	ɪ l ɨ d͡ʒ ɪ ɾ ə m ɨ t
 illusion	ɪ l uː ʒ ə n
 imma	aː m ə
-important	ɪ m p ɔ ɹ ɾ ə n t
-important	ɪ m p ɔ ɹ ʔ n̩ t
+important	ɪ m pʰ ɔ ɹ ʔ n̩ t
 inamorata	ɪ n æ m ə ɹ ɑː ɾ ə
 incalculable	ɪ n kʰ æ ɫ k j ə l ə b l̩
 incidental	ɪ n s ɪ d ɛ n tʰ ə l
@@ -933,13 +952,12 @@ intentional	ɪ n tʰ ɛ n ʃ n̩ ɫ̩
 interchangeable	ɪ ɾ̃ ɚ t͡ʃ e ɪ n d͡ʒ ə b l̩
 interconnect	ɪ n ɾ ɚ k ə n ɛ k t
 interconnect	ɪ ɾ̃ ɚ k ə n ɛ k t
-interloper	ɪ n t ɚ l o ʊ̯ p ɚ
-interloper	ɪ ɾ̃ ɚ l o ʊ̯ p ɚ
 international	ɪ n t ɚ n æ ʃ ə n ə ɫ
 international	ɪ ɾ̃ ɚ n æ ʃ ə n ə ɫ
 internet	ɪ ɾ̃ ɚ n ɛ t
 interstate	ɪ ɾ̃ ɚ s t e ɪ̯ t
 investigate	ɪ n v ɛ s t ɪ ɡ e ɪ̯ t
+invincibility	ɪ n v ɪ n s ə b ɪ l ə ɾ i
 ipa	a ɪ pʰ iː e ɪ
 ireland	a ɪ ɚ l ə n d
 ireland	ä ɪ ɚ ɫ ɪ̈ n d
@@ -1014,9 +1032,6 @@ language	l e ɪ ŋ ɡ w ɪ d͡ʒ
 languages	l e ɪ ŋ ɡ w ɪ d͡ʒ ɪ z
 lar	l ɑ ɹ
 lar	l ɑ ˞
-largely	l aː d͡ʒ l i
-largely	l ɑ ɹ d͡ʒ l i
-largely	l ɑː d͡ʒ l i
 lastborn	l æ s t b ɔ ɚ̯ n
 lastborn	l ɑː s t b ɔː n
 later	l e ɪ̯ ɾ ɚ
@@ -1061,7 +1076,6 @@ m'kay	ŋ k e ɪ
 ma'am	m e ə m
 ma'am	m ɛ ə m
 madder	m æ ɾ ɚ
-mail	m e ɪ̯ ɫ
 mailed	m e ɪ ɫ d
 maintenance	m ẽ ɪ̃ n ʔ ə n ə n s
 make	m e ɪ kʲ
@@ -1086,6 +1100,7 @@ medal	m e ɾ ɫ̩
 medal	m ɛ d ɫ̩
 medal	m ɛ ɾ ɫ̩
 meddle	m ɛ ɾ ə ɫ
+mediocrity	m i d ɪ ɑ k ɹ ɪ ɾ i
 medulla	m ə d ɐ l ə
 medulla	m ə d ʉ ɫ ə
 medulla	m ɛ d ɐ l ə
@@ -1125,7 +1140,7 @@ mikey	m ɐ ɪ kʰ iː
 mile	m a ɪ̯ ɫ
 milkshake	m ɪ ɫ k ʃ e ɪ k
 mill	m ɪ ɫ
-million	m ɪ l j ɪ n
+million	m ɪ ʎ ə n
 minecraft	m a ɪ̯ ŋ k ɹ æ f t
 minnesota	m ɪ n ɪ s o ʊ ɾ ə
 minnesotan	m ɪ n ə s o ʊ ʔ n̩
@@ -1134,8 +1149,8 @@ mirth	m ɝ θ
 mister	m ɪ s t ɚ
 mmm	m̩ː
 model	m ɑ ɾ ɫ
-molasses	m ə l æ s ɨ z
-molasses	m ɵ l æ s ɨ z
+molasses	m ə l æ s ɪ z
+molasses	m ɵ l æ s ɪ z
 moms	m ɑ m z
 montagnard	m ɑ n t ə n j ɑ ɹ d
 montagnard	m ɑ̃ⁿ t ə n j ɑ ˞ d
@@ -1144,7 +1159,7 @@ morgue	m o̞ ɹ ɡ
 morkin	m o̞ ɹ k ɪ n
 morn	m o̞ ɹ n
 morne	m o̞ ɹ n
-morning	m ɔ ɹ n ɪ ŋ
+morning	m o̞ ɹ n ɪ̃ ŋ
 morné	m o̞ ɹ n e ɪ
 moron	m o̞ ɹ ɑ n
 mosquitoey	m ə s k i ɾ o ʊ i
@@ -1190,6 +1205,7 @@ nah	n ẽː
 nail	n e ɪ̯ ɫ
 nares	n e ɹ iː z
 nares	n æ ɹ iː z
+narration	n æ ɹ e ɪ ʃ n̩
 narration	n ɛ ɚ ɹ e ɪ ʃ n̩
 nauruan	n ɑː uː ɹ uː n̩
 neato	n i ɾ o ʊ̯
@@ -1221,13 +1237,13 @@ normality	n ɔ ɹ m æ l ɪ t̬ i
 norse	n o̞ ɹ s
 north	n o̞ ɹ θ
 norville	n ɔː ɹ̩ v ə ɫ
-not	n ɑ t
+not	n ɑ ʔ t
 not	n ɒ t
+not	n ɒ ʔ t
 nothing	n ʌ ʔ n̩
 notice	n o ʊ ɾ ɪ s
 numeration	n j uː m ə ɹ e ɪ ʃ ə n
 numeration	n u m ɚ e ɪ ʃ ə n
-nut	n ɐ t
 nymphid	n ɪ m f ɪ d
 o'malley	o ʊ̯ m æ l i
 o'malley	ɵ m æ l i
@@ -1343,6 +1359,7 @@ petty	pʰ ɛ ɾ i
 pewter	p j u ɾ ɚ
 pff	p͡ɸː
 pff	ʙ̥͡ɸː
+pfft	p͡ɸː t
 phew	ɸ j u̥ ˥˩
 philadelphia	f ɪ ɫ ə d ɜ ɫ f i ə
 phlebolith	f l ɛ b ə l ɪ θ
@@ -1361,14 +1378,13 @@ pin	pʰ ɪ n
 pink	pʰ ɪ ŋ k
 pit	pʰ ɪ ʔ t
 pittance	pʰ ɪ ʔ n̩ s
-pizza	pʰ i t͡s ə
+pizza	pʰ i t s ə
 place	p l̥ e ɪ s
 plack	pʰ l̥ æ k
 plague	pʰ l̥ e ɪ ɡ
 plague	pʰ ɫ̥ ɛː ɡ
 plain	p l̥ e ɪ n
 plan	pʰ l̥ æ n
-plane	pʰ l̥ e ɪ n
 plant	pʰ l̥ æ n t
 plantigrade	p l e ə̯ ɾ̃ ə ɡ ɹ e ɪ̯ d
 plaque	pʰ l̥ æ k
@@ -1417,6 +1433,8 @@ principles	p ɹ ɪ n s ə p l̩ z
 printer	pʰ ɹ ɪ ɾ̃ ɚ
 prism	pʰ ɹ̠̊ ɪ z m̩
 prison	pʰ ɹ̠̊ ɪ z n̩
+probability	p ɹ ɑ b ə b ɪ l ə ɾ i
+probability	p ɹ ɑ b ə b ɪ l ɪ ɾ i
 processors	p ɹ ɑ s ɛ s ɚ z
 prodigal	pʰ ɹ ɑ ɾ ɪ ɡ ɫ̩
 produceorial	p ɹ ɑ d ə s o ʊ ɹ i ə l
@@ -1426,7 +1444,7 @@ pronunciation	pʰ ɹ ə n ʌ n s i e ɪ ʃ ə n
 propaganda	p ɹ ɑ p ə ɡ æ n d ə
 propaganda	p ɹ ɒ p ə ɡ æ n d ə
 property	p ɹ ɑ p ɚ ɾ i
-psittacosis	s i ɾ ə k o ʊ s ɨ s
+psittacosis	s i ɾ ə k o ʊ s ɪ s
 ptui	p͡tʼʰ
 ptui	p͡tʼʰ ə̥
 pulchritude	pʰ ʌ ɫ k ɹ ə t uː d
@@ -1503,8 +1521,6 @@ revelry	ɹ ɛ v ə ɫ ɹ i
 reëvoke	ɹ iː ʔ i v ə ʊ k
 rhotic	ɹ o ʊ̯ ɾ ɪ k
 rhythm	ɹ ɪ ð m̩
-ridden	ɹ ɪ d n̩
-ridden	ɹ ɪ d̚ n̩
 rider	ɹ̠ a ɪ ɾ ɚ
 right	ɹ a ɪ t
 robotic	ɹ o ʊ b ɑ ɾ ɪ k
@@ -1533,6 +1549,7 @@ sang	s æ ŋ
 sang	s ɛ ŋ
 sat	s æ ʔ t̚
 sat	ɛ s e ɪ̯ tʰ i
+satan	s e ɪ ʔ n̩
 saturday	s æ ɾ ɚ d e ɪ̯
 saturday	s æ ɾ ɚ d i
 saw	s ɔ ɹ
@@ -1541,7 +1558,7 @@ scale	s k e ɪ̯ ə ɫ
 scallion	s k æ l j n̩
 scallion	s k æ l ɪ ə n
 scape	s k e ɪ p
-scared	s k ɛ ə ɹ d
+scared	s k ɛ ɚ d
 schemes	s k iː m z̥
 screech	s k ɹ i t͡ʃ
 screech	s k ɹ iː t͡ʃ
@@ -1552,6 +1569,7 @@ scuttle	s k ʌ ɾ ɫ̩
 secretary	s ɛ k ɹ ə tʰ ɛ ɹ i
 security	s ə k j ɔ ɹ ɪ ɾ i
 security	s ə k j ʊ ɹ ɪ ɾ i
+selfish	s ɛ ɫ f ɪ ʃ
 semanticity	s ɪ m æ n tʰ ɪ s ɪ̈ t i
 semitic	s ə m ɪ ɾ ɪ k
 senpai	s ɛ m p a ɪ̯
@@ -1592,15 +1610,14 @@ snippet	s n ɪ p ɪ̈ ʔ t̚
 snow	s n o ʊ̯
 societal	s ə s a ɪ ə t l̩
 societal	s ə s a ɪ ə t̬ l̩
-soil	s ɔ ɪ̯ ɫ
+soil	s ɔ ɪ̯ ɫ̩
 solecism	s o ʊ l ɨ s ɪ z ə m
 soluble	s ɔ ɫ j ʊ b ə ɫ
 some	s ɐ m
-something	s ɐ m θ ɪ ŋ
-something	s ʌ m p θ ɪ ŋ
+something	s ɐ m̥ p θ ɪ ŋ
 something	s ʌ m ʔ m̩
-something	s ʌ m θ ɪ ŋ
-something	s ʌ n̪ θ ɪ ŋ
+something	s ʌ m̥ p θ ɪ ŋ
+something	s ʌ n̪̥ θ ɪ ŋ
 something	s ʌ ɾ̃ ɪ ŋ
 something	s ʌˑ ɪ ŋ
 something	s ʌ̃ː
@@ -1614,6 +1631,7 @@ spotted	s p ɑ ɾ ɪ̈ d
 squander	s kʷ ɑ n d ɚ
 squee	s k w iː
 squitten	s k w ɪ ʔ n̩
+stability	s t ə b ɪ l ɪ ɾ i
 staff	s t a f
 staff	s t e ə f
 staff	s t äː f
@@ -1635,15 +1653,14 @@ steven	s t e ɪ̯ v n̩
 steven	s t iː v n̩
 steven	s t ɛ v n̩
 stiletto	s t ɪ l ɛ ɾ o ʊ
+still	s t ɪ ɫ
 stope	s t o ʊ p
 strand	s t ɹ ɛ ə n d
 street	ʃ t͡ʃ ɹ i tˤ
 streets	ʃ t͡ʃ ɹ i t͡s
-strength	s t̠͡ɹ̠ æ ŋ k θ
 strength	s t̠͡ɹ̠ ɛ n̪ θ
 strength	s t̠͡ɹ̠ ɛ ŋ k θ
 strength	s t̠͡ɹ̠ ɪ ŋ k θ
-strength	ʃ t͡ʃ ɹ e ɪ ŋ k θ
 strident	s t ɹ a ɪ dˀ n t
 strong	s t̠͡ɹ̠ ɔ ŋ
 strong	ʃ t̠͡ɹ̠ ɔ ŋ
@@ -1678,6 +1695,7 @@ syntagms	s ɪ n t æ m z
 t'	t̚
 t'	ʔ
 t'	ː
+ta	tʰ ɑː
 tab	tʰ æ b̥
 tackle	tʰ æ k ɫ̩
 taco	tʰ ɑ k o ʊ
@@ -1702,6 +1720,7 @@ teared	t ɛ ɚ̯ d
 teared	t ɛː d
 teared	t ɪː d
 tech	tʰ ɛ k
+technological	t ɛ k n ə l ɑ d͡ʒ ɪ k l̩
 techwear	tʰ ɛ k w ɛ ɚ
 techwear	tʰ ɛ k w ɛ ɹ
 teeter	tʰ i ɾ ɚ
@@ -1718,8 +1737,7 @@ tenth	tʰ ɛ n̪ θ
 teotwawki	t i ɑ t w ɑ k i
 thank	ð æ ŋ k
 thank	θ æ ŋ k
-thanks	ð æ ŋ k s
-theosophy	θ i ɒ s ə f i
+theosophy	θ i ɑ s ə f i
 thickie	θ ɪ k i
 thirty	θ ɝ ɾ i
 thorn	θ o̞ ɹ n
@@ -1753,9 +1771,6 @@ today	tʰ ə d e ɪ
 today	tʰ ʉ ɾ e ɪː
 today	tʰ ʊ d e ɪ
 tomato	tʰ ə̥ m e ɪ ɾ o ʊ
-tomato	tʰ ə̥ m e ɪ ɾ ə
-tomato	tʰ ə̥ m ɐː tʰ ɐ ʉ
-tomato	tʰ ə̥ m ɑː tʰ ə ʊ
 tomfoolery	t ɔ m ɸ u l ɚ i
 tomfoolery	t ɔ ɱ f u l ɚ i
 too	tʰ u̟
@@ -1805,6 +1820,10 @@ trunk	t͡ʃ ɹ ʌ ŋ k
 trust	t ɹ ɐ s t
 trust	t ɹ ʌ s t
 truthfully	t ɹ uː θ f ɫ̩ i
+try	t ɹ̝̊ a ɪ̯
+try	t̠͡ɹ̠̊ ˔ a ɪ̯
+try	t̠͡ɹ̠̊ ˔ʷ a ɪ̯
+try	t͡ʃ ɹ a ɪ̯
 tucker	tʰ ʌ k ɚ
 tumult	t ʌ m ʌ l t̰̚
 turkish	t ɐ ˞ k ɪ ʃ
@@ -1867,8 +1886,8 @@ under	ʌ n ɾ ɚ
 under	ʌ ɾ̃ ɚ
 understand	ʌ ɾ̃ ɚ s t e ə̯ n d
 understand	ʌ ɾ̃ ɚ s t æ̃ n d
-underutilize	ʌ n ɾ ɚ j uː t ɨ l a ɪ z
-underutilize	ʌ ɾ̃ ɚ j uː t ɨ l a ɪ z
+underutilize	ʌ n ɾ ɚ j uː t ɪ l a ɪ z
+underutilize	ʌ ɾ̃ ɚ j uː t ɪ l a ɪ z
 undivided	ʌ ɾ̃ ɪ̈ v a ɪ̯ ɾ ɪ̈ d
 unfetter	ʌ n f ɛ ɾ ɚ
 unilateral	j ʉː n ə ɫ æ ɾ ɚ ɻ ɫ̩
@@ -1929,7 +1948,6 @@ wait	w e ɪ̯ ʔ t
 waiting	w e ɪ̯ ɾ ɪ ŋ
 wale	w e ɪ ɫ
 wales	w e ɪ ɫ z
-wanted	w ɑ n tʰ ɪ d
 wasn't	w ʌ d n̩ t
 wasn't	w ʌ z n̩ t
 water	w ɑ ɾ ɚ
@@ -1942,12 +1960,16 @@ wear	w ɛ ɹ
 weeaboos	w iː a b yː z
 welp	w ɛ l p̚
 went	w ɛ n ʔ t̚
+weren't	w ɝ n
+weren't	w ɝ̃ ʔ
+weren't	w ɝ̃ ʔ t̚
 westside	w ɛ s s a ɪ d
 westside	w ɛ s t s a ɪ d
 wetting	w ɛ ɾ ɪ ŋ
 what	w ʌ ɾ
 what	w ʌˀ
 what're	w ʌ ɾ ɚ
+whataboutism	w ə ɾ ə b a ʊ ɾ ɪ z m̩
 whatev	w ʌ ɾ ɛ v
 whet	w ɛ ʔ t̚
 whet	ʍ ɛ ʔ t̚
@@ -1971,7 +1993,8 @@ wholly	h o ʊ l i
 wholly	h o ʊ ɫ l i
 whuddup	w ʌ ɾ ʌ p
 width	w ɪ d̪ θ
-wild	w a ɪ ɫ d
+wild	w a ɪ̯ ɫ d
+wild	w a ɪ̯ ɫ̩ d
 wildcat	w a ɪ ə l ʔ k æ t
 wilde	w a ɪ ə̯ ɫ d
 will	w ɪ ɫ
@@ -1999,6 +2022,7 @@ work	w ɚ k
 work	w ɛː k
 work	w ɜː k
 work	w ʊː ɹ k
+workforce	w ɚ k f o̞ ɹ s
 worra	w ɒ ɾ ə
 wouldn't	w ʊ dⁿ n̩ t
 wouldn't	w ʊ n ʔ
@@ -2007,9 +2031,6 @@ wrake	ɹ e ɪ̯ kʰ
 wrightwood	ɹ a i̯ t̚ w ʊ d̚
 wristlet	ɹ ɪ s l ɨ ʔ̚
 writer	ɹ̠ ă ɪ ɾ ɚ
-written	ɹ ɪ ɾ ɪ n
-written	ɹ ɪ ʔ t̚ n̩
-written	ɹ ɪ ʔ ɪ n
 wuddup	w ʌ ɾ ʌ p
 y'all's	j ɔ l z
 yatt	j a t

--- a/data/scrape/tsv_summary.tsv
+++ b/data/scrape/tsv_summary.tsv
@@ -85,12 +85,12 @@ egy_latn_broad.tsv	egy	Egyptian (Ancient)	Egyptian	Latin		False	Broad	False	3569
 ell_grek_broad.tsv	ell	Modern Greek (1453-)	Greek	Greek		False	Broad	True	11900
 ell_grek_broad_filtered.tsv	ell	Modern Greek (1453-)	Greek	Greek		True	Broad	True	11725
 ell_grek_narrow.tsv	ell	Modern Greek (1453-)	Greek	Greek		False	Narrow	True	407
-eng_latn_uk_broad.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Broad	True	71727
-eng_latn_uk_broad_filtered.tsv	eng	English	English	Latin	UK, Received Pronunciation	True	Broad	True	71021
-eng_latn_uk_narrow.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Narrow	True	1557
-eng_latn_us_broad.tsv	eng	English	English	Latin	US, General American	False	Broad	True	69683
-eng_latn_us_broad_filtered.tsv	eng	English	English	Latin	US, General American	True	Broad	True	68874
-eng_latn_us_narrow.tsv	eng	English	English	Latin	US, General American	False	Narrow	True	2035
+eng_latn_uk_broad.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Broad	True	72377
+eng_latn_uk_broad_filtered.tsv	eng	English	English	Latin	UK, Received Pronunciation	True	Broad	True	71835
+eng_latn_uk_narrow.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Narrow	True	1574
+eng_latn_us_broad.tsv	eng	English	English	Latin	US, General American	False	Broad	True	70280
+eng_latn_us_broad_filtered.tsv	eng	English	English	Latin	US, General American	True	Broad	True	69706
+eng_latn_us_narrow.tsv	eng	English	English	Latin	US, General American	False	Narrow	True	2056
 enm_latn_broad.tsv	enm	Middle English (1100-1500)	Middle English	Latin		False	Broad	True	8825
 epo_latn_broad.tsv	epo	Esperanto	Esperanto	Latin		False	Broad	True	4889
 epo_latn_narrow.tsv	epo	Esperanto	Esperanto	Latin		False	Narrow	True	12218


### PR DESCRIPTION
Uploading tsv files for upstream cleaning with regards to English high vowel and schwa.

......
history goes here
.....
git clone https://github.com/Othergreengrasses/wikipron.git
git checkout -b eng_high_front_vowel_and_schwa
cd data/
cd scrape/
./scrape.py --restriction eng
./postprocess
git add README.md
git add tsv/eng_latn_uk_broad.tsv
git add tsv/eng_latn_uk_broad_filtered.tsv
git add tsv/eng_latn_uk_narrow.tsv
git add tsv/eng_latn_us_broad.tsv
git add tsv/eng_latn_us_broad_filtered.tsv
git add tsv/eng_latn_us_narrow.tsv
git add tsv_summary.tsv
git add CHANGELOG.md

....

 Please merge if it looks good.
Thank you!

