### PR TITLE
Added missing palatal stops to Azerbaijani phonelist

### DIFF
--- a/data/phones/phones/aze_narrow.phones
+++ b/data/phones/phones/aze_narrow.phones
@@ -7,9 +7,7 @@
 # are a number of points I am unsure about. The transcriptions did not always
 # match the orthography in the expected way, and due to the lack of data, I 
 # could not tell if this was due to allophony, inconsistent orthography, or
-# errors in the transcription. Additionally, some phones listed in the sources
-# (such as /c/ and /ɟ/) did not appear in the data, or appeared only a handful
-# of times. I'm also unsure whether all vowels and consonants have long 
+# errors in the transcription. I'm also unsure whether all vowels and consonants have long 
 # counterparts, or only some.
 #####
 # CONSONANTS
@@ -40,6 +38,8 @@ t͡ʃ
 d͡ʒ
 ʃ
 ʒ
+c
+ɟ
 ç
 j
 k  # Apparently, only occurs in loanwords. Nevertheless, it is very common in the data.

--- a/data/phones/phones/nob_broad.phones
+++ b/data/phones/phones/nob_broad.phones
@@ -2,28 +2,45 @@
 #
 ### CONSONANTS ###
 p
+pː
 b
+bː
 m
+mː
 f
+fː
 v  # Allophone of /ʋ/.
 ʋ
 t
+tː
 d
+dː
 n
+nː
 r
+rː
 ɾ  # Less common (but apparently, more phonetically accurate) transcription of /r/.
 s
+sː
 l
+lː
 ʃ  # Less common transcription of /ʂ/.
+ʃː
 ʈ  # Underlyingly /rt/.
+ʈː
 ɳ  # Underlyingly /rn/.
 ʂ
+ʂː
 ɽ
 ç
 j
+jː
 k
+kː
 ɡ
+ɡː
 ŋ
+ŋː
 h
 # Syllabic consonants
 n̩


### PR DESCRIPTION
[ɟ, c] were missing from the Azerbaijani phonelist (aze_narrow.phones). I added them in.

Closes #527 