### PR TITLE
Fix dialect xpath selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
 
 #### Changed
 
+-   Fixes dialect xpath selector. (\#545)
 -   Fixes table alignment. (\#539)
 -   Repeats big scrape after \#523. (\#536)
 -   Fixes excessive line wrapping. (\#529)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ requests-html==0.10.0
 requests==2.32.3
 segments==2.2.1
 setuptools==65.6.3
-twine==4.0.1
+twine==5.1.1
 unicodedataplus==15.0.0

--- a/src/wikipron/config.py
+++ b/src/wikipron/config.py
@@ -30,8 +30,8 @@ _PRON_XPATH_SELECTOR_TEMPLATE = """
 """
 _DIALECT_XPATH_SELECTOR_TEMPLATE = (
     "and\n"
-    '  (span[@class = "ib-content"]//a[{dialects_text}]\n'
-    '   or count(span[@class = "ib-content"]) = 0)'
+    '  (span[contains(@class, "ib-content")]//a[{dialects_text}]\n'
+    '   or count(span[contains(@class, "ib-content")]) = 0)'
 )
 _PHONEMES_REGEX = r"/(.+?)/"
 _PHONES_REGEX = r"\[(.+?)\]"

--- a/src/wikipron/config.py
+++ b/src/wikipron/config.py
@@ -30,7 +30,7 @@ _PRON_XPATH_SELECTOR_TEMPLATE = """
 """
 _DIALECT_XPATH_SELECTOR_TEMPLATE = (
     "and\n"
-    '  (span[@class = "ib-content" and a[{dialects_text}]]\n'
+    '  (span[@class = "ib-content"]//a[{dialects_text}]\n'
     '   or count(span[@class = "ib-content"]) = 0)'
 )
 _PHONEMES_REGEX = r"/(.+?)/"

--- a/tests/test_wikipron/test_config.py
+++ b/tests/test_wikipron/test_config.py
@@ -153,8 +153,8 @@ def test_ipa_regex(narrow, ipa_regex, word_in_ipa):
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
-                '  (span[@class = "ib-content" and a[text() = "US"]]\n'  # noqa: E501
-                '   or count(span[@class = "ib-content"]) = 0)\n'  # noqa: E501
+                '  (span[contains(@class, "ib-content")]//a[text() = "US"]\n'  # noqa: E501
+                '   or count(span[contains(@class, "ib-content")]) = 0)\n'  # noqa: E501
                 "]\n"
             ),
         ),
@@ -170,8 +170,8 @@ def test_ipa_regex(narrow, ipa_regex, word_in_ipa):
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
-                '  (span[@class = "ib-content" and a[text() = "General American" or text() = "US"]]\n'  # noqa: E501
-                '   or count(span[@class = "ib-content"]) = 0)\n'  # noqa: E501
+                '  (span[contains(@class, "ib-content")]//a[text() = "General American" or text() = "US"]\n'  # noqa: E501
+                '   or count(span[contains(@class, "ib-content")]) = 0)\n'  # noqa: E501
                 "]\n"
             ),
         ),


### PR DESCRIPTION
- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

It looks like wiktionary changed their formatting from 

```
<span class="ib-content qualifier-content">
        <a href="https://en.wikipedia.org/wiki/American_English" class="extiw" title="w:American English">US</a>
</span>
```

to

```
<span class="ib-content qualifier-content">
    <span class="usage-label-accent">
        <a href="https://en.wikipedia.org/wiki/American_English" class="extiw" title="w:American English">US</a>
    </span>
</span>
```

i.e., adding another span with "usage-label-accent" around the link.  I've changed the dialect xpath selector to still be based on the "ib-content" span but allow intermediate nodes between that span and the link to the dialect.  Alternatively, we could change it use the new "usage-label-accent" class, but I don't know how reliably it's used across languages if it's a new thing.

Resolves #545 