### PR TITLE
Cycle Python version support:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ workflows:
             - twine
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       - build-python-win:
           requires:
             - flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wikipron"
 version = "1.3.3"
 description = "Scraping grapheme-to-phoneme data from Wiktionary"
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 authors = [ { name = "WikiPron authors", email = "kylebgorman@gmail.com" } ]
 keywords = [
@@ -33,11 +33,11 @@ classifiers = [
     "Environment :: Console",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Text Processing :: Linguistic",
 ]
 


### PR DESCRIPTION
* Drops 3.8 support (it is EOL as of late 2024)
* Adds 3.13 support

NB: 3.14 support will be added at the end of the year.

- [ ] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
