### PR TITLE
Added "ː"-suffixed chars to list of valid IPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 ### Under `data/`
 
 ### Under `wikipron/` and elsewhere
+-   Added "ː"-suffixed characters to list of valid IPAs. (\#497)
 
 [1.3.0] - 2022-11-28
 --------------------

--- a/data/phones/lib/list_phones.py
+++ b/data/phones/lib/list_phones.py
@@ -24,11 +24,11 @@ _other_valid_ipa = frozenset(
 )
 
 _suffixed_other_valid_ipa = frozenset(
-    phone + 'ː'
-    for phone in _other_valid_ipa
+    phone + "ː" for phone in _other_valid_ipa
 )
 
 OTHER_VALID_IPA = _other_valid_ipa | _suffixed_other_valid_ipa
+
 
 def _count_phones(filepath: str) -> Dict[str, Set[str]]:
     """Count the phones in the given TSV file.

--- a/data/phones/lib/list_phones.py
+++ b/data/phones/lib/list_phones.py
@@ -17,12 +17,18 @@ from typing import Dict, List, Set
 
 import ipapy
 
-OTHER_VALID_IPA = frozenset(
+OTHER_VALID_IPA = set(
     phone
     for phone in ipapy.UNICODE_TO_IPA.keys()
     if not ipapy.is_valid_ipa(unicodedata.normalize("NFD", phone))
 )
 
+SUFFIXED_OTHER_VALID_IPA = set(
+    phone + 'ː'
+    for phone in OTHER_VALID_IPA
+)
+
+OTHER_VALID_IPA = frozenset(OTHER_VALID_IPA | SUFFIXED_OTHER_VALID_IPA)
 
 def _count_phones(filepath: str) -> Dict[str, Set[str]]:
     """Count the phones in the given TSV file.

--- a/data/phones/lib/list_phones.py
+++ b/data/phones/lib/list_phones.py
@@ -17,18 +17,18 @@ from typing import Dict, List, Set
 
 import ipapy
 
-OTHER_VALID_IPA = set(
+_other_valid_ipa = frozenset(
     phone
     for phone in ipapy.UNICODE_TO_IPA.keys()
     if not ipapy.is_valid_ipa(unicodedata.normalize("NFD", phone))
 )
 
-SUFFIXED_OTHER_VALID_IPA = set(
+_suffixed_other_valid_ipa = frozenset(
     phone + 'ː'
-    for phone in OTHER_VALID_IPA
+    for phone in _other_valid_ipa
 )
 
-OTHER_VALID_IPA = frozenset(OTHER_VALID_IPA | SUFFIXED_OTHER_VALID_IPA)
+OTHER_VALID_IPA = _other_valid_ipa | _suffixed_other_valid_ipa
 
 def _count_phones(filepath: str) -> Dict[str, Set[str]]:
     """Count the phones in the given TSV file.


### PR DESCRIPTION
Fixed issues outlined in [issue #272](https://github.com/CUNY-CL/wikipron/issues/272)

[list_phones.py](https://github.com/CUNY-CL/wikipron/blob/master/data/phones/lib/list_phones.py) was incorrectly rejecting IPA symbols such as "t̼ː" because ipapy doesn't recognize "ː" as a valid suffix for some IPA characters for whatever reason. I added all "ː"-suffixed IPA symbols to our supplementary list of IPA symbols not covered by ipapy to fix this.

- [ ] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.