### PR TITLE
Added missing palatal stops to Azerbaijani phonelist

### DIFF
--- a/data/phones/README.md
+++ b/data/phones/README.md
@@ -3,7 +3,7 @@ See the [HOWTO](HOWTO.md) for the steps to generate phone lists.
 | :---- | :---- | :---- | :---- | :---- | ----: |
 | [phone](phones/ady_narrow.phones) | ady | Adyghe | Adyghe | Narrow | 67 |
 | [phone](phones/afr_broad.phones) | afr | Afrikaans | Afrikaans | Broad | 61 |
-| [phone](phones/aze_narrow.phones) | aze | Azerbaijani | Azerbaijani | Narrow | 54 |
+| [phone](phones/aze_narrow.phones) | aze | Azerbaijani | Azerbaijani | Narrow | 56 |
 | [phone](phones/ben_dhaka_broad.phones) | ben | Bengali | Bengali (Dhaka) | Broad | 98 |
 | [phone](phones/ben_rarh_broad.phones) | ben | Bengali | Bengali (Rarh, Standard Bengali) | Broad | 99 |
 | [phone](phones/bul_broad.phones) | bul | Bulgarian | Bulgarian | Broad | 52 |

--- a/data/phones/phones/aze_narrow.phones
+++ b/data/phones/phones/aze_narrow.phones
@@ -7,10 +7,8 @@
 # are a number of points I am unsure about. The transcriptions did not always
 # match the orthography in the expected way, and due to the lack of data, I 
 # could not tell if this was due to allophony, inconsistent orthography, or
-# errors in the transcription. Additionally, some phones listed in the sources
-# (such as /c/ and /ɟ/) did not appear in the data, or appeared only a handful
-# of times. I'm also unsure whether all vowels and consonants have long 
-# counterparts, or only some.
+# errors in the transcription. I'm also unsure whether all vowels and consonants 
+# have long counterparts, or only some.
 #####
 # CONSONANTS
 p
@@ -42,6 +40,8 @@ d͡ʒ
 ʒ
 ç
 j
+c
+ɟ
 k  # Apparently, only occurs in loanwords. Nevertheless, it is very common in the data.
 kː
 ɡ

--- a/data/phones/summary.tsv
+++ b/data/phones/summary.tsv
@@ -1,6 +1,6 @@
 ady_narrow.phones	ady	Adyghe	Adyghe	Narrow	67
 afr_broad.phones	afr	Afrikaans	Afrikaans	Broad	61
-aze_narrow.phones	aze	Azerbaijani	Azerbaijani	Narrow	54
+aze_narrow.phones	aze	Azerbaijani	Azerbaijani	Narrow	56
 ben_dhaka_broad.phones	ben	Bengali	Bengali (Dhaka)	Broad	98
 ben_rarh_broad.phones	ben	Bengali	Bengali (Rarh, Standard Bengali)	Broad	99
 bul_broad.phones	bul	Bulgarian	Bulgarian	Broad	52

--- a/data/scrape/README.md
+++ b/data/scrape/README.md
@@ -5,7 +5,7 @@
   * Broad transcription files: 23
   * Narrow transcription files: 22
 * Scripts: 42
-* Pronunciations: 4,311,168
+* Pronunciations: 4,311,273
 
 
 | Link | ISO 639-3 Code | ISO 639 Language Name | Wiktionary Language Name | Script | Dialect | Filtered | Narrow/Broad | # of entries |
@@ -42,9 +42,9 @@
 | [TSV](tsv/ast_latn_broad.tsv) | ast | Asturian | Asturian | Latin |  | False | Broad | 1,018 |
 | [TSV](tsv/ast_latn_narrow.tsv) | ast | Asturian | Asturian | Latin |  | False | Narrow | 986 |
 | [TSV](tsv/ayl_arab_broad.tsv) | ayl | Libyan Arabic | Libyan Arabic | Arabic |  | False | Broad | 163 |
-| [TSV](tsv/aze_latn_broad.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | False | Broad | 367 |
-| [TSV](tsv/aze_latn_narrow.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | False | Narrow | 4,137 |
-| [TSV](tsv/aze_latn_narrow_filtered.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | True | Narrow | 3,499 |
+| [TSV](tsv/aze_latn_broad.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | False | Broad | 383 |
+| [TSV](tsv/aze_latn_narrow.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | False | Narrow | 4,226 |
+| [TSV](tsv/aze_latn_narrow_filtered.tsv) | aze | Azerbaijani | Azerbaijani | Latin |  | True | Narrow | 4,011 |
 | [TSV](tsv/bak_cyrl_broad.tsv) | bak | Bashkir | Bashkir | Cyrillic |  | False | Broad | 179 |
 | [TSV](tsv/bak_cyrl_narrow.tsv) | bak | Bashkir | Bashkir | Cyrillic |  | False | Narrow | 2,184 |
 | [TSV](tsv/ban_bali_broad.tsv) | ban | Balinese | Balinese | Balinese |  | False | Broad | 410 |

--- a/data/scrape/summary.tsv
+++ b/data/scrape/summary.tsv
@@ -30,9 +30,9 @@ asm_beng_broad.tsv	asm	Assamese	Assamese	Bengali		False	Broad	2925
 ast_latn_broad.tsv	ast	Asturian	Asturian	Latin		False	Broad	1018
 ast_latn_narrow.tsv	ast	Asturian	Asturian	Latin		False	Narrow	986
 ayl_arab_broad.tsv	ayl	Libyan Arabic	Libyan Arabic	Arabic		False	Broad	163
-aze_latn_broad.tsv	aze	Azerbaijani	Azerbaijani	Latin		False	Broad	367
-aze_latn_narrow.tsv	aze	Azerbaijani	Azerbaijani	Latin		False	Narrow	4137
-aze_latn_narrow_filtered.tsv	aze	Azerbaijani	Azerbaijani	Latin		True	Narrow	3499
+aze_latn_broad.tsv	aze	Azerbaijani	Azerbaijani	Latin		False	Broad	383
+aze_latn_narrow.tsv	aze	Azerbaijani	Azerbaijani	Latin		False	Narrow	4226
+aze_latn_narrow_filtered.tsv	aze	Azerbaijani	Azerbaijani	Latin		True	Narrow	4011
 bak_cyrl_broad.tsv	bak	Bashkir	Bashkir	Cyrillic		False	Broad	179
 bak_cyrl_narrow.tsv	bak	Bashkir	Bashkir	Cyrillic		False	Narrow	2184
 ban_bali_broad.tsv	ban	Balinese	Balinese	Balinese		False	Broad	410

--- a/data/scrape/tsv/aze_latn_broad.tsv
+++ b/data/scrape/tsv/aze_latn_broad.tsv
@@ -32,6 +32,8 @@ ar	ɑ r
 armağan	ɑ r m ɑ ɣ ɑ n
 arpa	ɑ r p ɑ
 arxa	ɑ r χ ɑ
+arxayın	ɑ ɾ x e j i n
+arxayın	ɑ ɾ x ɑ j ɯ n
 arxivləşdirmək	ɑ r x i v l æ ʃ d i r m æ c
 arzu	ɑ r z u
 at	ɑ t
@@ -68,8 +70,11 @@ busə	b u s æ
 butulka	b u t u ɫ k a
 buğda	b u ɣ d ɑ
 bölmək	b œ l m æ k
+bülöv	b ɯ l œ
+bünövrə	b ɯ n œ r æ
 bürümək	b y r y m æ k
 bütöv	b y t œ v
+bütöv	b ɯ t œ
 bütün	b y t y n
 bığ	b ɯ ɣ
 bələk	b æ l æ c
@@ -88,6 +93,8 @@ dalğın	d ɑ ɫ ɣ ɯ n
 dam	d ɑ m
 davam	d ɑ v ɑ m
 deyil	d e j i l
+deyil	d æ d ʒ i l
+deyil	d æː l
 deşik	d e ʃ i k
 dildaş	d i l d ɑ ʃ
 diloça	d i l oː t͡ʃ ɑ
@@ -102,6 +109,7 @@ dəstək	d æ s t æ c
 dəstəkləmək	d æ s t æ c l æ m æ c
 e	e
 el	e l
+etimologiya	ɛ t i m o l o ɟ i j ɑ
 evlənmək	e v l æ n m æ k
 evsizlik	e v s i z l i c
 eyi	e j i
@@ -158,6 +166,9 @@ həvəs	h æ v æ s
 həvəskar	h æ v æ s c ɑ r
 i	ɪ
 idman	i d m ɑ n
+igid	i d ʒ i d
+igid	i j i t
+igid	i ɟ i d
 iki	i c i
 inadkar	i n ɑ d k ɑ r
 inanmaq	i n ɑ n m ɑ χ
@@ -204,6 +215,8 @@ noyabr	n o j ɑ b r
 nə	n æ
 nəmənə	n æ m æ n æ
 o	ɔ
+od	o d
+od	o t
 onlar	o n l a r
 oyaq	o j ɑ χ
 oğlan	o ɣ ɫ ɑ n
@@ -253,6 +266,8 @@ soyqırım	s o j ɡ ɯ ɾ ɯ m
 soyunmaq	s o j u n m ɑ χ
 sual	s u ɑ ɫ
 sulu	s u ɫ u
+süd	s y d
+süd	s y t
 sınmaq	s ɯ n m ɑ χ
 sən	s æ n
 səngək	s æ ŋ æ k
@@ -293,7 +308,7 @@ y	j
 ya	j ɑ
 ya	j ɑː
 yapışqan	j ɑ p ɯ ʃ ɡ ɑ n
-yağmaq	j ɑ ɣ m ɑ χ
+yağmaq	j ɑ ɣ m ɑ x
 yaşıl	j ɑ ʃ ɯ ɫ
 yekə	j e c æ
 yenə	j e n æ
@@ -355,12 +370,13 @@ zənci	z æ n d͡ʒ i
 şəxsi	ʃ æ χ s i
 Ədirnə	æ d i r n æ
 Əli	æ l i
+Ƣ	ɣ
+ƣ	ɣ
 ə	æ
 əmcək	æ m d͡ʒ æ k
 ərik	æ r i c
 əsas	æ s ɑ s
 əslində	æ s l i n d æ
-əvəzlik	æ v æ z l i k
 əyyam	æ j ɑ m
 əyyam	ɑ j ɑ m
 əzim	æ z i m

--- a/data/scrape/tsv/aze_latn_narrow.tsv
+++ b/data/scrape/tsv/aze_latn_narrow.tsv
@@ -234,6 +234,7 @@ aylanmaq	ɑ j ɫ ɑ n m ɑ χ
 aylıq	ɑ j ɫ ɯ χ
 ayran	ɑ j r ɑ n
 aysberq	ɑ j s b e r ɡ
+aysız	ɑ j s ɯ z
 ayğır	ɑ j ɣ ɯ r
 ayılmaq	ɑ j ɯ ɫ m ɑ χ
 ayıq	ɑ j ɯ χ
@@ -348,6 +349,7 @@ bariqa	b ɑ r i ɡ ɑ
 barmaq	b ɑ r m ɑ χ
 barmaqlamaq	b ɑ r m ɑ ɣ l ɑ m ɑ χ
 barmaqlıq	b ɑ r m ɑ ɣ ɫ ɯ χ
+baron	b ɑ r o n
 barı	b ɑ r ɯ
 barışmaq	b ɑ r ɯ ʃ m ɑ χ
 barədə	b ɑː r æ d æ
@@ -417,6 +419,8 @@ beyt	b e j t
 bezmək	b e z m æ j
 bezmək	b e z m æ k
 beşbarmaq	b e ʃ b ɑ r m ɑ χ
+beşbetər	b e ʃ b e t æ r
+beşbetər	b e ʃ p æ t æ r
 beşik	b e ʃ i j
 beşik	b e ʃ i k
 beşik	b e ʃ i ç
@@ -425,6 +429,7 @@ bibi	b i b i
 bibioğlu	b i b i o ɣ ɫ u
 bibiqızı	b i b i ɡ ɯ z ɯ
 bibər	b i b æ ɾ
+biganə	b i ɟ ɑː n æ
 bilgi	b i l ɟ i
 bilik	b i l i c
 bilik	b i l i j
@@ -538,6 +543,7 @@ buzov	b z ɔ w
 buğur	b u ɣ u r
 buğur	b ɯ ɣ ɯ r
 böhran	b œ h r ɑ n
+bölmə	b œ l m æ
 börk	b ø ɾ t̚
 börk	b œ r c
 böyründə	b œ j r y n d æ
@@ -560,7 +566,8 @@ bülöv	b y l œ v
 bülövləmək	b y l œ v l æ m æ k
 bünyad	b y n j ɑ d
 bünövrə	b y n œ v r æ
-bütöv	p ẙ t œ v
+bütpərəst	b y t p æ r æ s t
+bütöv	p y̥ t œ v
 bütün	p y̥ t y n
 bıçaq	b ɯ t͡ʃ ɑ χ
 bıçaq	p t͡s ɑ χ
@@ -576,6 +583,8 @@ bəla	b æ ɫ ɑ
 bəlağət	b æ ɫ ɑː ɣ æ t
 bəlağətli	b æ ɫ ɑː ɣ æ t l i
 bəlağətli	b æ ɫ ɑː ɣ æ tː i
+bəlgə	b æ l i j æ
+bəlgə	b æ l ɟ æ
 bəlkə	b æ l k æ
 bəlkə	b æ l k æ m
 bəlkə	b æ r k æ
@@ -601,6 +610,7 @@ bərk	b æ ɾ t̚
 bərkdən	b æ r k d æ n
 bərkdən	b æ r k t æ n
 bərpa	b æ r p ɑ
+bərəkallah	b æ r æ c ɑ nː ɑ h
 bərəkallah	b æ r æ c ɑ ɫː ɑ h
 bərəkət	b æ r æ c æ t
 bərəkət	b æ r æ t͡ʃ æ t
@@ -658,6 +668,8 @@ cinsi	d͡z i n s i
 cinsi	d͡ʒ i n s i
 civi	d͡z i v i
 civi	d͡ʒ i v i
+cizgi	d͡z i z d͡ʒ i
+cizgi	d͡ʒ i z ɡ i
 cizyə	d͡z i z j æ
 cizyə	d͡ʒ i z j æ
 cuhud	d͡z u h u d
@@ -687,6 +699,8 @@ cığır	d͡z ɯ ɣ ɯ r
 cığır	d͡ʒ ɯ ɣ ɯ r
 cəbhəçi	d͡z æ p h æ t͡s i
 cəbhəçi	d͡ʒ æ p h æ t͡ʃ i
+cəbri	d͡z æ b r i
+cəbri	d͡ʒ æ b r i
 cəhan	d͡ʒ æ h ɑ n
 cəhd	d͡z æ h d
 cəhd	d͡ʒ æ h d
@@ -831,6 +845,7 @@ dincəlmək	d i n d͡z æ l m æ j
 dincəlmək	d i n d͡z æ l m æ k
 dincəlmək	d i n d͡ʒ æ l m æ j
 dincəlmək	d i n d͡ʒ æ l m æ k
+dindar	d i n d a r
 dindirmə	d i n d i r m æ
 dinləmək	d i n l æ m æ c
 dinləmək	d i n l æ m ɑ χ
@@ -909,8 +924,12 @@ dördüncü	d œ ɾ d y n d͡ʒ y
 dövlət	d œ w l æ t
 dövlət	d œ y̯ v l æ t
 dövr	d œ v r
+dövri	d e v r i
+dövri	d œ v r i
+dövri	d œ v r y
 dövriyyə	d œ v r i j æ
 dövrə	d œ v r æ
+dövrəvi	d œ v r æ v i
 döymək	d œ j m æ c
 döymək	d œ j m æ j
 döymək	d œ j m ɑ χ
@@ -1015,6 +1034,7 @@ dərzi	d æ r z i
 dəstək	d æ s t æ j
 dəstək	d æ s t æ ç
 dəstəmaz	d æ s t æ m ɑ z
+dəxil	d æ x i l
 dəxl	d æ x l
 dəxmə	d æ x m æ
 dəyirman	d æ j i r m ɑ n
@@ -1087,6 +1107,7 @@ evcik	e v d͡ʒ i j
 evcik	e v d͡ʒ i k
 evlənmək	e v l æ mː æ j
 evlənmək	e v l æ mː æ k
+evsiz	e v s i z
 eybəcər	e j b æ d͡z æ r
 eybəcər	e j b æ d͡ʒ æ r
 eyham	e j h ɑ m
@@ -1149,6 +1170,8 @@ gecəqondu	ɟ e d͡ʒ æ ɡ o n d u
 general	ɟ e n e r ɑ ɫ
 geniş	d͡ʒ e n i ʃ
 geniş	ɟ e n i ʃ
+genişlənmək	ɟ e n i ʃ l æ mː æ c
+genişlənmək	ɟ e n i ʃ l æ n m æ c
 geri	ɟ e r i
 getmək	d͡ʒ e t m ɑ χ
 getmək	ɟ e t m æ c
@@ -1364,6 +1387,8 @@ hasa	h ɑ s ɑ
 hasar	h ɑ s ɑ r
 hasilat	h ɑː s i ɫ ɑ t
 hava	h ɑ v ɑ
+havaxt	h ɑ v ɑ χ t
+hayan	h ɑ j ɑ n
 hazır	h ɑ z ɯ r
 hazır	h ɑː z ɯ r̥
 hazırkı	h ɑ z ɯ r k i
@@ -1385,12 +1410,15 @@ heç	h e t͡ʃ
 hilal	h i l ɑ l
 his	h i s
 hiss	h i sː
+hissə	h i sː æ
 hiylə	h i j l æ
 homoseksuallıq	h o m o s e k s u a ɫː ɯ χ
 hoppanmaq	h o pː ɑ mː ɑ χ
 hoqqa	h o kː ɑ
 hovuz	h o v u z
 huş	h u ʃ
+huşsuzluq	h u ʃ s u z d u x
+huşsuzluq	h u ʃ s u z ɫ u x
 hökumət	h œ c uː m æ t
 hökumət	h œ c y m æ t
 hörmətcil	h œ r m æ t d͡z i l
@@ -1438,6 +1466,7 @@ həmsöhbət	h æ m s œ j b æ t
 həmsöhbət	h æ m s œː b æ t
 həmyaş	h æ m j ɑ ʃ
 həndəsə	h æ n d æ s æ
+həngamə	h æ ŋ ɟ ɑː m æ
 həqarət	h æ ɡ ɑː r æ t
 həqiqi	h æ ɡ iː ɡ i
 hər	h æ r
@@ -1697,7 +1726,7 @@ kimyaçı	t͡ʃ i m j a t͡s ɯ
 kimyəvi	c i m j æː v i
 kimyəvi	t͡ʃ i m j æː v i
 kiməsə	c i m æ s æ
-kinayə	k i n ɑː j æ
+kinayə	c i n ɑː j æ
 kiriş	c i r i ʃ
 kirli	c i r l i
 kirli	c i rː i
@@ -1708,8 +1737,8 @@ kirəc	t͡ʃ i r æ d͡z
 kitabxana	c i t ɑ b χ ɑ n ɑ
 kitabxanaçı	c i t ɑ b x ɑ n ɑ t͡ʃ ɯ
 kitabxanaçı	t͡ʃ i t ɑ b x ɑ n ɑ t͡s ɯ
-kitayski	kʲʰ i t ɑ j s kʲ i
-kitayski	t͡ʃ i t ɑ j s kʲʰ i
+kitayski	c i t ɑ j s c i
+kitayski	t͡ʃ i t ɑ j s c i
 kiçik	c i t͡ʃ i c
 kiçik	c i t͡ʃ i j
 kiçik	c i t͡ʃ i ç
@@ -1739,7 +1768,8 @@ kor	t͡ʃ o r̥
 korona	k ɑ ɾ oː n ɑ
 koğuş	c o ɣ u ʃ
 kravat	k r ɑ v ɑ t
-kulyok	k u l j o k
+kulyok	k u ɫ j ɔ k
+kulyok	k ɫ ɔ k
 kuxna	k u x n a
 köhnə	c œ h n æ
 köhnə	c œ j n æ
@@ -1778,6 +1808,8 @@ köçəri	t͡ʃ œ t s æ r i
 köşək	c œ ʃ æ c
 köşək	c œ ʃ æ j
 köşək	t͡ʃ œ ʃ æ t͡ʃ
+küftə	c y f t æ
+küftə	t͡ʃ y f t æ
 kül	k y l
 küll	c y l
 külək	c y l æ c
@@ -1844,6 +1876,8 @@ kəsmək	c æ s m æ k
 kəsmək	t͡ʃ æ s m ɑ χ
 kəsək	c æ s æ c
 kəsək	t͡ʃ æ s æ c
+kəsəl	c æ s æ l
+kəsəl	t͡ʃ æ s æ l
 labüd	ɫ ɑː b y d
 lahiyə	ɫ ɑː h i j æ
 lakin	l aː c i n
@@ -2022,6 +2056,7 @@ müşəmbə	m y ʃ æ m b æ
 müəllif	m y æ lː i f
 müəllif	mᶣ æ lː i f
 müəllim	m y æ lː i m
+müəllimlik	m y æ lː i m l i c
 müəllimə	m y æ lː i m æ
 müəzzəm	m y æ zː æ m
 mıx	m ɯ χ
@@ -2090,6 +2125,7 @@ məğlubiyyət	m æ ɣ ɫ u b i j æ t
 məşrutə	m æ ʃ r uː t æ
 nadir	n ɑː d i r
 nahiyə	n ɑː h i j æ
+nakam	n ɑː c ɑ m
 nal	n ɑ ɫ
 namaz	n ɑ m ɑ z
 namə	n ɑː m æ
@@ -2212,6 +2248,8 @@ osturaqçı	o s t u r a χ t͡ʃ ɯ
 osurmaq	o s u r m ɑ χ
 otaq	o t ɑ χ
 otaqda	o t ɑ ɣ d ɑ
+otlamaq	o t ɫ ɑ m ɑ x
+otlamaq	o tː ɑ m ɑ x
 oturacaq	o t u r ɑ d͡z ɑ χ
 oturacaq	o t u r ɑ d͡ʒ ɑ χ
 oturmaq	o t u r m ɑ χ
@@ -2272,6 +2310,7 @@ paxıllıq	p ɑ χ ɯ ɫː ɯ χ
 paxır	p ɑ χ ɯ r
 paylaşım	p ɑ j ɫ ɑ ʃ ɯ m
 paytaxt	p ɑ j t ɑ χ t
+payız	p ɑ j ɯ z
 paçka	p a t͡s kʲ ɑ
 paçka	p ɑ t͡ʃ k ɑ
 paçka	p ɑ ʃ k ɑ
@@ -2330,6 +2369,8 @@ pəncərə	p e n d͡z æ r æ
 pəncərə	p e n d͡ʒ æ r æ
 pəncərə	p æ n d͡z æ r æ
 pəncərə	p æ n d͡ʒ æ r æ
+pərakəndə	p æ r ɑ c æ n d æ
+pərakəndəlik	p æ r ɑː c æ n d æ l i c
 pərvanə	p æ r v ɑː n æ
 qab	ɡ ɑ b
 qab	ɡ ɑ b̥
@@ -2377,6 +2418,7 @@ qanacaqlı	ɡ ɑ n ɑ d͡z ɑ ɣ ɫ ɯ
 qanacaqlı	ɡ ɑ n ɑ d͡ʒ ɑ ɣ ɫ ɯ
 qanad	ɡ ɑ n ɑ d
 qanamaq	ɡ ɑ n ɑ m ɑ χ
+qanbur	ɡ ɑ n b u r
 qancıq	ɡ ɑ n d͡z ɯ χ
 qancıq	ɡ ɑ n d͡ʒ ɯ χ
 qandal	ɡ ɑ n d ɑ ɫ
@@ -2395,6 +2437,7 @@ qapı	ɡ ɑ p ɯ
 qar	ɡ ɑ r
 qara	ɡ æ r æ
 qara	ɡ ɑ r ɑ
+qarabaşaq	ɡ ɑ r ɑ b ɑ ʃ ɑ x
 qaraciyər	ɡ ɑ r ɑ d͡z i j æ r
 qaraciyər	ɡ ɑ r ɑ d͡ʒ i j æ r
 qaradərili	ɡ ɑ r ɑ d æ r i l i
@@ -2419,12 +2462,14 @@ qarşılamaq	ɡ ɑ r ʃ ɯ ɫ ɑ m ɑ χ
 qarşılıqlı	ɡ ɑ r ʃ ɯ ɫ ɯ ɣ ɫ ɯ
 qarşısında	ɡ ɑ r ʃ ɯ s ɯ n d ɑ
 qarət	ɡ ɑː r æ t
+qasıq	ɡ ɑ s ɯ x
 qasırğa	ɡ ɑ s ɯ r ɣ a
 qat	ɡ æ t
 qat	ɡ ɑ t
 qatı	ɡ ɑ t ɯ
 qatıq	ɡ ɑ t ɯ χ
 qatışıq	ɡ ɑ t ɯ ʃ ɯ χ
+qax	ɡ ɑ x
 qaya	ɡ ɑ j ɑ
 qayda	ɡ ɑ j d ɑ
 qaydasında	ɡ ɑ j d ɑ s ɯ n d ɑ
@@ -2552,6 +2597,9 @@ quru	ɡ u r u
 qurum	ɡ u r u m
 qurutmaq	ɡ u r u t m ɑ χ
 qusmaq	ɡ u s m ɑ χ
+qutab	k u t ɑ b
+qutab	x tʰ a p
+qutab	ɡ u t ɑ b
 quyruq	ɡ u j r u ɣ
 quyu	ɡ u j u
 quzey	ɡ u z e j
@@ -2590,6 +2638,7 @@ qırğın	ɡ ɯ r ɣ ɯ n
 qısa	k ɯ̥ s ɑ
 qısa	ɡ ɯ s ɑ
 qıt	ɡ ɯ t
+qıvrım	ɡ ɯ v r ɯ m
 qıymaq	ɡ ɯ j m ɑ χ
 qızdırmaq	ɡ ɯ z d ɯ r m a χ
 qızlıq	ɡ ɯ z d ɯ χ
@@ -2655,6 +2704,9 @@ riayət	r i ɑ j æ t
 rozetka	r ɑ z e t k ɑ
 ruhani	r u h ɑː n i
 ruhi	r uː h i
+ruzigar	r u z i ɟ a r
+ruzigar	r y z d͡ʒ a r
+ruzigar	r y z ɟ a r
 ruznamə	r u z n ɑ m æ
 rüşvət	r y ʃ v æ t
 rüşvətxorluq	r y ʃ v æ t x o r ɫ u x
@@ -2768,6 +2820,7 @@ sikmək	s i k m æ k
 sikmək	s i k m æ ç
 silahlanmaq	s i l ɑ h l ɑ mː a χ
 silahlı	s i ɫ ɑ h ɫ ɯ
+silk	s i l c
 silmək	s i l m æ k
 sima	s æ m ɑ
 simic	s i m i d͡z
@@ -2795,7 +2848,7 @@ sonuncu	s o n u n d͡ʒ u
 sormaq	s o r m ɑ χ
 sosializm	s o s i ɑ l i z m
 sosializm	s ɑ s i ɑ l i z m
-soxasox	s o χ ɑ s o x
+soxasox	s o χ ɑ s o χ
 soxmaq	s o χ m ɑ χ
 soxulcan	s o x u ɫ d͡z ɑ n
 soxulcan	s o x u ɫ d͡ʒ ɑ n
@@ -2899,6 +2952,8 @@ sığmaq	s ɯ ɣ m ɑ χ
 sığortalamaq	s ɯ ɣ o r t ɑ ɫ ɑ m ɑ χ
 sığınmaq	s ɯ ɣ ɯ n m ɑ χ
 sığınmaq	s ɯ ɣ ɯː m ɑ χ
+səbirsiz	s æ b r s i z
+səbirsizlik	s æ b r s i z l i c
 səbəb	s æ b æ b
 sədd	s æ d
 səfalət	s æ f ɑː l æ t
@@ -2939,6 +2994,7 @@ səs	s æ s
 səsvermə	s æ s v e r m æ
 səviyyə	s æ v i jː æ
 tabaşir	t ɑ b ɑː ʃ i r
+tabe	t ɑː b e
 tac	t ɑ d͡z
 tac	t ɑ d͡ʒ
 tacir	t ɑː d͡z i r
@@ -2972,6 +3028,7 @@ tarla	t ɑ r ɫ ɑ
 taun	t ɑ u n
 taxmaq	t ɑ χ m ɑ χ
 tayfa	t ɑ j f ɑ
+tayqol	t ɑ j ɡ o ɫ
 tayqulaq	t ɑ j ɡ u ɫ ɑ x
 tel	t e l
 telefon	t e l e f o n
@@ -3005,6 +3062,8 @@ tok	t o k
 topa	t o p ɑ
 topal	t o p ɑ ɫ
 toplu	t o p ɫ u
+toran	t o r ɑ n
+torba	t o r b ɑ
 tormoz	t o r m o z
 torpaq	t o p r ɑ χ
 torpaq	t o r p ɑ χ
@@ -3065,6 +3124,7 @@ tədarük	t æ d ɑː r y t͡ʃ
 tədbir	t æ d b i r
 tədbirli	t æ d b i r l i
 tədbirli	t æ d b i rː i
+tədhiş	t æ d h i ʃ
 təfavüt	t a f o t
 təfavüt	t æ f o t
 təfavüt	t æ f ɑː v y t
@@ -3093,6 +3153,7 @@ təkər	t æ c æ r
 təkər	t æ j æ ɾ
 təkər	t æ t͡ʃ æ r
 təlabat	t æ ɫ ɑ b ɑ t
+təlatüm	t æ ɫ ɑː t y m
 təliqə	t æ l i ɡ æ
 tələbat	t æ l æ b ɑ t
 tələbə	t æ l æ b æ
@@ -3110,8 +3171,10 @@ təmizləmək	t æ m i z d æ m æ j
 təmizləmək	t æ m i z l æ m æ c
 təmizləmək	t æ m i z l æ m æ j
 təmrin	t æ m r i n
+təntik	t æ n t i c
 tənək	t æ n æ c
 tənək	t æ ŋ æ c
+təqaüd	t æ ɡ ɑː y d
 təqdir	t æ ɡ d i r
 təqdis	t æ ɡ d i s
 təqvim	t æ ɡ v i m
@@ -3173,6 +3236,7 @@ ulama	u ɫ ɑ m ɑ
 ulamaq	u ɫ ɑ m ɑ x
 ulduz	u ɫ d ú z
 ulu	u ɫ u
+unitaz	u n i t ɑ z
 unudulmaz	u n u d u ɫ m ɑ z
 unutmaq	u n u t m ɑ χ
 unutqan	u n u t k ɑ n
@@ -3188,8 +3252,10 @@ uzaqbaşı	u z ɑ ɣ b ɑ ʃ ɯ
 uzaqlıq	u z ɑ ɣ ɫ ɯ x
 uzun	u z u n
 uzundraz	u z u n d r ɑ z
-uçmaq	u t͡s m ɑ χ
-uçmaq	u t͡ʃ m ɑ χ
+uçmaq	u t͡s m ɑ x
+uçmaq	u t͡ʃ m ɑ x
+uçurmaq	u t͡s u r m ɑ x
+uçurmaq	u t͡ʃ u r m ɑ x
 uçuş	u t͡s ɯ ʃ
 uçuş	u t͡ʃ ɯ ʃ
 uğramaq	u ɣ r ɑ m ɑ χ
@@ -3289,6 +3355,8 @@ xodlamaq	χ o dː ɑ m ɑ χ
 xodlamaq	χ o tː ɑ m ɑ χ
 xodlanmaq	χ o dː ɑ m ɑ χ
 xodlanmaq	χ o tː ɑ m ɑ χ
+xonça	x o n t͡s ɑ
+xonça	x o n t͡ʃ ɑ
 xora	x o r ɑ
 xoş	x o ʃ
 xoşagəlməz	χ o ʃ ɑ d͡ʒ æ l m æ z
@@ -3556,6 +3624,7 @@ yırtıcı	j ɯ r t ɯ d͡ʒ ɯ
 yırğalamaq	j ɯ r ɣ ɑ ɫ ɑ m ɑ χ
 yıxmaq	j ɯ χ m ɑ χ
 yığmaq	j ɯ ɣ m ɑ χ
+yığılmaq	j ɯ ɣ ɯ ɫ m ɑ x
 yığışdırmaq	j ɯ ɣ ɯ ʃ d ɯ r m ɑ χ
 yığışmaq	j ɯ ɣ ɯ ʃ m ɑ χ
 yəqin	j æ ɡ i n
@@ -3572,8 +3641,11 @@ zidd	z i d
 ziddiyyət	z i dː i j æ t
 zirinc	z i r i n d͡z
 zirinc	z i r i n d͡ʒ
+ziyadə	z i j ɑː d æ
 ziyafət	z i j ɑ f æ t
 ziyil	z i j i l
+zorakı	z oː r ɑ c ɯ
+zorakı	z oː r ɑ t͡ʃ ɯ
 zorakılıq	z o r ɑ k ɯ l ɯ χ
 zorla	z o r ɫ ɑ
 zorla	z o rː ɑ
@@ -3581,10 +3653,13 @@ zorlama	z o r ɫ ɑ m ɑ
 zorlama	z o rː ɑ m ɑ
 zorlamaq	z o r ɫ ɑ m ɑ χ
 zorlamaq	z o rː ɑ m ɑ χ
+zorən	z oː r æ n
 zökəm	z œ c æ m
 zəfər	z æ f æ ɾ
 zəfəran	z æ f æ r ɑ n
 zəhmət	z æ h m æ t
+zəhrimar	z æ h i r m ɑ r
+zəhrimar	z æ h r i m ɑ r
 zəhər	z æ h æ r̥
 zəhərli	z æ h æ r l i
 zəhərli	z æ h æ rː i
@@ -3596,6 +3671,8 @@ zəmanə	z æ m ɑː n æ
 zən	z æ n
 zəncir	z æ n d͡z i r
 zəncir	z æ n d͡ʒ i r
+zəncirvari	z æ n d͡z i r v ɑː r i
+zəncirvari	z æ n d͡ʒ i r v ɑː r i
 zəncəfil	z æ n d͡z æ f i l
 zəncəfil	z æ n d͡ʒ æ f i l
 zəngin	z æ n d͡ʒ i n
@@ -3626,6 +3703,8 @@ zərər	z æ r æ r
 çaqqı	t͡s ɑ kː ɯ
 çar	t͡s ɑ r
 çar	t͡ʃ ɑ r
+çardaq	t͡s ɑ r d ɑ x
+çardaq	t͡ʃ ɑ r d ɑ x
 çarə	t͡s ɑː r æ
 çarə	t͡ʃ ɑː r æ
 çatdırmaq	t͡s ɑ tː ɯ r m ɑ χ
@@ -3851,6 +3930,8 @@ zərər	z æ r æ r
 ötəri	œ t æ r i
 övlad	e v l ɑ d
 övlad	œ v l ɑ d
+övladsız	œ v ɫ ɑ d s ɯ z
+övladsız	œ v ɫ ɑ t s ɯ z
 övrə	œ v r æ
 öxbə	œ h b æ
 öxbə	œ x b æ
@@ -3863,6 +3944,7 @@ zərər	z æ r æ r
 öyəc	œ j æ d͡ʒ
 öyəc	œ ɟ æ d͡ʒ
 özfəaliyyət	œ z f æ ɑ l i jː æ t
+özünlə	œ z y n l æ
 özəl	œ z æ l
 ülgü	y l ɟ y
 ülgüc	y l ɟ y d͡ʒ
@@ -3885,6 +3967,8 @@ zərər	z æ r æ r
 üstünə	y s t y n æ
 ütü	y t y
 üzbəüz	y z b æ y z
+üzgün	y z d͡ʒ y n
+üzgün	y z ɟ y n
 üzmək	y z m æ j
 üzmək	y z m æ k
 üzmək	y z m ɑ χ
@@ -4045,6 +4129,7 @@ zərər	z æ r æ r
 əmcək	æ m d͡z æ j
 əmcək	æ m d͡ʒ æ j
 əmi	æ m i
+əmin	æ m i n
 əmioğlu	æ m i o ɣ ɫ u
 əmiqızı	æ m i ɡ ɯ z ɯ
 əmizdirmək	æ m i z d i r m æ k
@@ -4052,6 +4137,7 @@ zərər	z æ r æ r
 əmmək	æ mː æ k
 əmn	æ m n
 əmr	æ m r
+əmsal	æ m s ɑ l
 əmzik	æ m z i c
 əmək	æ m æ j
 əmək	æ m æ k
@@ -4098,10 +4184,11 @@ zərər	z æ r æ r
 əsər	æ s æ r
 əsər	æ s æ r̥
 ət	æ t
+ətalət	æ t aː l æ t
 ətağa	æː t ɑ ɣ ɑ
 ətirşah	æ t i r ʃ ɑ h
 ətsatan	æ t s ɑ t ɑ n
-əttökən	æ t t œ c æ n
+əttökən	æ tː œ c æ n
 ətyeyən	æ t j e j æ n
 ətçəkən	æ t t͡ʃ æ k æ n
 ətək	æ t æ j
@@ -4111,6 +4198,8 @@ zərər	z æ r æ r
 əvvəlki	æ vː æ l c i
 əvvəlki	æ vː æ l t͡ʃ i
 əvət	æ v æ t
+əvəzlik	æ v æ z d i c
+əvəzlik	æ v æ z l i c
 əxlaq	æ h ɫ ɑ k
 əxlaq	æ h ɫ ɑ ɡ
 əxlaq	æ h ɫ ɑ χ

--- a/data/scrape/tsv/aze_latn_narrow_filtered.tsv
+++ b/data/scrape/tsv/aze_latn_narrow_filtered.tsv
@@ -6,6 +6,7 @@ Avroviziya	ɑ v r o v iː z i j ɑ
 Avroviziya	ɑ v r ɑ v iː z i j ɑ
 Azərbaycan	ɑː z æ r b ɑ j d͡z ɑ n
 Azərbaycan	ɑː z æ ɾ b ɑ j d͡ʒ ɑ n
+Bakı	b ɑ c ɯ
 Bağır	b ɑ ɣ ɯ r
 Cübeyl	d͡ʒ y b e j l
 DNT	d e e n t e
@@ -13,10 +14,13 @@ Firuzə	f i r uː z æ
 Fətəli	f æ t æ l i
 Fəzzan	f æ z z ɑ n
 Gülnarə	d͡ʒ y l n ɑː r æ
+Gülnarə	ɟ y l n ɑː r æ
 Gürcüstan	d͡ʒ y ɾ d͡z y s t ɑ n
+Gürcüstan	ɟ y ɾ d͡ʒ y s t ɑ n
 Hələb	h æ l æ b
 Həştərxan	h æ ʃ t æ r χ ɑ n
 Kətayun	k æ t ɑ j u n
+Lökbatan	l œ c b ɑ t ɑ n
 Lökbatan	l œ t͡ʃ b ɑ t ɑ n
 Makedoniya	m ɑ t͡ʃ e d o n i j ɑ
 Musa	m u s ɑ
@@ -77,6 +81,7 @@ aidiyyət	ɑ i d i j æ t
 ailə	ɑ i l æ
 aktivləşdirmək	ɑ k t i v l æ ʃ t i r m æ k
 aktyor	ɑ k t j o r
+alagöz	ɑ ɫ ɑ ɟ œ z
 aldanmaq	ɑ ɫ d ɑ n m ɑ χ
 aldanmaq	ɑ ɫː ɑ n m ɑ χ
 aldatmaq	ɑ ɫ d ɑ t m ɑ χ
@@ -111,6 +116,7 @@ amansız	ɑ m ɑ n s ɯ z
 amcıq	ɑ m d͡z ɯ χ
 amcıq	ɑ m d͡ʒ ɯ χ
 amcıqgöz	ɑ m d͡z ɯ ɣ d͡ʒ œ z
+amcıqgöz	ɑ m d͡ʒ ɯ ɣ ɟ œ z
 amma	ɑ m b ɑ
 amma	ɑ mː ɑ
 ana	ɑ n ɑ
@@ -125,6 +131,7 @@ anmaq	ɑ n m ɑ χ
 anormal	ɑ n o r m ɑ ɫ
 anqırmaq	ɑ n ɡ ɯ r m ɑ χ
 antigen	ɑ n t i d͡ʒ e n
+antigen	ɑ n t i ɟ e n
 anım	ɑ n ɯ m
 aparmaq	ɑ p ɑ r m ɑ χ
 aqibət	ɑ ɡ iː b æ t
@@ -133,6 +140,7 @@ araba	ɑ r ɑ b ɑ
 arabir	ɑ r ɑ b i r
 arada	ɑ r ɑ d ɑ
 aram	ɑ r ɑ m
+aramgah	ɑ r ɑ m ɟ ɑ h
 arasında	ɑ r ɑ s ɯ n d ɑ
 arayış	ɑ r ɑ j ɯ ʃ
 araşdırmaq	ɑ r ɑ ʃ d ɯ r m ɑ χ
@@ -146,6 +154,7 @@ arvad	ɑ r v ɑ d
 arxac	ɑ r x ɑ d͡z
 arxac	ɑ r x ɑ d͡ʒ
 arxadaş	ɑ r χ ɑ d ɑ ʃ
+arxaik	ɑ r χ ɑ i c
 arxalanmaq	ɑ r x a ɫ ɑ mː ɑ x
 arxalanmaq	ɑ r x a ɫ ɑ n m ɑ x
 arxasında	ɑ r χ ɑ s ɯ n d ɑ
@@ -185,6 +194,7 @@ avarçəkən	ɑ v ɑ r t͡s æ t͡ʃ æ n
 avarçəkən	ɑ v ɑ r t͡ʃ æ k æ n
 avqust	ɑ v ɡ u s t
 avro	ɑ v r o
+avtomatik	a f t o m a t i c
 avtoqraf	ɑ f t o ɡ r a f
 avtoş	ɑ f t o ʃ
 axmaq	ɑ χ m ɑ χ
@@ -214,6 +224,7 @@ aylanmaq	ɑ j ɫ ɑ n m ɑ χ
 aylıq	ɑ j ɫ ɯ χ
 ayran	ɑ j r ɑ n
 aysberq	ɑ j s b e r ɡ
+aysız	ɑ j s ɯ z
 ayğır	ɑ j ɣ ɯ r
 ayılmaq	ɑ j ɯ ɫ m ɑ χ
 ayıq	ɑ j ɯ χ
@@ -251,6 +262,7 @@ ağac	ɑ ɣ ɑ ʃ
 ağacdələn	ɑ ɣ ɑ d ʒ d æ l æ n
 ağartı	ɑ ɣ ɑ r t ɯ
 ağbirçək	ɑ ɣ b i r t͡s æ t͡ʃ
+ağbirçək	ɑ ɣ b i r t͡ʃ æ c
 ağlabatmaz	ɑ ɣ ɫ ɑ b a ɯ t m ɑ z
 ağlama	ɑ ɣ ɫ ɑ m ɑ
 ağlamaq	ɑ ɣ ɫ ɑ m ɑ χ
@@ -295,7 +307,9 @@ baha	b ɑ h ɑ
 bahadır	b ɑ h ɑ d ɯ r
 bahalı	b ɑ h ɑ ɫ ɯ
 bahar	b ɑ h ɑ r
+bakir	b ɑː c i r
 bakir	b ɑː t͡ʃ i r
+bakirə	b ɑː c i r æ
 bakirə	b ɑː t͡ʃ i r æ
 bal	b ɑ ɫ
 bala	b ɑ ɫ ɑ
@@ -317,11 +331,13 @@ bandotdel	b ɑ n d o t d e l
 bandotdel	b ɑ n d ɑ t d e l
 bani	b ɑː n i
 baqaj	b ɑ ɡ a ʒ
+baqajnik	b ɑ ɡ a ʒ n i c
 barama	b ɑ r ɑ m ɑ
 bariqa	b ɑ r i ɡ ɑ
 barmaq	b ɑ r m ɑ χ
 barmaqlamaq	b ɑ r m ɑ ɣ l ɑ m ɑ χ
 barmaqlıq	b ɑ r m ɑ ɣ ɫ ɯ χ
+baron	b ɑ r o n
 barı	b ɑ r ɯ
 barışmaq	b ɑ r ɯ ʃ m ɑ χ
 barədə	b ɑː r æ d æ
@@ -390,6 +406,8 @@ beyt	b e j t
 bezmək	b e z m æ j
 bezmək	b e z m æ k
 beşbarmaq	b e ʃ b ɑ r m ɑ χ
+beşbetər	b e ʃ b e t æ r
+beşbetər	b e ʃ p æ t æ r
 beşik	b e ʃ i j
 beşik	b e ʃ i k
 beşik	b e ʃ i ç
@@ -398,6 +416,9 @@ bibi	b i b i
 bibioğlu	b i b i o ɣ ɫ u
 bibiqızı	b i b i ɡ ɯ z ɯ
 bibər	b i b æ ɾ
+biganə	b i ɟ ɑː n æ
+bilgi	b i l ɟ i
+bilik	b i l i c
 bilik	b i l i j
 bilik	b i l i ç
 bilmək	b i l m e j
@@ -412,9 +433,12 @@ biraz	b i r ɑ z
 bircə	b i r d͡z æ
 bircə	b i r d͡ʒ æ
 birdən	b i r d æ n
+birgə	b i r ɟ æ
 birinci	b i r i m d͡z i
 birinci	b i r i n d͡z i
 birinci	b i r i n d͡ʒ i
+birisigün	b i r i s i ɟ y n
+birisigün	b y r s y ɟ y n
 birlikdə	b i r l i k d æ
 birlikdə	b i r l i k t æ
 birləşdirmək	b i r l æ ʃ d i r m æ j
@@ -468,7 +492,9 @@ boşqab	b u ʃ ɣ a b
 bucaq	b u d͡z ɑ χ
 bucaq	b u d͡ʒ ɑ χ
 budaq	b u d ɑ χ
+bugün	b u ɟ y n
 bugün	b y j y n
+bugün	b y ɟ y n
 bulanlıq	b u ɫ ɑ n ɫ ɯ χ
 bulanlıq	b u ɫ ɑ nː ɯ χ
 bulanıq	b u l ɑ n ɯ χ
@@ -497,12 +523,18 @@ buzov	b u z o v
 buğur	b u ɣ u r
 buğur	b ɯ ɣ ɯ r
 böhran	b œ h r ɑ n
+bölmə	b œ l m æ
+börk	b œ r c
 böyründə	b œ j r y n d æ
+böyük	b œ j y c
+böyümək	b œ j y m æ c
 böyür	b œ j y r
 böyürmək	b œ j y r m æ j
 böyürmək	b œ j y r m æ k
 böyürmək	b œ j y r m æ ç
+böyürtkən	b œ j y r t c æ n
 böyütmək	b œ j y t m æ k
+böyələk	b œ j æ l æ c
 bükmək	b y h m ɑ χ
 bükmək	b y k m æ j
 bükmək	b y k m æ k
@@ -513,6 +545,7 @@ bülöv	b y l œ v
 bülövləmək	b y l œ v l æ m æ k
 bünyad	b y n j ɑ d
 bünövrə	b y n œ v r æ
+bütpərəst	b y t p æ r æ s t
 bıçaq	b ɯ t͡ʃ ɑ χ
 bıçaq	p t͡s ɑ χ
 bıçaq	p t͡ʃ ɑ χ
@@ -526,6 +559,8 @@ bəla	b æ ɫ ɑ
 bəlağət	b æ ɫ ɑː ɣ æ t
 bəlağətli	b æ ɫ ɑː ɣ æ t l i
 bəlağətli	b æ ɫ ɑː ɣ æ tː i
+bəlgə	b æ l i j æ
+bəlgə	b æ l ɟ æ
 bəlkə	b æ l k æ
 bəlkə	b æ l k æ m
 bəlkə	b æ r k æ
@@ -549,6 +584,9 @@ bərk	b æ r k
 bərkdən	b æ r k d æ n
 bərkdən	b æ r k t æ n
 bərpa	b æ r p ɑ
+bərəkallah	b æ r æ c ɑ nː ɑ h
+bərəkallah	b æ r æ c ɑ ɫː ɑ h
+bərəkət	b æ r æ c æ t
 bərəkət	b æ r æ t͡ʃ æ t
 bəsləmək	b æ s l æ m æ k
 bəsləmək	b æ s t æ m æ j
@@ -602,6 +640,8 @@ cinsi	d͡z i n s i
 cinsi	d͡ʒ i n s i
 civi	d͡z i v i
 civi	d͡ʒ i v i
+cizgi	d͡z i z d͡ʒ i
+cizgi	d͡ʒ i z ɡ i
 cizyə	d͡z i z j æ
 cizyə	d͡ʒ i z j æ
 cuhud	d͡z u h u d
@@ -631,6 +671,8 @@ cığır	d͡z ɯ ɣ ɯ r
 cığır	d͡ʒ ɯ ɣ ɯ r
 cəbhəçi	d͡z æ p h æ t͡s i
 cəbhəçi	d͡ʒ æ p h æ t͡ʃ i
+cəbri	d͡z æ b r i
+cəbri	d͡ʒ æ b r i
 cəhan	d͡ʒ æ h ɑ n
 cəhd	d͡z æ h d
 cəhd	d͡ʒ æ h d
@@ -729,14 +771,21 @@ deaktivləşdirmək	d e ɑ k t i v l æ ʃ t i r m æ k
 demək	d e m æ k
 devirmək	d e v i r m æ j
 devirmək	d e v i r m æ k
+deyinmək	d e j i n m æ c
 deyəsən	d e j æ s æ n
 deyəsən	d i j æ s æ n
 deşik	d e ʃ i j
 deşik	d e ʃ i ç
+didik	d i d i c
+didmək	d i d m æ c
+didərgin	d i d æ r ɟ i n
 digər	d i d͡ʒ æ r
+digər	d i ɟ æ r
+dik	d i c
 dik	d i t͡ʃ
 dikbaş	d i k b ɑ ʃ
 dikbaş	d i t͡ʃ b ɑ ʃ
+dikmək	d i c m æ c
 dikmək	d i k m æ j
 dikmək	d i t͡ʃ m æ ç
 diktor	d i k t o r
@@ -766,8 +815,11 @@ dincəlmək	d i n d͡z æ l m æ j
 dincəlmək	d i n d͡z æ l m æ k
 dincəlmək	d i n d͡ʒ æ l m æ j
 dincəlmək	d i n d͡ʒ æ l m æ k
+dindar	d i n d a r
 dindirmə	d i n d i r m æ
+dinləmək	d i n l æ m æ c
 dinləmək	d i n l æ m ɑ χ
+dinləmək	d i nː æ m æ c
 dirçəliş	d i r t͡s æ l i ʃ
 dirçəliş	d i r t͡ʃ æ l i ʃ
 diskriminasiya	d i s k r i m i n ɑ s i j a
@@ -817,6 +869,7 @@ dux	d u χ
 duymaq	d u j m ɑ χ
 duyğu	d u j ɣ u
 döl	d œ l
+dölləndirmək	d œ lː æ n d i r m æ c
 dönmək	d œ mː æ j
 dönmək	d œ mː æ k
 dönmək	d œ n m æ j
@@ -826,10 +879,16 @@ dönər	d œ n æ r
 dönərxana	d œ n æ r χ ɑ n ɑ
 dörd	d œ r d
 dördgöz	d œ r d d͡ʒ œ z
+dördgöz	d œ r d ɟ œ z
 dördüncü	d œ ɾ d y n d͡ʒ y
 dövr	d œ v r
+dövri	d e v r i
+dövri	d œ v r i
+dövri	d œ v r y
 dövriyyə	d œ v r i j æ
 dövrə	d œ v r æ
+dövrəvi	d œ v r æ v i
+döymək	d œ j m æ c
 döymək	d œ j m æ j
 döymək	d œ j m ɑ χ
 döymək	d œ ɡ m e j
@@ -850,9 +909,13 @@ döşək	d œ ʃ æ k
 döşəkağı	d œ ʃ æ j ɑ ɣ ɯ
 dübarə	d y b aː r æ
 düha	d y h ɑ
+dükan	d y c a n
 dükan	d y t͡ʃ a n
+dükan	t y c a n
 dükan	t y t͡ʃ a n
+dükançı	d y c a n t͡ʃ ɯ
 dükançı	d y t͡ʃ a n t͡s ɯ
+dülgər	d y l ɟ æ r
 dünyəvi	d y n j æː v i
 dünən	d y n æ n
 dürüst	d y r y s t
@@ -862,11 +925,13 @@ düyə	d y j ɑ
 düz	d y z
 düzbucaqlı	d y z b u d͡z ɑ ɣ ɫ ɯ
 düzbucaqlı	d y z b u d͡ʒ ɑ ɣ ɫ ɯ
+düzgün	d y z ɟ y n
 düzəlmək	d y z æ l m e j
 düzəlmək	d y z æ l m æ j
 düzəlmək	d y z æ l m æ k
 düzəlmək	d y z æ l m ɑ χ
 düzəltmək	d y z æ l t m e j
+düzəltmək	d y z æ l t m æ c
 düzəltmək	d y z æ l t m æ j
 düzəltmək	d y z æ t m ɑ χ
 düzən	d y z æ n
@@ -925,6 +990,7 @@ dərzi	d æ r z i
 dəstək	d æ s t æ j
 dəstək	d æ s t æ ç
 dəstəmaz	d æ s t æ m ɑ z
+dəxil	d æ x i l
 dəxl	d æ x l
 dəxmə	d æ x m æ
 dəyirman	d æ j i r m ɑ n
@@ -932,6 +998,8 @@ dəyişdirmək	d æ j i ʃ d i r m æ j
 dəyişdirmək	d æ j i ʃ d i r m æ k
 dəyişdirmək	d æ j i ʃ t i r m æ j
 dəyişdirmək	d æ j i ʃ t i r m æ k
+dəyişik	d æ j i ʃ i c
+dəyişkən	d æ j i ʃ c æ n
 dəyişmək	d æ j i ʃ m æ j
 dəyişmək	d æ j i ʃ m æ k
 dəymiş	d æ j m i ʃ
@@ -941,11 +1009,18 @@ dəymək	d æ j m ɑ χ
 dəyməz	d æ j m æ z
 dəyə	d æ j æ
 dəyər	d æ j æ r
+ecgahan	e d͡ʒ ɟ ɑ h ɑ n
 ecgahan	e j d͡z ɑ h ɑ n
 ecgahan	e j d͡z ɑː n
 ecgahan	e j d͡ʒ ɑ h ɑ n
 ecgahan	e j d͡ʒ ɑː n
+ecgahan	e ʒ ɟ æ h i n
+ecgahan	e ʒ ɟ ɑ h ɑ n
+ecgahan	e ʒ ɟ ɑ n
+ecgahan	e ʒ ɟ ɑː n
 ecgahan	æ d͡z d͡ʒ ɑ h ɑ n
+ecgahan	æ d͡ʒ ɟ ɑ h ɑ n
+ecgahan	æ ʒ ɟ e j i n
 edam	eː d a m
 ehtiram	e h t i r ɑ m
 ehtiramlı	e h t i r ɑ m ɫ ɯ
@@ -962,9 +1037,11 @@ elə	e l æ
 eləmək	e l æ m æ k
 en	e n
 endirmə	e n d i r m æ
+endirmək	e n d i r m æ c
 enmək	e mː æ k
 enmək	e n m æ j
 enmək	e n m æ k
+epidemiologiya	e p i d e m i o ɫ o ɟ i j ɑ
 epidemioloji	e p i d e m i o l o ʒ ɯ
 epidemiya	e p i d e m i j ɑ
 ertə	e r t æ
@@ -984,11 +1061,13 @@ evcik	e v d͡ʒ i j
 evcik	e v d͡ʒ i k
 evlənmək	e v l æ mː æ j
 evlənmək	e v l æ mː æ k
+evsiz	e v s i z
 eybəcər	e j b æ d͡z æ r
 eybəcər	e j b æ d͡ʒ æ r
 eyham	e j h ɑ m
 eyib	e j i b
 eyib	æ j i b
+eyib	æ ɟ i b
 eyib	ɑ j ɯ b
 eyləmək	e j l æ m æ k
 eyləmək	e j l æ m ɑ χ
@@ -1009,6 +1088,8 @@ fani	f ɑː n i
 fars	f ɑ r s
 faşizm	f ɑ ʃ i z m
 ferma	f e r m ɑ
+fikirləşmək	f i c i r l æ ʃ m æ j
+fikirləşmək	f i c i rː æ ʃ m æ j
 film	f i l m
 firqə	f i r ɡ æ
 fit	f i t
@@ -1032,69 +1113,207 @@ fərqlənmək	f æ r ɡ l æ mː æ j
 fərqlənmək	f æ r ɡ l æ mː æ k
 fəryad	f æ r j ɑ d
 fəsil	f æ s i l
+gah	ɟ ɑ h
 gec	d͡ʒ e d͡z
+gec	ɟ e d͡ʒ
 gecə	d͡ʒ e d͡z æ
+gecə	ɟ e d͡ʒ æ
 gecəqondu	d͡ʒ e d͡z æ ɡ o n d u
+gecəqondu	ɟ e d͡ʒ æ ɡ o n d u
+general	ɟ e n e r ɑ ɫ
 geniş	d͡ʒ e n i ʃ
+geniş	ɟ e n i ʃ
+genişlənmək	ɟ e n i ʃ l æ mː æ c
+genişlənmək	ɟ e n i ʃ l æ n m æ c
+geri	ɟ e r i
 getmək	d͡ʒ e t m ɑ χ
+getmək	ɟ e t m æ c
+getmək	ɟ e t m æ j
+getmək	ɟ e t m æ ç
+geydirmə	ɟ e j d i r m æ
 geyim	d͡ʒ e j i m
+geyim	ɟ e j i m
+geyinmək	ɟ e j i n m æ k
+geymək	ɟ e j m æ k
 gic	d͡ʒ i d͡z
+gic	ɟ i d͡ʒ
+gicdıllaq	ɟ i ʒ d ɯ ɫː ɑ χ
 gicgah	d͡ʒ i d͡z d͡ʒ ɑ h
+gicgah	ɟ i d͡ʒ ɟ ɑ h
 giley	d͡ʒ i l e j
+giley	ɟ i l e j
 gileylənmək	d͡ʒ i l e j l æ n m æ t͡ʃ
+gileylənmək	ɟ i l e j l æ n m æ c
 gilə	d͡ʒ i l æ
+gilə	ɟ i l æ
+girdə	ɟ i r d æ
+giriş	ɟ i r i ʃ
+girişmək	ɟ i r i ʃ m æ c
 girmək	d͡ʒ i r m ɑ χ
+girmək	ɟ i r m e j
+girmək	ɟ i r m æ k
+giryə	ɟ i r j æ
 gizli	d͡ʒ i z l i
+gizli	ɟ i z d i
+gizli	ɟ i z l i
 gizlin	d͡ʒ i z l i n
+gizlin	ɟ i z d i n
+gizlin	ɟ i z l i n
+gizləmək	ɟ i z d æ m æ k
+gizləmək	ɟ i z l æ m æ k
+gizlənmək	ɟ i z d æ n m æ k
+gizlənmək	ɟ i z l æ n m æ k
+gizlənpaç	ɟ i z d æ n p ɑ t͡ʃ
+gizlənpaç	ɟ i z l æ n p ɑ t͡ʃ
 gizlətmək	d͡ʒ i z l æ t m ɑ χ
+gizlətmək	ɟ i z d æ t m æ k
+gizlətmək	ɟ i z l æ t m æ k
+gombul	ɟ o m b u ɫ
+gop	ɟ o p
+gopçu	ɟ o p t͡ʃ u
+gor	ɟ o r
+gorbagor	ɟ o r b ɑ ɟ o r
+gurluq	ɟ u r ɫ u χ
+gurluq	ɟ u rː u χ
+göbələk	ɟ œ b æ l æ j
+göbələk	ɟ œ b æ l æ k
 göl	d͡ʒ œ l
+göl	ɟ œ l
+gömmək	ɟ œ mː æ j
+gömmək	ɟ œ mː æ k
 göndərmək	d͡ʒ œ n d æ r m ɑ χ
+göndərmək	ɟ œ n d æ r m æ k
 görmək	d͡ʒ œ r m ɑ χ
+görmək	ɟ œ r m æ k
 görünmək	d͡ʒ œ r y n m æ t͡ʃ
+görünmək	ɟ œ r y n m æ k
 görüş	d͡ʒ œ r y ʃ
+görüş	ɟ œ r y ʃ
+görüşdürmək	ɟ œ r y ʃ d y r m æ c
 görüşmək	d͡ʒ œ r y ʃ m æ t͡ʃ
+görüşmək	ɟ œ r y ʃ m æ c
 görə	d͡ʒ œ r æ
+görə	ɟ œ r æ
 görəsən	d͡ʒ œ r æ s æ n
+görəsən	ɟ œ r æ s æ n
 göstəriş	d͡ʒ œ s t æ r i ʃ
+göstəriş	ɟ œ s t æ r i ʃ
 göstərmək	d͡ʒ œ s t æ r m ɑ χ
+göstərmək	ɟ œ s t æ r m æ k
 göt	d͡ʒ œ t
+göt	ɟ œ t
 götvərən	d͡ʒ œ t v æ r æ n
+götvərən	ɟ œ t v æ r æ n
+götvərənlik	ɟ œ t v æ r æ n l i k
+götürmək	ɟ œ t y r m æ k
+gövdə	ɟ œ v d æ
 göy	d͡ʒ œ j
+göy	ɟ œ j
+göydələn	ɟ œ j d æ l æ n
 göyərti	d͡ʒ œ j æ r t i
+göyərti	ɟ œ j æ r t i
+göyərti	ɟ œ ɟ æ r t i
 göyərçin	d͡ʒ œ j æ r t͡s i n
+göyərçin	ɟ œ j æ r t͡ʃ i n
+göyərçin	ɟ œ ɟ æ r t͡ʃ i n
 gözlük	d͡ʒ œ z l y t͡ʃ
+gözlük	ɟ œ z l y c
 gözləmək	d͡ʒ œ z l æ m ɑ χ
+gözləmək	ɟ œ z d æ m e j
+gözləmək	ɟ œ z d æ m æ c
+gözləmək	ɟ œ z l æ m æ c
+gözlənilməz	ɟ œ z d æ n i l m æ z
+gözlənilməz	ɟ œ z l æ n i l m æ z
+gözlənti	ɟ œ z d æ n t i
+gözlənti	ɟ œ z l æ n t i
 gözmuncuğu	d͡ʒ œ z m u n d͡z u ɣ u
+gözmuncuğu	ɟ œ z m u n d͡ʒ u ɣ u
 gözüaçıq	d͡ʒ œ z y ɑ t͡s ɯ χ
+gözüaçıq	ɟ œ z y ɑ t͡ʃ ɯ χ
 güc	d͡ʒ y ʒ
 güclü	d͡ʒ y d͡z l y
+güclü	ɟ y d͡ʒ l y
+gül	ɟ y l
 gülab	d͡ʒ y l ɑ b
+gülab	ɟ y l ɑ b
+güllə	ɟ y lː æ
 güllələmək	d ʒ y lː æ l æ m ɑ χ
+güllələmək	ɟ y lː æ l æ m æ k
 gülmək	d͡ʒ y l m ɑ χ
+gülmək	ɟ y l m æ c
+gülümsəmək	ɟ y l y m s æ m æ j
+gülümsəmək	ɟ y l y m s æ m æ k
+gülüş	ɟ y l y ʃ
+gülərüz	ɟ y l æ r y z
+gülərüzlü	ɟ y l æ r y z l y
 güləş	d͡ʒ y l æ ʃ
+güləş	ɟ y l æ ʃ
 güləşçi	d͡ʒ y l æ ʃ t͡s i
+güləşçi	ɟ y l æ ʃ t͡ʃ i
+gümüş	ɟ y m y ʃ
 gün	d͡ʒ y n
+gün	ɟ y n
 günah	d͡ʒ y n ɑ h
+günah	ɟ u n ɑ h
+günah	ɟ y n ɑ h
 günahkar	d͡ʒ u n a h t͡ʃ ɑ r
+günahkar	ɟ u n a h c ɑ r
+günahkar	ɟ y n a h c ɑ r
 günahsız	d͡ʒ y n ɑ h s ɯ z
+günahsız	ɟ u n ɑ h s ɯ z
+günahsız	ɟ y n ɑ h s ɯ z
 güncəl	d͡ʒ y n d͡z æ l
+güncəl	ɟ y n d͡ʒ æ l
 gündüz	d͡ʒ y n d y z
+gündüz	ɟ y n d y z
 gündəlik	d͡ʒ y n d æ l i k
+gündəlik	ɟ y n d æ l i k
+günorta	ɟ y n o r t ɑ
+günya	ɟ y n j ɑ
+günəbaxan	ɟ y n æ b ɑ x ɑ n
+günəş	ɟ y n æ ʃ
 gürcü	d͡ʒ y r d͡z y
+gürcü	ɟ y r d͡ʒ y
+güvənmək	ɟ y v æ mː æ j
+güvənmək	ɟ y v æ n m æ k
+gəlin	ɟ æ l i n
 gəlincik	d͡ʒ æ l i n d͡z i t͡ʃ
+gəlincik	ɟ æ l i n d͡ʒ i c
+gəlmə	ɟ æ l m æ
+gəlmək	ɟ æ l m æ c
+gəlmək	ɟ æ l m æ j
+gəlmək	ɟ æ l m æ ç
 gəmi	d͡ʒ æ m i
+gəmi	ɟ æ m i
 gəmirici	d͡ʒ æ m i r i d͡z i
+gəmirici	ɟ æ m i r i d͡ʒ i
+gəmirmək	ɟ æ m i r m æ ç
 gənc	d͡ʒ æ n d͡z
+gənc	ɟ æ n d͡ʒ
 gənclik	d͡ʒ æ n d͡z l i t͡ʃ
+gənclik	ɟ æ n d͡ʒ l i k
+gərgin	ɟ æ r ɟ i n
+gərək	ɟ æ r æ j
+gərək	ɟ æ r æ k
+gərəkmək	ɟ æ r æ c m æ ç
+gətirmək	ɟ æ t i r m æ c
 gəzdirmək	d͡ʒ æ z d i r m ɑ χ
+gəzdirmək	ɟ æ z d i r m e j
+gəzdirmək	ɟ æ z d i r m æ j
+gəzdirmək	ɟ æ z d i r m æ k
 gəzmək	d͡ʒ æ z m ɑ χ
+gəzmək	ɟ æ z m e j
+gəzmək	ɟ æ z m æ j
+gəzmək	ɟ æ z m æ k
 hakim	h ɑː k i m
 hakimiyyət	h ɑː k i m i j æ t
 hakimiyyət	h ɑː t͡ʃ i m i j æ t
+hakimiyyətçi	h ɑː c i m i j æ t t͡ʃ i
 hakimiyyətçi	h ɑː t͡ʃ i m i j æ t t͡s i
 halbuki	h ɑ ɫ b u k i
 hamar	h ɑ m ɑ r
 hamilə	h ɑ m i l æ
+hamiləlik	h ɑː m i l æ l i c
 hamı	h ɑ mː ɯ
 hamısı	h ɑ m s ɯ
 hamısı	h ɑ mː ɯ s ɯ
@@ -1115,6 +1334,8 @@ hasa	h ɑ s ɑ
 hasar	h ɑ s ɑ r
 hasilat	h ɑː s i ɫ ɑ t
 hava	h ɑ v ɑ
+havaxt	h ɑ v ɑ χ t
+hayan	h ɑ j ɑ n
 hazır	h ɑ z ɯ r
 hazırkı	h ɑ z ɯ r k i
 hazırkı	h ɑ z ɯ r k ɯ
@@ -1125,6 +1346,8 @@ hazırlaşmaq	h ɑ z ɯ rː ɑ ʃ m ɑ χ
 hazırlıq	h ɑ z ɯ r ɫ ɯ χ
 hazırlıq	h ɑ z ɯ rː ɯ χ
 haçan	h ɑ t͡ʃ ɑ n
+hekayə	h e c ɑː j æ
+hekayət	h e c ɑː j æ t
 hesabına	h eː s ɑ b ɯ n ɑ
 heykəl	h e j k æ l
 heykəltəraş	h e j k æ l t æ r ɑ ʃ
@@ -1133,11 +1356,16 @@ heç	h e t͡ʃ
 hilal	h i l ɑ l
 his	h i s
 hiss	h i sː
+hissə	h i sː æ
 hiylə	h i j l æ
 homoseksuallıq	h o m o s e k s u a ɫː ɯ χ
 hoqqa	h o kː ɑ
 hovuz	h o v u z
 huş	h u ʃ
+huşsuzluq	h u ʃ s u z d u x
+huşsuzluq	h u ʃ s u z ɫ u x
+hökumət	h œ c uː m æ t
+hökumət	h œ c y m æ t
 hörmətcil	h œ r m æ t d͡z i l
 hörmətcil	h œ r m æ t d͡ʒ i l
 hörmətli	h œ r m æ t l i
@@ -1179,6 +1407,7 @@ həmsöhbət	h æ m s œ j b æ t
 həmsöhbət	h æ m s œː b æ t
 həmyaş	h æ m j ɑ ʃ
 həndəsə	h æ n d æ s æ
+həngamə	h æ ŋ ɟ ɑː m æ
 həqarət	h æ ɡ ɑː r æ t
 həqiqi	h æ ɡ iː ɡ i
 hər	h æ r
@@ -1214,6 +1443,7 @@ igidlik	i ɡ i d l i j
 igidlik	i ɡ i d l i k
 ikiarvadlı	i k i ɑ r v ɑ d ɫ ɯ
 ikiarvadlılıq	i k i ɑ r v ɑ d ɫ ɯ l ɯ χ
+ikinci	i c i n d͡ʒ i
 ilbiz	i l b i z
 ildırım	i ɫ d ɯ r ɯ m
 ildırım	ɯ ɫ d ɯ ɾ ɯ m
@@ -1226,6 +1456,9 @@ imarət	i m ɑː r æ t
 imkan	i m t͡ʃ ɑ n
 imla	i m ɫ ɑ
 inad	i n ɑ d
+inadkar	i n ɑ d c ɑ r
+inadkarlıq	i n ɑ d c ɑ r ɫ ɯ χ
+inadkarlıq	i n ɑ d c ɑ rː ɯ χ
 inanc	i n ɑ n d͡z
 inanc	i n ɑ n d͡ʒ
 inanmaq	i n ɑ mː ɑ χ
@@ -1251,9 +1484,12 @@ intişar	i n t i ʃ ɑ r
 inzibat	i n z i b ɑ t
 ipək	i p æ j
 ipək	i p æ k
+ipəkqurdu	i p æ c ɡ u r d u
 iqlim	i ɡ l i m
 iranşünas	i ɾ a n ʃ y n ɑ s
 irgənmək	i r d͡ʒ æ n m æ t͡ʃ
+irgənmək	i r ɟ æ mː æ c
+irgənmək	i r ɟ æ n m æ c
 iri	i r i
 irin	i r i n
 irlandiyalı	i r ɫ ɑ n d i j ɑ l ɯ
@@ -1297,6 +1533,7 @@ itaət	i t ɑ æ t
 itaətsizlik	i t ɑ æ t s i z l i k
 itburnu	i t b u r n u
 itirmək	i t i r m e j
+itirmək	i t i r m æ c
 itirmək	i t i r m æ j
 itirmək	i t i r m ɑ χ
 itkin	i n k i n
@@ -1354,66 +1591,158 @@ janr	ʒ ɑ n r
 jasmin	ʒ ɑ s m i n
 jurnal	ʒ u r n ɑ ɫ
 jurnalist	ʒ u r n a l i s t
+kabab	c ɑ b ɑ b
+kaftar	c ɑ f t ɑ r
 kaftar	t͡ʃ ɑ f t ɑ r
+kal	c ɑ ɫ
+kalan	c ɑ ɫ ɑ n
 kamança	t͡ʃ ɑ m ɑ n t͡s ɑ
 kanalizasiya	k ɑ n ɑ l i z ɑ s i j ɑ
 kanalizasiya	ɡ ɑ n ɑ l i z ɑ s i j ɑ
 karp	k ɑ r p
+karvansara	c ɑ r v ɑ n s ɑ r ɑ
+kasa	c a s a
 kasa	t͡ʃ ɑ s ɑ
+katib	c ɑː t i b
+katib	c ɑː t ɯ b
 katib	t͡ʃ aː t i b
 katib	t͡ʃ aː t ɯ b
+katibə	c ɑː t i b æ
 katibə	t͡ʃ aː t i b æ
+kağız	c ɑ ɣ ɯ z
 kağız	t͡ʃ ɑ ɣ ɯ z
+kaş	c ɑ ʃ
 kaş	t͡ʃ ɑ ʃ
+keçi	c e t͡ʃ i
 keçi	d͡ʒ e t͡s i
 keçi	t͡ʃ e t͡s i
+keçinmək	c e t͡ʃ i n m æ c
+keçinmək	c e t͡ʃ i n m æ j
 keçinmək	t͡ʃ e t͡s i n m æ t͡ʃ
+keçmək	c e t͡ʃ m æ c
+keçmək	ɟ e ʃ m ɑ x
 keçəl	k e t͡ʃ æ l
 keçəl	t͡ʃ e t͡s æ l
 keçəllənmək	k e t͡ʃ æ lː æ n m æ j
 keçəllənmək	k e t͡ʃ æ lː æ n m æ k
 keçəllənmək	t͡ʃ e t͡s æ lː æ n m æ t͡ʃ
+keçən	c e t͡ʃ æ n
 keçən	t͡ʃ e t͡s æ n
+ki	c i
+ki	c i n
+kifirləşmək	c i f i r l æ ʃ m æ j
+kifirləşmək	c i f i rː æ ʃ m æ j
+kilsə	c i l s æ
+kim	c i m
+kimdənsə	c i m d æ n s æ
+kimdənsə	c i m n æ n s æ
+kimdəsə	c i m d æ s æ
+kimi	c i m i
 kimi	t͡ʃ i m i
+kiminləsə	c i m i n l æ s æ
+kiminsə	c i m i n s æ
+kimisə	c i m i s æ
+kimlik	c i m l i k
 kimlik	t͡ʃ i m l i t͡ʃ
+kimsə	c i m s æ
+kimsədə	c i m s æ d æ
+kimsədən	c i m s æ d æ n
+kimsəni	c i m s æ n i
+kimsənin	c i m s æ n i n
+kimsəyə	c i m s æ j æ
+kimya	c i m j a
 kimya	t͡ʃ i m j a
+kimyaçı	c i m j a t͡ʃ ɯ
 kimyaçı	t͡ʃ i m j a t͡s ɯ
+kimyəvi	c i m j æː v i
 kimyəvi	t͡ʃ i m j æː v i
-kinayə	k i n ɑː j æ
+kiməsə	c i m æ s æ
+kinayə	c i n ɑː j æ
+kiriş	c i r i ʃ
+kirli	c i r l i
+kirli	c i rː i
+kirpi	c i r p i
+kirpik	c i r p i c
+kirəc	c i r æ d͡ʒ
 kirəc	t͡ʃ i r æ d͡z
+kitabxana	c i t ɑ b χ ɑ n ɑ
+kitabxanaçı	c i t ɑ b x ɑ n ɑ t͡ʃ ɯ
 kitabxanaçı	t͡ʃ i t ɑ b x ɑ n ɑ t͡s ɯ
+kitayski	c i t ɑ j s c i
+kitayski	t͡ʃ i t ɑ j s c i
+kiçik	c i t͡ʃ i c
+kiçik	c i t͡ʃ i j
+kiçik	c i t͡ʃ i ç
+kiçik	c ç i t͡s i j
 kiçik	t͡s i t͡s i h
+kiçilmək	c i t͡ʃ i l m e j
+kiçilmək	c i t͡ʃ i l m æ c
+kiçilmək	c i t͡ʃ i l m æ j
+kiçilmək	c i t͡ʃ i l m æ t͡ʃ
+kiçilmək	c ç i t͡s i l m æ j
 kiçilmək	t͡s i t͡s i l m æ h
 kişibaz	k i ʃ i b ɑ z
 kişibazlıq	k i ʃ i b ɑ z ɫ ɯ χ
+kişmiş	c i ʃ m i ʃ
 kişmiş	t͡ʃ i ʃ m i ʃ
 kobud	t͡ʃ o b u d
 kodlaşdırma	k o d ɫ ɑ ʃ d ɯ r m ɑ
+kol	c o ɫ
 kommunizm	k o m u n i z m
 kommunizm	k ɑ m u n i z m
+kor	c o r
+koğuş	c o ɣ u ʃ
 kravat	k r ɑ v ɑ t
-kulyok	k u l j o k
 kuxna	k u x n a
+köhnə	c œ h n æ
+köhnə	c œ j n æ
 köhnə	t͡ʃ œ h n æ
+kök	c œ c
+köks	c œ c s
 köks	t͡ʃ œ t͡ʃ s
 kökəlmək	k œ k æ l m æ j
 kökəlmək	k œ k æ l m æ k
+kölgə	c œ l ɟ æ
 kömür	k œ m y r
 kömür	t͡ʃ œ m y r
+kömək	c œ m e j
+kömək	c œ m æ c
+kömək	c œ m æ j
+kömək	c œ m æ t͡ʃ
+kömək	c œ m æ ç
+könül	c œ n y l
+könül	c œ ŋ y l
 könül	d͡ʒ œː l
+köpük	c œ p y c
+köpək	c œ p æ c
+köpək	c œ p æ ç
 köpək	k œ p æ j
+körpü	c œ r p y
 körpə	k œ r p æ
 körpə	t͡ʃ œ r p æ
 kösöv	k œ s œ v
 kösöv	t͡ʃ œ s œ v
+köynək	c œ j n æ c
 köynək	t͡ʃ œ j n æ t͡ʃ
+köçkün	c œ t͡ʃ c y n
 köçkün	t͡ʃ œ t͡s t͡ʃ y n
+köçəri	c œ t͡ʃ æ r i
 köçəri	t͡ʃ œ t s æ r i
+köşək	c œ ʃ æ c
+köşək	c œ ʃ æ j
 köşək	t͡ʃ œ ʃ æ t͡ʃ
+küftə	c y f t æ
+küftə	t͡ʃ y f t æ
 kül	k y l
+küll	c y l
+külək	c y l æ c
+külək	c y l æ j
+külək	c y l æ ç
 külək	t͡ʃ y l æ t͡ʃ
 künc	t͡ʃ y n d͡z
+kündür	c y n d y r
 kündür	t͡ʃ y n d y r
+kürəcik	c y r æ d͡ʒ i k
 kürəcik	t͡ʃ y r æ d͡z i t͡ʃ
 kürəkçi	k y r æ k t͡ʃ i
 kürəkçi	t͡ʃ y r æ t͡ʃ t͡s i
@@ -1421,27 +1750,54 @@ kürəkən	k y r æ k æ n
 kürəkən	t͡ʃ y r æ t͡ʃ æ n
 küsmək	k y s m æ j
 küsmək	k y s m æ k
+küçə	c y t͡ʃ æ
 küçə	t͡s y t͡s æ
 küçə	t͡ʃ y t͡s æ
+kəfgir	c æ f ɟ i r
 kəfgir	t͡ʃ æ f d͡ʒ i r
+kəfən	c æ f æ n
 kəfən	t͡ʃ æ f æ n
+kəklik	c æ c l i c
+kəklikotu	c æ c l i c o t u
+kəklikotu	c æ c l i j o t u
+kəlbətin	c æ l b æ t i n
 kəlbətin	t͡ʃ æ l b æ t i n
+kəllə	c æ lː æ
 kəllə	t͡ʃ æ lː æ
+kəlmə	c æ l m æ
 kəlmə	t͡ʃ æ l m æ
+kəlçə	c æ l t͡ʃ æ
 kəlçə	t͡ʃ æ l t͡s æ
+kələk	c æ l æ c
 kələk	t͡ʃ æ l æ t͡ʃ
+kənar	c æ n ɑ r
 kənar	t͡ʃ æ n ɑ r
+kənd	c æ n d
+kənd	c æ t
 kəpək	k æ p æ j
 kəpək	k æ p æ k
 kəpək	t͡ʃ æ p æ t͡ʃ
+kəpənək	c æ p æ n æ c
+kərki	c æ r c i
 kərki	t͡ʃ æ r t͡ʃ i
+kərt	c æ r t
 kərt	t͡ʃ æ r t
+kərtənkələ	c æ r t æ n c æ l æ
 kərə	k æ r æ
+kəs	c æ s
+kəsik	c æ s i c
 kəsik	t͡ʃ æ s i t͡ʃ
+kəsilmək	c æ s i l m æ c
 kəsilmək	t͡ʃ æ s i l m ɑ χ
+kəsmək	c æ s m æ k
 kəsmək	t͡ʃ æ s m ɑ χ
+kəsək	c æ s æ c
+kəsək	t͡ʃ æ s æ c
+kəsəl	c æ s æ l
+kəsəl	t͡ʃ æ s æ l
 labüd	ɫ ɑː b y d
 lahiyə	ɫ ɑː h i j æ
+lakin	l aː c i n
 lakin	l aː t͡ʃ i n
 lampoçka	ɫ ɑ m b ɯ t͡s k ɑ
 lampoçka	ɫ ɑ m p ɯ t͡s k ɑ
@@ -1459,6 +1815,7 @@ lehinə	l æ h i n æ
 leysan	l e j s ɑ n
 liman	l i m ɑ n
 loru	l o r u
+lök	l œ c
 lök	l œ t͡ʃ
 lövbər	l œ v b æ r
 lüt	l y t
@@ -1468,6 +1825,7 @@ ləhcə	l æ h d͡ʒ æ
 ləhcəşünas	l æ h d͡ʒ æ ʃ y n ɑ s
 ləhcəşünaslıq	l æ h d͡ʒ æ ʃ y n ɑ s ɫ ɯ χ
 lətifə	l æ t i f æ
+ləzgi	l æ z ɟ i
 maarif	m ɑː r i f
 maarifləndirmək	m ɑː r i f l æ n d i r m æ j
 maarifləndirmək	m ɑː r i f l æ n d i r m æ k
@@ -1509,6 +1867,7 @@ meynə	m e j n æ
 milad	m i ɫ ɑ d
 millət	m i lː æ t
 milçək	m i l t͡s æ t͡ʃ
+milçək	m i l t͡ʃ æ c
 min	m i n
 minbər	m i n b æ r
 minmək	m i mː æ k
@@ -1588,12 +1947,14 @@ müxalifət	m u x ɑ l i f æ t
 müxalifət	m y x ɑː l i f æ t
 müxbir	m y x b i r
 müxtəlif	m y x t æ l i f
+müzakirə	m y z ɑː c i r æ
 müğənni	m y ɣ æ nː i
 müşahidə	m y ʃ ɑː h i d æ
 müştəri	m y ʃ t æ r i
 müşəmbə	m y ʃ æ m b æ
 müəllif	m y æ lː i f
 müəllim	m y æ lː i m
+müəllimlik	m y æ lː i m l i c
 müəllimə	m y æ lː i m æ
 mıx	m ɯ χ
 məbəd	m æː b æ d
@@ -1613,6 +1974,7 @@ məhz	m æ h z
 məhşur	m æ h ʃ u r
 məhşər	m æ h ʃ æ r
 məhəlli	m æ h æ lː i
+məktub	m æ c t u b
 məktub	m æ h t u b
 məktəb	m æ k t æ b
 məktəb	m æ ç t æ b
@@ -1658,6 +2020,7 @@ məğlubiyyət	m æ ɣ ɫ u b i j æ t
 məşrutə	m æ ʃ r uː t æ
 nadir	n ɑː d i r
 nahiyə	n ɑː h i j æ
+nakam	n ɑː c ɑ m
 nal	n ɑ ɫ
 namaz	n ɑ m ɑ z
 namə	n ɑː m æ
@@ -1673,7 +2036,9 @@ narın	n ɑː r ɯ n
 natamamlıq	n ɑ t ɑ m ɑ m ɫ ɯ χ
 natamamlıq	n ɑ t ɑ m ɑ n ɫ ɯ χ
 natəmiz	n ɑː t æ m i z
+nazik	n ɑː z i c
 nazir	n ɑː z i r
+nazirlik	n ɑː z i r l i c
 nazirlik	n ɑː z i r l i j
 nağıl	n ɑ ɣ ɯ ɫ
 naşir	n ɑː ʃ i r
@@ -1701,6 +2066,7 @@ nijad	n i ʒ ɑ d
 nikbin	n i k b i n
 niyə	n i j æ
 noxta	n o x t ɑ
+nökər	n œ c æ r
 nökər	n œ t͡ʃ æ r
 nömrə	n œ m r æ
 nöqtə	n œ k t æ
@@ -1764,6 +2130,8 @@ osturaqçı	o s t u r a χ t͡ʃ ɯ
 osurmaq	o s u r m ɑ χ
 otaq	o t ɑ χ
 otaqda	o t ɑ ɣ d ɑ
+otlamaq	o t ɫ ɑ m ɑ x
+otlamaq	o tː ɑ m ɑ x
 oturacaq	o t u r ɑ d͡z ɑ χ
 oturacaq	o t u r ɑ d͡ʒ ɑ χ
 oturmaq	o t u r m ɑ χ
@@ -1823,6 +2191,7 @@ paxıllıq	p ɑ χ ɯ ɫː ɯ χ
 paxır	p ɑ χ ɯ r
 paylaşım	p ɑ j ɫ ɑ ʃ ɯ m
 paytaxt	p ɑ j t ɑ χ t
+payız	p ɑ j ɯ z
 paçka	p ɑ t͡ʃ k ɑ
 paçka	p ɑ ʃ k ɑ
 pencək	p e n d͡ʒ æ k
@@ -1875,6 +2244,8 @@ pəncərə	p e n d͡z æ r æ
 pəncərə	p e n d͡ʒ æ r æ
 pəncərə	p æ n d͡z æ r æ
 pəncərə	p æ n d͡ʒ æ r æ
+pərakəndə	p æ r ɑ c æ n d æ
+pərakəndəlik	p æ r ɑː c æ n d æ l i c
 pərvanə	p æ r v ɑː n æ
 qab	ɡ ɑ b
 qabaq	ɡ ɑ b ɑ χ
@@ -1919,6 +2290,7 @@ qanacaqlı	ɡ ɑ n ɑ d͡z ɑ ɣ ɫ ɯ
 qanacaqlı	ɡ ɑ n ɑ d͡ʒ ɑ ɣ ɫ ɯ
 qanad	ɡ ɑ n ɑ d
 qanamaq	ɡ ɑ n ɑ m ɑ χ
+qanbur	ɡ ɑ n b u r
 qancıq	ɡ ɑ n d͡z ɯ χ
 qancıq	ɡ ɑ n d͡ʒ ɯ χ
 qandal	ɡ ɑ n d ɑ ɫ
@@ -1937,6 +2309,7 @@ qapı	ɡ ɑ p ɯ
 qar	ɡ ɑ r
 qara	ɡ æ r æ
 qara	ɡ ɑ r ɑ
+qarabaşaq	ɡ ɑ r ɑ b ɑ ʃ ɑ x
 qaraciyər	ɡ ɑ r ɑ d͡z i j æ r
 qaraciyər	ɡ ɑ r ɑ d͡ʒ i j æ r
 qaradərili	ɡ ɑ r ɑ d æ r i l i
@@ -1961,12 +2334,14 @@ qarşılamaq	ɡ ɑ r ʃ ɯ ɫ ɑ m ɑ χ
 qarşılıqlı	ɡ ɑ r ʃ ɯ ɫ ɯ ɣ ɫ ɯ
 qarşısında	ɡ ɑ r ʃ ɯ s ɯ n d ɑ
 qarət	ɡ ɑː r æ t
+qasıq	ɡ ɑ s ɯ x
 qasırğa	ɡ ɑ s ɯ r ɣ a
 qat	ɡ æ t
 qat	ɡ ɑ t
 qatı	ɡ ɑ t ɯ
 qatıq	ɡ ɑ t ɯ χ
 qatışıq	ɡ ɑ t ɯ ʃ ɯ χ
+qax	ɡ ɑ x
 qaya	ɡ ɑ j ɑ
 qayda	ɡ ɑ j d ɑ
 qaydasında	ɡ ɑ j d ɑ s ɯ n d ɑ
@@ -2091,6 +2466,8 @@ quru	ɡ u r u
 qurum	ɡ u r u m
 qurutmaq	ɡ u r u t m ɑ χ
 qusmaq	ɡ u s m ɑ χ
+qutab	k u t ɑ b
+qutab	ɡ u t ɑ b
 quyruq	ɡ u j r u ɣ
 quyu	ɡ u j u
 quzey	ɡ u z e j
@@ -2126,6 +2503,7 @@ qırxmaq	ɡ ɯ r χ m ɑ χ
 qırğın	ɡ ɯ r ɣ ɯ n
 qısa	ɡ ɯ s ɑ
 qıt	ɡ ɯ t
+qıvrım	ɡ ɯ v r ɯ m
 qıymaq	ɡ ɯ j m ɑ χ
 qızdırmaq	ɡ ɯ z d ɯ r m a χ
 qızlıq	ɡ ɯ z d ɯ χ
@@ -2163,6 +2541,7 @@ qəlbən	ɡ æ ɫ b æ n
 qəliz	ɡ æ l i z
 qəlyan	ɡ æ l j ɑ n
 qələbə	ɡ æ l æ b æ
+qəməngiz	ɡ æ m æ ŋ ɟ i z
 qənd	ɡ æ n d
 qənirsiz	ɡ æ n i r s i z
 qəpik	ɡ æ p i h
@@ -2185,6 +2564,9 @@ riayət	r i ɑ j æ t
 rozetka	r ɑ z e t k ɑ
 ruhani	r u h ɑː n i
 ruhi	r uː h i
+ruzigar	r u z i ɟ a r
+ruzigar	r y z d͡ʒ a r
+ruzigar	r y z ɟ a r
 ruznamə	r u z n ɑ m æ
 rüşvət	r y ʃ v æ t
 rüşvətxorluq	r y ʃ v æ t x o r ɫ u x
@@ -2261,6 +2643,7 @@ sağsağan	s ɑ x s a ɣ a n
 sevda	s e v d ɑ
 sevda	s œ j d ɑ
 sevda	s œ y d ɑ
+sevgi	s e v ɟ i
 sevgisiz	s e v d͡ʒ i s i z
 sevgisiz	s e v ɡ i s i z
 sevindirici	s e v i n d i r i d͡z i
@@ -2273,6 +2656,7 @@ sevinmək	s œ j y n m ɑ χ
 sevmək	s e v m æ j
 sevmək	s e v m æ k
 sevmək	s œ j m ɑ χ
+seyrək	s e j r æ c
 sezmək	s e z m æ j
 sezmək	s e z m æ k
 seçici	s e t͡s i d͡z i
@@ -2293,6 +2677,7 @@ sikmək	s i k m æ k
 sikmək	s i k m æ ç
 silahlanmaq	s i l ɑ h l ɑ mː a χ
 silahlı	s i ɫ ɑ h ɫ ɯ
+silk	s i l c
 silmək	s i l m æ k
 sima	s æ m ɑ
 simic	s i m i d͡z
@@ -2319,7 +2704,7 @@ sonuncu	s o n u n d͡ʒ u
 sormaq	s o r m ɑ χ
 sosializm	s o s i ɑ l i z m
 sosializm	s ɑ s i ɑ l i z m
-soxasox	s o χ ɑ s o x
+soxasox	s o χ ɑ s o χ
 soxmaq	s o χ m ɑ χ
 soxulcan	s o x u ɫ d͡z ɑ n
 soxulcan	s o x u ɫ d͡ʒ ɑ n
@@ -2333,6 +2718,10 @@ soyutma	s o j u t m ɑ
 soyutmaq	s o j u t m ɑ χ
 ssenari	sː e n ɑ r i
 stul	s t u ɫ
+stəkan	i s c æ n
+stəkan	i s c ɑ n
+stəkan	i s t æ c ɑ n
+stəkan	s t æ c ɑ n
 su	s u
 subay	s u b ɑ j
 suiti	s u i t i
@@ -2377,14 +2766,19 @@ sümük	s y m y j
 sümük	s y m y k
 sünni	s y nː i
 sünnət	s y n n æ t
+sürgün	s y r ɟ y n
 sürmək	s y r m æ j
 sürmək	s y r m æ k
 sürmək	s y r m ɑ χ
 sürtgü	s y r t d͡ʒ y
+sürtgü	s y r t ɟ y
+sürtkü	s y r t c y
 sürtkü	s y r t t͡ʃ y
 sürü	s y r y
 sürücü	s y r y d͡z y
 sürücü	s y r y d͡ʒ y
+sürüşkən	s y r y ʃ c æ n
+sürüşkən	s y r y ʃ ɟ æ n
 sürətləndirmək	s y r æ t l æ n d i r m æ k
 sürətlənmə	s y r æ t l æ mː æ
 sürətlənmə	s y r æ t l æ n m æ
@@ -2412,6 +2806,8 @@ sıçrayış	s ɯ t͡ʃ r ɑ j ɯ ʃ
 sığmaq	s ɯ ɣ m ɑ χ
 sığortalamaq	s ɯ ɣ o r t ɑ ɫ ɑ m ɑ χ
 sığınmaq	s ɯ ɣ ɯ n m ɑ χ
+səbirsiz	s æ b r s i z
+səbirsizlik	s æ b r s i z l i c
 səbəb	s æ b æ b
 sədd	s æ d
 səfalət	s æ f ɑː l æ t
@@ -2421,6 +2817,7 @@ səfər	s æ f æ r
 səhnə	s æ h n æ
 səhv	s æ f
 səhər	s æ h æ r
+səkkizinci	s æ c c i z i n d͡ʒ i
 səksəninci	s æ ç s æ n i n d͡ʒ i
 sələf	s æ l æ f
 səma	s æ m ɑ
@@ -2447,6 +2844,7 @@ sərçə	s æ r t͡ʃ æ
 səs	s æ s
 səsvermə	s æ s v e r m æ
 tabaşir	t ɑ b ɑː ʃ i r
+tabe	t ɑː b e
 tac	t ɑ d͡z
 tac	t ɑ d͡ʒ
 tacir	t ɑː d͡z i r
@@ -2476,6 +2874,7 @@ tarla	t ɑ r ɫ ɑ
 taun	t ɑ u n
 taxmaq	t ɑ χ m ɑ χ
 tayfa	t ɑ j f ɑ
+tayqol	t ɑ j ɡ o ɫ
 tayqulaq	t ɑ j ɡ u ɫ ɑ x
 tel	t e l
 telefon	t e l e f o n
@@ -2492,7 +2891,9 @@ tezliklə	t e z l i k l æ
 tibb	t i b
 ticarət	t i d͡z ɑ ɾ æ t
 ticarət	t i d͡ʒ ɑ ɾ æ t
+tikili	t i c i l i
 tikili	t i t͡ʃ i l i
+tikinti	t i c i n t i
 tikinti	t i t͡ʃ i n t i
 tikmək	t i k m e j
 tikmək	t i k m æ j
@@ -2500,11 +2901,14 @@ tikmək	t i t͡ʃ m æ ç
 tikmək	t i t͡ʃ m ɑ χ
 tikə	t i k æ
 tikə	t i t͡ʃ æ
+tilişkə	t i l i ʃ c æ
 tire	t i r e
 tok	t o k
 topa	t o p ɑ
 topal	t o p ɑ ɫ
 toplu	t o p ɫ u
+toran	t o r ɑ n
+torba	t o r b ɑ
 tormoz	t o r m o z
 torpaq	t o p r ɑ χ
 torpaq	t o r p ɑ χ
@@ -2525,7 +2929,10 @@ turşəng	t u r ʃ æ ŋ ɡ
 tutmaq	d u t m ɑ χ
 tutmaq	t u t m ɑ χ
 tutulmaq	t u t u ɫ m ɑ χ
+tökmək	t œ c m æ c
+tökmək	t œ c m æ j
 tökmək	t œ k m ɑ χ
+törəmək	t œ r æ m æ c
 tövbə	t œ v b æ
 tövbə	t œː b æ
 tövsiyə	t œ v s i j æ
@@ -2534,6 +2941,7 @@ tükənmə	t y k æ n m æ
 tükənmə	t y t͡ʃ æ n m æ
 tükənmək	t y k æ mː æ k
 tükənmək	t y k æ n m æ k
+tülkü	t y l c y
 tünd	t y n d
 türbə	t y r b æ
 tüstü	t y s t y
@@ -2548,12 +2956,15 @@ təbrik	t æ b r i k
 təbrik	t æ b r i t͡ʃ
 təbəə	t æ b æ æ
 təcavüzkar	t æ d͡z ɑː v y z t͡ʃ ɑ r
+təcavüzkar	t æ d͡ʒ ɑː v y z c ɑ r
 təcrübə	t æ d͡z r y b æ
 təcrübə	t æ d͡ʒ r y b æ
+tədarük	t æ d ɑː r y c
 tədarük	t æ d ɑː r y t͡ʃ
 tədbir	t æ d b i r
 tədbirli	t æ d b i r l i
 tədbirli	t æ d b i rː i
+tədhiş	t æ d h i ʃ
 təfavüt	t a f o t
 təfavüt	t æ f o t
 təfavüt	t æ f ɑː v y t
@@ -2564,32 +2975,52 @@ təhsil	t æ h s i l
 tək	t æ h
 tək	t æ k
 tək	t æ ç
+təkbuynuz	t æ c b u j n u z
+təki	t æ c i
 təkid	t æ k i d
 təkid	t æ t͡ʃ i d
 təkmilləşdirmək	t æ k m i lː æ ʃ d i r m æ k
 təknikahlılıq	t æ t͡ʃ n i d͡ʒ a h ɫ ɯ l ɯ χ
 təknikahlılıq	t æ t͡ʃ n i t͡ʃ a h ɫ ɯ l ɯ χ
+təkrar	t i c r ɑ r
 təkrar	t i t͡ʃ r ɑ r
+təkrar	t æ c r ɑ r
+təkyə	t æ c j æ
 təkə	t æ k æ
+təkər	t æ c æ r
 təkər	t æ j æ ɾ
 təkər	t æ t͡ʃ æ r
 təlabat	t æ ɫ ɑ b ɑ t
+təlatüm	t æ ɫ ɑː t y m
 təliqə	t æ l i ɡ æ
 tələbat	t æ l æ b ɑ t
 tələbə	t æ l æ b æ
+tələk	t æ l æ c
 tələk	t æ l æ t͡ʃ
 tələt	t æ l æ t
 təmin	t æː m i n
 təmir	t æː m i r
+təmizkar	t æ m i z c ɑ r
+təmizkarlıq	t æ m i z c ɑ r ɫ ɯ χ
+təmizkarlıq	t æ m i z c ɑ rː ɯ χ
+təmizləmək	t æ m i z d æ m æ c
 təmizləmək	t æ m i z d æ m æ j
+təmizləmək	t æ m i z l æ m æ c
 təmizləmək	t æ m i z l æ m æ j
 təmrin	t æ m r i n
+təntik	t æ n t i c
+tənək	t æ n æ c
+tənək	t æ ŋ æ c
+təqaüd	t æ ɡ ɑː y d
 təqdir	t æ ɡ d i r
 təqdis	t æ ɡ d i s
 təqvim	t æ ɡ v i m
 tər	t æ r
 tərcüməçi	t æ ɾ d͡z y m æ t͡s i
 tərcüməçi	t æ ɾ d͡ʒ y m æ t͡ʃ i
+tərgitmək	t æ r ɟ i t m æ j
+tərgitmək	t æ r ɟ i t m æ k
+tərləmək	t æ rː æ m æ c
 tərləmək	t æ rː æ m æ j
 tərləmək	t æ rː æ m ɑ χ
 tərpənmək	t æ r p æ mː m æ j
@@ -2601,6 +3032,7 @@ tərəzi	t æ r æ z i
 təsirli	t æ s i r l i
 təsirli	t æ s i rː i
 təsirsiz	t æ s i r s i z
+tətik	t æ t i c
 təvəllüd	t æ v æ lː y d
 təvəllüdlü	t æ v æ lː y d l y
 təxir	t æ χ i r
@@ -2632,6 +3064,7 @@ uduş	u d ɯ ʃ
 ulama	u ɫ ɑ m ɑ
 ulamaq	u ɫ ɑ m ɑ x
 ulu	u ɫ u
+unitaz	u n i t ɑ z
 unudulmaz	u n u d u ɫ m ɑ z
 unutmaq	u n u t m ɑ χ
 unutqan	u n u t k ɑ n
@@ -2647,8 +3080,10 @@ uzaqbaşı	u z ɑ ɣ b ɑ ʃ ɯ
 uzaqlıq	u z ɑ ɣ ɫ ɯ x
 uzun	u z u n
 uzundraz	u z u n d r ɑ z
-uçmaq	u t͡s m ɑ χ
-uçmaq	u t͡ʃ m ɑ χ
+uçmaq	u t͡s m ɑ x
+uçmaq	u t͡ʃ m ɑ x
+uçurmaq	u t͡s u r m ɑ x
+uçurmaq	u t͡ʃ u r m ɑ x
 uçuş	u t͡s ɯ ʃ
 uçuş	u t͡ʃ ɯ ʃ
 uğramaq	u ɣ r ɑ m ɑ χ
@@ -2673,6 +3108,10 @@ vatsap	v ɑ t s ɑ p
 vağzal	v ɑ ɣ z ɑ ɫ
 vec	v e d͡z
 vec	v e d͡ʒ
+vergi	v e r ɟ i
+vergi	v æ r ɟ i
+vergiçi	v e r ɟ i t͡s i
+vergiçi	v e r ɟ i t͡ʃ i
 vergül	v e r ɡ y l
 veriliş	v e r i l i ʃ
 verilmək	v e r i l m æ j
@@ -2680,6 +3119,7 @@ verilmək	v e r i l m æ k
 verilmək	v æ r i l m ɑ χ
 verilmək	v æ r y l m e j
 verilənlər	v e r i l æ n l æ r
+vermək	v e r m æ c
 vermək	v e r m æ ç
 vermək	v e r m ɑ χ
 vermək	v æ r m æ j
@@ -2740,9 +3180,12 @@ xiyaban	χ ɯ j ɑ b ɑ n
 xiyar	χ ɯ j ɑ r
 xodlamaq	χ o tː ɑ m ɑ χ
 xodlanmaq	χ o tː ɑ m ɑ χ
+xonça	x o n t͡s ɑ
+xonça	x o n t͡ʃ ɑ
 xora	x o r ɑ
 xoş	x o ʃ
 xoşagəlməz	χ o ʃ ɑ d͡ʒ æ l m æ z
+xoşagəlməz	χ o ʃ ɑ ɟ æ l m æ z
 xudbin	χ u d b i n
 xurma	χ u r m ɑ
 xötək	χ œ t æ j
@@ -2893,6 +3336,7 @@ yeddi	j e tː i
 yeddinci	j e tː i n d͡z i
 yeddinci	j e tː i n d͡ʒ i
 yeganə	j e d͡ʒ ɑː n æ
+yeganə	j e ɟ ɑː n æ
 yekə	j e k æ
 yekə	j e t͡ʃ æ
 yel	j e l
@@ -2906,8 +3350,10 @@ yelpik	j e l p i j
 yelpik	j e l p i k
 yelpik	j e l p i ç
 yelçəkən	j e l t͡ʃ æ k æ n
+yemək	j e m æ c
 yemək	j e m æ j
 yemək	j e m ɑ χ
+yengə	j e ŋ ɟ æ
 yeni	j e n i
 yenidən	j e n i d æ n
 yenilməz	j e n i l m æ z
@@ -2925,17 +3371,23 @@ yerləşmək	j e rː æ ʃ m æ j
 yersiz	j e r s i z
 yesir	j e s i r
 yetim	j e t i m
+yetişdirmək	j e t i ʃ d i r m æ c
 yetişdirmək	j e t i ʃ d i r m æ j
 yetişmiş	j e t i ʃ m i ʃ
+yetişmək	j e t i ʃ m æ c
 yetişmək	j e t i ʃ m æ j
 yetmiş	j e t m i ʃ
 yetmişinci	j e t m i ʃ i n d͡ʒ i
+yetmək	j e t m æ c
 yetmək	j e t m æ j
 yey	j e j
 yey	j e ɡ
+yeyilmək	j e j i l m æ c
 yeyilmək	j e j i l m æ j
 yeznə	j e z n æ
 yiyə	j i j æ
+yiyələnmək	j i j æ l æ mː æ c
+yiyələnmək	j i j æ l æ n m æ c
 yiyəsiz	j i j æ s i z
 yoluxmaq	j o ɫ u χ m ɑ χ
 yoluxucu	j o ɫ u χ u d͡z u
@@ -2979,7 +3431,10 @@ yönlü	j œ nː y
 yüksək	j y k s æ k
 yükçü	j y k t͡s y
 yükçü	j y k t͡ʃ y
+yüngül	j y n ɟ y l
+yürümək	j y r y m æ c
 yürümək	j y r y m æ j
+yüyürmək	j y j y r m æ c
 yüyürmək	j y j y r m æ j
 yüzüncü	j y z y n d͡ʒ y
 yırtmaq	j ɯ r t m ɑ χ
@@ -2988,12 +3443,14 @@ yırtıcı	j ɯ r t ɯ d͡ʒ ɯ
 yırğalamaq	j ɯ r ɣ ɑ ɫ ɑ m ɑ χ
 yıxmaq	j ɯ χ m ɑ χ
 yığmaq	j ɯ ɣ m ɑ χ
+yığılmaq	j ɯ ɣ ɯ ɫ m ɑ x
 yığışdırmaq	j ɯ ɣ ɯ ʃ d ɯ r m ɑ χ
 yığışmaq	j ɯ ɣ ɯ ʃ m ɑ χ
 yəqin	j æ ɡ i n
 yəqin	j æː ɡ i n
 zabit	z ɑː b i t
 zad	z ɑ d
+zadəgan	z ɑː d æ ɟ ɑ n
 zahiri	z ɑː h i r i
 zahı	z ɑ h ɯ
 zaman	z ɑ m ɑ n
@@ -3002,6 +3459,7 @@ zavod	z ɑ v o d
 zidd	z i d
 zirinc	z i r i n d͡z
 zirinc	z i r i n d͡ʒ
+ziyadə	z i j ɑː d æ
 ziyafət	z i j ɑ f æ t
 ziyil	z i j i l
 zorakılıq	z o r ɑ k ɯ l ɯ χ
@@ -3011,9 +3469,12 @@ zorlama	z o r ɫ ɑ m ɑ
 zorlama	z o rː ɑ m ɑ
 zorlamaq	z o r ɫ ɑ m ɑ χ
 zorlamaq	z o rː ɑ m ɑ χ
+zökəm	z œ c æ m
 zəfər	z æ f æ ɾ
 zəfəran	z æ f æ r ɑ n
 zəhmət	z æ h m æ t
+zəhrimar	z æ h i r m ɑ r
+zəhrimar	z æ h r i m ɑ r
 zəhərli	z æ h æ r l i
 zəhərli	z æ h æ rː i
 zəif	z æ i f
@@ -3024,10 +3485,13 @@ zəmanə	z æ m ɑː n æ
 zən	z æ n
 zəncir	z æ n d͡z i r
 zəncir	z æ n d͡ʒ i r
+zəncirvari	z æ n d͡z i r v ɑː r i
+zəncirvari	z æ n d͡ʒ i r v ɑː r i
 zəncəfil	z æ n d͡z æ f i l
 zəncəfil	z æ n d͡ʒ æ f i l
 zəngin	z æ n d͡ʒ i n
 zəngin	z æ ŋ ɡ i n
+zərgər	z æ r ɟ æ r
 zərurət	z æ r uː r æ t
 zərər	z æ r æ r
 Çənab	t͡ʃ æ n ɑ b
@@ -3053,6 +3517,8 @@ zərər	z æ r æ r
 çaqqı	t͡s ɑ kː ɯ
 çar	t͡s ɑ r
 çar	t͡ʃ ɑ r
+çardaq	t͡s ɑ r d ɑ x
+çardaq	t͡ʃ ɑ r d ɑ x
 çarə	t͡s ɑː r æ
 çarə	t͡ʃ ɑː r æ
 çatdırmaq	t͡s ɑ tː ɯ r m ɑ χ
@@ -3103,6 +3569,7 @@ zərər	z æ r æ r
 çibin	t͡s i b i n
 çibin	t͡ʃ i b i n
 çilingər	t͡s i l i n d͡ʒ æ r
+çilingər	t͡ʃ i l i n ɟ æ r
 çimizdirmək	t͡s i m i z d i r m æ k
 çimizdirmək	t͡ʃ i m i z d i r m æ j
 çimizdirmək	t͡ʃ i m i z d i r m æ k
@@ -3141,7 +3608,10 @@ zərər	z æ r æ r
 çul	t͡s u ɫ
 çul	t͡ʃ u ɫ
 çuğundur	t͡ʃ u ɣ u n d u r
+çökmək	t͡s œ c m æ t͡ʃ
+çökmək	t͡ʃ œ c m æ c
 çöküntü	t͡s œ t͡ʃ y n t y
+çöküntü	t͡ʃ œ c y n t y
 çöl	t͡s œ l
 çöl	t͡ʃ œ l
 çömçəquyruq	t͡ʃ œ m t͡ʃ æ ɡ u j r u χ
@@ -3201,11 +3671,16 @@ zərər	z æ r æ r
 ödlük	œ d l y ç
 ödəniş	œ d æ n i ʃ
 ödənişsiz	œ d æ n i ʃ s i z
+öfgə	o f ɟ æ
 öfgə	œ f d͡ʒ æ
+öfgə	œ f ɟ æ
+ögey	œ ɟ e j
+ögey	œ ɟ æ j
 öküz	œ k y z
 öldürmək	œ l d y r m æ j
 öldürmək	œ l d y r m æ k
 öldürmək	œ l d y r m ɑ χ
+ölkə	œ l c æ
 ölmək	œ l m æ k
 ölmək	œ l m ɑ χ
 ölçmək	œ l t͡s m æ j
@@ -3234,6 +3709,9 @@ zərər	z æ r æ r
 ördək	œ r d æ k
 ördək	œ r d æ ç
 ördəkburun	œ r d æ k b u r u n
+örgənmək	œ r ɟ æ mː æ c
+örgənmək	œ r ɟ æ n m æ c
+örgəşmək	œ r ɟ æ ʃ m æ c
 örpək	œ r p æ j
 örpək	œ r p æ ç
 örtmək	œ r t m æ j
@@ -3243,11 +3721,14 @@ zərər	z æ r æ r
 örtük	œ r t y j
 örtük	œ r t y ç
 öskürmək	œ s k y r m æ j
+öskürmək	œ s ɟ y r m ɑ χ
 ötkəm	œ t k æ m
 ötrü	œ t r y
 ötəri	œ t æ r i
 övlad	e v l ɑ d
 övlad	œ v l ɑ d
+övladsız	œ v ɫ ɑ d s ɯ z
+övladsız	œ v ɫ ɑ t s ɯ z
 övrə	œ v r æ
 öxbə	œ h b æ
 öxbə	œ x b æ
@@ -3258,7 +3739,11 @@ zərər	z æ r æ r
 öyəc	œ d͡ʒ æ d͡z
 öyəc	œ j æ d͡z
 öyəc	œ j æ d͡ʒ
+öyəc	œ ɟ æ d͡ʒ
+özünlə	œ z y n l æ
 özəl	œ z æ l
+ülgü	y l ɟ y
+ülgüc	y l ɟ y d͡ʒ
 ümid	y m i d
 ümumi	y m uː m i
 ünlü	y n l y
@@ -3266,19 +3751,25 @@ zərər	z æ r æ r
 ünsür	y n s y r
 ünvan	y n v ɑ n
 ürək	y r æ ç
+ürək	y ɾ æ c
 ürək	y ɾ æ j
 ürəmək	y r y m æ χ
+ürəmək	y r æ m æ c
+ürəmək	y r æ m æ ɟ
 üst	y s t
 üstqurum	y s t ɡ u r u m
 üstündə	y s t y n d æ
 üstünə	y s t y n æ
 ütü	y t y
 üzbəüz	y z b æ y z
+üzgün	y z d͡ʒ y n
+üzgün	y z ɟ y n
 üzmək	y z m æ j
 üzmək	y z m æ k
 üzmək	y z m ɑ χ
 üzrə	y z r æ
 üzv	y z v
+üzügülər	y z y ɟ y l æ r
 üzük	y z y j
 üzük	y z y k
 üzərində	y z æ r i n d æ
@@ -3288,11 +3779,13 @@ zərər	z æ r æ r
 üçün	y t͡ʃ y n
 üçüncü	y t͡ʃ y n d͡ʒ y
 üşütmə	y ʃ y t m æ
+üşütmək	y ʃ y t m æ c
 Ğ	ɣ
 Şamaxı	ʃ ɑ m ɑ χ ɯ
 Şəhla	ʃ æ h l ɑ
 şad	ʃ ɑ d
 şadlıq	ʃ ɑ d ɫ ɯ χ
+şagird	ʃ ɑː ɟ i ɾ t
 şahanə	ʃ ɑ h ɑː n æ
 şahid	ʃ ɑː h i d
 şahmat	ʃ ɑ h m ɑ t
@@ -3311,11 +3804,14 @@ zərər	z æ r æ r
 şer	ʃ e i r
 şer	ʃ e r
 şeytan	ʃ e j t ɑ n
+şikəst	ʃ i c æ s t
 şikəst	ʃ i t͡ʃ æ s t
 şillələmək	ʃ i lː æ
 şimali	ʃ i m ɑ l ɯ
 şimali	ʃ i m ɑː l i
+şimşək	ʃ i m ʃ æ c
 şimşək	ʃ i m ʃ æ j
+şirkət	ʃ i r c æ t
 şiş	ʃ i ʃ
 şişirtmək	ʃ i ʃ i r m æ j
 şişirtmək	ʃ i ʃ i r m æ k
@@ -3331,12 +3827,15 @@ zərər	z æ r æ r
 şüur	ʃ y uː r
 şüyüd	ʃ y j y d
 şüşə	ʃ y ʃ æ
+şəbəkə	ʃ æ b æ c æ
 şəbəkə	ʃ æ b æ t͡ʃ æ
 şəcərə	ʃ æ d͡z æ r æ
 şəcərə	ʃ æ d͡ʒ æ r æ
 şəhid	ʃ æ h i d
 şəhla	ʃ æ h l ɑ
 şəhər	ʃ æ h æ ɾ
+şəkil	ʃ æ c i l
+şəkər	ʃ æ c æ ɾ
 şəlalə	ʃ æ ɫ ɑː l æ
 şənbə	ʃ æ m b æ
 şərbət	ʃ æ r b æ t
@@ -3361,6 +3860,7 @@ zərər	z æ r æ r
 əcəl	æ ʒ æ l
 əcəm	æ d͡ʒ æ m
 ədalət	æ d ɑː l æ t
+ədalətsizlik	æ d ɑː l æ t s i z l i c
 ədat	æ d a t
 ədhəm	æ d h æ m
 ədliyyə	æ d l i j æ
@@ -3370,6 +3870,7 @@ zərər	z æ r æ r
 əfv	æ f
 əgər	æ d͡ʒ æ r
 əgər	æ j æ ɾ
+əgər	æ ɟ æ ɾ
 əhali	æ h ɑ l i
 əhl	æ h l
 əhvalat	æ h v ɑ ɫ ɑ t
@@ -3383,6 +3884,7 @@ zərər	z æ r æ r
 əklil	æ t͡ʃ l i l
 əkmək	æ k m æ j
 əkmək	æ k m æ k
+əksinə	æ c s i n æ
 əksəriyyət	æ k s æ r i j æ t
 əl	æ l
 əla	æ ɫ ɑ
@@ -3417,6 +3919,7 @@ zərər	z æ r æ r
 əmcək	æ m d͡z æ j
 əmcək	æ m d͡ʒ æ j
 əmi	æ m i
+əmin	æ m i n
 əmioğlu	æ m i o ɣ ɫ u
 əmiqızı	æ m i ɡ ɯ z ɯ
 əmizdirmək	æ m i z d i r m æ k
@@ -3424,6 +3927,8 @@ zərər	z æ r æ r
 əmmək	æ mː æ k
 əmn	æ m n
 əmr	æ m r
+əmsal	æ m s ɑ l
+əmzik	æ m z i c
 əmək	æ m æ j
 əmək	æ m æ k
 əməl	æ m æ l
@@ -3432,6 +3937,7 @@ zərər	z æ r æ r
 əndazə	æ n d ɑː z æ
 əng	æ ŋ ɡ
 ənis	æ n i s
+ənlik	æ n l i c
 ənsə	æ n s æ
 ənənə	æ n æː n æ
 ənənəvi	æ n æ n æː v i
@@ -3451,8 +3957,10 @@ zərər	z æ r æ r
 əsgər	æ s ɡ æ r
 əsin	æ s i n
 əsir	æ s i r
+əski	æ s c i
 əsnəmək	æ s n æ m æ j
 əsnəmək	æ s n æ m æ k
+əsrarəngiz	æ s r a r æ ŋ ɟ i z
 əsrik	æ s r i j
 əsrik	æ s r i k
 əsrik	æ s r i t͡ʃ
@@ -3465,15 +3973,19 @@ zərər	z æ r æ r
 əsəb	æ s æ b
 əsər	æ s æ r
 ət	æ t
+ətalət	æ t aː l æ t
 ətağa	æː t ɑ ɣ ɑ
 ətirşah	æ t i r ʃ ɑ h
 ətsatan	æ t s ɑ t ɑ n
+əttökən	æ tː œ c æ n
 ətyeyən	æ t j e j æ n
 ətçəkən	æ t t͡ʃ æ k æ n
 ətək	æ t æ j
 ətək	æ t æ k
 ətək	æ t æ t͡ʃ
 əvət	æ v æ t
+əvəzlik	æ v æ z d i c
+əvəzlik	æ v æ z l i c
 əxlaq	æ h ɫ ɑ k
 əxlaq	æ h ɫ ɑ ɡ
 əxlaq	æ h ɫ ɑ χ


### PR DESCRIPTION
[ɟ, c] were missing from the Azerbaijani phonelist (aze_narrow.phones). I added them in.

Closes #527 