### PR TITLE
Catch iso639.language.LanguageNotFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Unreleased
 ### Under `data/`
 
 ### Under `wikipron/` and elsewhere
--   Added "ː"-suffixed characters to list of valid IPAs. (\#497)
+-   Caught iso639.language.LanguageNotFoundError error in codes.py (\#498)
 
 [1.3.0] - 2022-11-28
 --------------------
@@ -22,6 +22,7 @@ Unreleased
 
 #### Added
 
+-   Added "ː"-suffixed characters to list of valid IPAs. (\#497)
 -   Renamed the two TSV summaries to `summary.tsv`. (\#494)
 -   Renamed `generate_tsv_summary.py` to `generate_summary.py`. (\#492)
 -   Upstream cleaning wrt English tie bar. (\#491)

--- a/data/scrape/lib/codes.py
+++ b/data/scrape/lib/codes.py
@@ -174,14 +174,14 @@ def main() -> None:
             wiktionary_code = _scrape_wiktionary_language_code(
                 wiktionary_name.replace(" ", "_")
             )
-            
+
             try:
                 iso639_lang = iso639.Language.match(wiktionary_code)
             except iso639.language.LanguageNotFoundError:
                 logging.warning(
                     "Could not find language with code %s", wiktionary_code
                 )
-                
+
             if iso639_lang is None:
                 # No match found for the Wiktionary code.
                 unmatched_languages[wiktionary_code] = {

--- a/data/scrape/lib/codes.py
+++ b/data/scrape/lib/codes.py
@@ -174,7 +174,14 @@ def main() -> None:
             wiktionary_code = _scrape_wiktionary_language_code(
                 wiktionary_name.replace(" ", "_")
             )
-            iso639_lang = iso639.Language.match(wiktionary_code)
+            
+            try:
+                iso639_lang = iso639.Language.match(wiktionary_code)
+            except iso639.language.LanguageNotFoundError:
+                logging.warning(
+                    "Could not find language with code %s", wiktionary_code
+                )
+                
             if iso639_lang is None:
                 # No match found for the Wiktionary code.
                 unmatched_languages[wiktionary_code] = {

--- a/data/scrape/lib/codes.py
+++ b/data/scrape/lib/codes.py
@@ -174,14 +174,13 @@ def main() -> None:
             wiktionary_code = _scrape_wiktionary_language_code(
                 wiktionary_name.replace(" ", "_")
             )
-
             try:
                 iso639_lang = iso639.Language.match(wiktionary_code)
             except iso639.language.LanguageNotFoundError:
                 logging.warning(
                     "Could not find language with code %s", wiktionary_code
                 )
-
+                continue
             if iso639_lang is None:
                 # No match found for the Wiktionary code.
                 unmatched_languages[wiktionary_code] = {


### PR DESCRIPTION
The iso639 module occasionally doesn't recognizing ISO language codes. Updated the code to catch this error and display a warning.

- [X] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.