### PR TITLE
[uzb] Adds Uzbek to big scrape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
 
 ### Under `data/`
 
+-  Adds Uzbek (`uzb`). (\#565)
+
 #### Changed
 
 -   Adds custom English extractor to increase the consistency of English r. (\#561)

--- a/data/scrape/README.md
+++ b/data/scrape/README.md
@@ -1,11 +1,11 @@
-* Languages: 306
-  * Broad transcription files: 309
-  * Narrow transcription files: 174
+* Languages: 307
+  * Broad transcription files: 310
+  * Narrow transcription files: 175
 * Dialects: 17
   * Broad transcription files: 25
   * Narrow transcription files: 22
 * Scripts: 42
-* Pronunciations: 3,958,916
+* Pronunciations: 3,959,384
 
 
 | Link | ISO 639-3 Code | ISO 639 Language Name | Wiktionary Language Name | Script | Dialect | Filtered | Narrow/Broad | # of entries |
@@ -460,6 +460,8 @@
 | [TSV](tsv/urd_arab_narrow.tsv) | urd | Urdu | Urdu | Arabic |  | False | Narrow | 104 |
 | [TSV](tsv/urk_thai_broad.tsv) | urk | Urak Lawoi' | Urak Lawoi' | Thai |  | False | Broad | 565 |
 | [TSV](tsv/urk_thai_narrow.tsv) | urk | Urak Lawoi' | Urak Lawoi' | Thai |  | False | Narrow | 565 |
+| [TSV](tsv/uzb_latn_broad.tsv) | uzb | Uzbek | Uzbek | Latin |  | False | Broad | 293 |
+| [TSV](tsv/uzb_latn_narrow.tsv) | uzb | Uzbek | Uzbek | Latin |  | False | Narrow | 175 |
 | [TSV](tsv/vie_latn_hanoi_narrow.tsv) | vie | Vietnamese | Vietnamese | Latin | Hà Nội | False | Narrow | 23,320 |
 | [TSV](tsv/vie_latn_hanoi_narrow_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Hà Nội | True | Narrow | 23,320 |
 | [TSV](tsv/vie_latn_hue_narrow.tsv) | vie | Vietnamese | Vietnamese | Latin | Huế | False | Narrow | 26,372 |

--- a/data/scrape/summary.tsv
+++ b/data/scrape/summary.tsv
@@ -448,6 +448,8 @@ urd_arab_broad.tsv	urd	Urdu	Urdu	Arabic		False	Broad	4493
 urd_arab_narrow.tsv	urd	Urdu	Urdu	Arabic		False	Narrow	104
 urk_thai_broad.tsv	urk	Urak Lawoi'	Urak Lawoi'	Thai		False	Broad	565
 urk_thai_narrow.tsv	urk	Urak Lawoi'	Urak Lawoi'	Thai		False	Narrow	565
+uzb_latn_broad.tsv	uzb	Uzbek	Uzbek	Latin		False	Broad	293
+uzb_latn_narrow.tsv	uzb	Uzbek	Uzbek	Latin		False	Narrow	175
 vie_latn_hanoi_narrow.tsv	vie	Vietnamese	Vietnamese	Latin	Hà Nội	False	Narrow	23320
 vie_latn_hanoi_narrow_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Hà Nội	True	Narrow	23320
 vie_latn_hue_narrow.tsv	vie	Vietnamese	Vietnamese	Latin	Huế	False	Narrow	26372

--- a/data/scrape/tsv/uzb_latn_broad.tsv
+++ b/data/scrape/tsv/uzb_latn_broad.tsv
@@ -1,0 +1,293 @@
+Afrika	a f r i k a
+Belarus	bʲ e ɫ a r u s
+Eron	ɛ r ɒ n
+Fiji	ɸ i d͡ʒ i
+Gʻ	ʁ
+Ishoq	i s h ɒ q
+J	d͡ʒ
+Jizzax	d͡ʒ i z z a χ
+Margʻilon	m a r ʁ i l ɒ n
+Mirrix	m i r r i χ
+Namangan	n a m a ŋ ɡ a n
+Navoiy	n a ʋ ɒ i j
+Oʻ	o
+Oʻzbekiston	o z b ɛ k i s t ɒ n
+Qarshi	q a r ʃ ɨ
+Qirgʻiziston	q i ɾ ʁ i z i s t ɒ n
+Qozogʻiston	q ɒ z ɒ ʁ ɨ s t ɒ n
+Qoʻqon	q o q ɒ n
+Rossiya	r a sʲ i j a
+Rossiya	r o s i j æ
+Toshkent	t ɒ ʃ k ɛ n t
+Ziyo	z i j ɒ
+achimsiq	ɑ t͡ʃ i m s ɨ q
+adolat	a d ɒ l a t
+agar	ɑ ɡ ɑ r
+aka	a k a
+araq	a r a q
+araqxoʻr	a r a q χ o r
+aroq	æ ɾ ɒ q
+aroq	æ ɾ ɒ χ
+arslon	a r s l ɒ n
+badaviy	b æ d æ w i j
+bahor	b a h ɒ r
+bek	b ɛ k
+bermoq	b e ɾ m ɒ q
+besh	b ɛ ʃ
+bilan	b i l a n
+bilmoq	b ɪ l m ɒ q
+bir	b ɪ r
+bizga	b i z ɡ a
+bogʻ	b ɒ ʁ
+bola	b ɒ l a
+bormoq	b ɒ ɾ m ɒ q
+bosh	b ɒ ʃ
+boshqird	b ɒ ʃ q i ɾ d
+botil	b ɒ t i l
+boʻhton	b o h ɒ n
+boʻlmoq	b o l m ɒ q
+boʻri	b o ɾ i
+bu	b ʊ
+bugun	b ʊ ɡ ʊ n
+bulut	b ʊ l ʊ t
+butun	b ʊ t ʊ n
+buyuk	b ʊ j ʊ k
+ch	t ʃ
+chekmoq	t͡ʃ e k m ɒ q
+chiqish	t͡ʃ i q i ʃ
+chiqmoq	t͡ʃ i q m ɒ q
+chivin	t͡ʃ ɨ v ɨ n
+choy	t͡ʃ ɔ j
+choʻchqa	t͡ʃ o t͡ʃ q ɑ
+chuqur	t͡ʃ u q u ɾ
+darvoza	d æ ɾ v ɒ z æ
+davlat	d a ʋ l a t
+demoq	d e m ɒ q
+din	d i n
+doʻkon	d o k ɒ n
+dunyo	d ʊ n j ɒ
+ellik	æ l l i
+ellik	ɛ l l i k
+eng	e ŋ
+ertaga	ɛ r t a ɡ a
+eshak	e ʃ a k
+fil	f i l
+gul	ɡ ʊ l
+guruh	ɡ u r u h
+gʻ	ʁ
+gʻa	ʁ a
+hashamat	h æ ʃ æ m æ t
+hukumat	h u k u m a t
+hur	h u r
+hurmat	h u r m æ t
+iqror	i q r ɒ r
+iqtisodiy	i q t i s ɒ d i j
+irq	i ɾ q
+irqiy	i ɾ q i j
+ishchi	ʔ ɪ ʃ t͡ʃ ɪ
+ism	ʔ ɪ s m
+izhor	i z h ɒ r
+izoh	i z ɒ h
+j	d͡ʒ
+jahon	d͡ʒ a h ɒ n
+jodugar	d͡ʒ ɒː d uː ɡ æ ɾ
+juma	d͡ʒ u m a
+kabi	k æ b i
+kattakon	k æ t t æ k ɒ n
+kel	k ɛ l
+kel	ɡ æ l
+kelin	k ɛ l ɪ n
+kelmoq	k ɛ l m ɒ q
+kerak	k ɛ r a k
+kinoya	k ɪ n ɒ j æ
+kishi	k i ʃ i
+korol	k ɒ r ɒ l
+korol	k ɒ r ɔ l
+koʻk	k o k
+koʻl	k o l
+koʻp	k o p
+koʻr	k o ɾ
+koʻrlik	k o ɾ l ɪ k
+koʻrsatmoq	k o ɾ s æ t m ɒ q
+koʻtarilmoq	k ɔ t ɑ ɾ i l m ɒ q
+koʻtarinki	k o t̪ ɑ ɾ i n k i
+kuch	k ʊ t͡ʃ
+kun	k ʊ n
+kun	ɡ ʊ n
+kuz	k ʊ z
+kuz	ɡ ʊː z
+maishat	m æ i ʃ æ t
+makkajoʻxori	m a k k a d͡ʒ o χ ɒ ɾ i
+maktab	m a k t a b
+men	m ɛ n
+menga	m e ŋ ɡ a
+ming	m i ŋ
+moddiy	m ɒ d d i j
+muhim	m u h i m
+muhimlik	m u h i m l i k
+muqaddima	m u q æ d d i m æ
+mushuk	m u ʃ u k
+muxtor	m u χ t ɒ r
+muxtoriyat	m u χ t ɒ r i j æ t
+muz	m u z
+nafas	n æ ɸ æ s
+nafosat	n æ ɸ ɒ s æ t
+najosat	n æ d͡ʒ ɒ s æ t
+naql	n æ q l
+ng	ŋ
+niyat	n i j æ t
+nok	n ɔ k
+nordon	n ɒ ɾ d̪ ɒ n
+nuqson	n u q s ɒ n
+och	ɒ t ʃ
+ochlik	ɒ t ʃ l i k
+ochmoq	ɒ t͡ʃ m ɒ q
+odam	ɒ d a m
+ogʻir	ɒ ʁ i r
+olma	ɒ l m a
+olti	ɒ l t i
+oltin	ɒ l t ɪ n
+ona	ɒ n a
+orol	ɒ ɾ ɒ l
+oshiq	ɔ ʃ i q
+osmon	ɒ s m ɒ n
+osmoniy	ɒ s m ɒ n iː
+osmonlamoq	ɒ s m ɒ n l ɑ m ɒ q
+osmoq	ɒ s m ɒ q
+oson	ɒ s ɒ n
+ota	ɒ t a
+otadi	ɒ t æ d i
+otaman	ɒ t æ m æ n
+otasan	ɒ t æ s æ n
+otmayajak	ɒ t m æ j æ d͡ʒ æ k
+otmayman	ɒ t m æ j m æ n
+otmoq	ɒ t m ɒ q
+otmoqchiman	ɒ t m ɒ q t͡ʃ i m æ n
+ovoz	ɒ v ɒ z
+oxirat	ɒ χ i r æ t
+oy	ɒ j
+oydek	ɒ j d ɛ k
+ozod	ɒ z ɒ d
+ozodlik	ɒ z ɒ d l i k
+oʻ	o
+oʻgʻil	o ʁ i l
+oʻn	ʔ o n
+oʻrganmoq	o r ɡ æ n m ɒ q
+oʻt	o t
+oʻyin	o j i n
+oʻynamoq	o j n ɑ m ɒ q
+oʻzbek	o z b e k
+pashsha	p a ʃ ʃ a
+pirat	p ɪ r a t
+pornografiya	p ɔ r n ɔ ɡ r a f ɪ j a
+provinsiya	p r ɒ v i n s i j æ
+pul	p ʊ l
+qanot	q a n ɒ t
+qatagʻon	q a t a ʁ ɒ n
+qavat	q a ʋ a t
+qilmoq	q i l m ɒ q
+qirgʻiz	q i ɾ ʁ i z
+qishloq	q ɨ ʃ l ɒ q
+qiz	q i z
+qiz	q iː z
+qolmoq	q ɒ l m ɒ q
+qon	q ɒ n
+qora	q ɒ ɾ a
+qoraqalpoq	q ɒ ɾ a q a l p ɒ q
+qozoq	q ɒ z ɒ q
+qul	q u l
+qum	q u m
+rahmat	r a h m a t
+ravshan	r a ʋ ʃ a n
+ruhdan	r u h d ɑ n
+ruhoniy	r u h ɒ n i j
+sakson	s a k s ɒ n
+samimiy	s æ m i m i j
+sanʼat	s a n ʔ a t
+sarflamoq	s a r f l a m ɒ q
+savol	s æ w ɒ l
+sevmoq	s e v m ɒ q
+sh	ʃ
+shahar	ʃ a h a r
+sher	ʃ ɛ r
+shirin	ʃ i r i n
+shirin	ʃ ɪ r̟ ɪ n̟
+siloh	s i l ɒ h
+soch	s ɔ t͡ʃ
+soʻm	s o m
+soʻramoq	s o ɾ æ m ɒ q
+soʻroq	s o ɾ ɒ q
+soʻz	s o z
+soʻzlik	s o z l i k
+suv	s ʊ ʋ
+tajalli	t a d ʒ a l l i
+tanaffus	t æ n æ ɸ ɸ u s
+taqmoq	t æ q m ɒ q
+tavakkal	t æ w æ k k æ l
+tavba	t æ w b æ
+taxallus	t a χ a l l ʊ s
+til	t ɪ l
+tosh	d ɒː ʃ
+tosh	t ɒ ʃ
+tovar	t ɒ v a ɾ
+toʻngʻiz	t o n ʁ i z
+toʻrt	t o r t
+tuhmat	t u h m æ t
+tuman	t u m a n
+tun	t ʊ n
+turk	t u ɾ k
+turkiy	t u ɾ k i j
+tushunmoq	t u ʃ u n m ɒ q
+tuz	t ʊ z
+u	ʔ ʊ
+uch	ʔ ʊ t͡ʃ
+uchun	ʔ ʊ t͡ʃ ʊ n
+ular	ʔ ʊ l a r
+uradi	u ɾ æ d i
+uradilar	u ɾ æ d ɪ l æ ɾ
+uraman	u ɾ æ m æ n
+uramiz	u ɾ æ m ɪ z
+urasan	u ɾ æ s æ n
+urasiz	u ɾ æ s ɪ z
+urmoq	u ɾ m ɒ q
+uxlamoq	ʊ χ l æ m ɒ q
+uy	u j
+uzum	u z u m
+va	v æ
+vahshiy	w æ h ʃ i j
+vazir	ʋ a z i r
+vijdon	w i ʒ d ɒ n
+vijdoniy	w i ʒ d ɒ n i j
+viloyat	ʋ i l ɒ j a t
+xachir	χ æ t͡ʃ i ɾ
+xalq	χ a l q
+xoin	χ ɒ i n
+xoʻja	χ o d͡ʒ a
+xurofiy	χ u r ɒ ɸ i j
+xurofot	χ u r ɒ ɸ ɒ t
+xusus	χ u s u s
+xususan	χ u s u s a n
+yalangʻoch	j a l a n ʁ ɒ t͡ʃ
+yangi	j æ ŋ ɡ i
+yaxshi	j a χ ʃ i
+yemoq	j e m ɒ q
+yer	j ɛ r
+yil	j i l
+yoki	j ɒ k i
+yolgʻon	j ɒ l ʁ ɒ n
+yomgʻir	j ɒ m ʁ i r
+yoqmoq	j ɒ q m ɒ q
+yosh	j ɔ ʃ
+yoz	j ɑː z
+yoz	j ɒ z
+yoʻl	j o l
+yoʻl	j oː l
+yoʻldosh	j o l d ɒ ʃ
+yoʻq	j o q
+yoʻq	j oː q
+yulduz	j ʊ l d ʊ z
+zamon	z a m ɒ n
+zavq	z æ w q
+ziyo	z i j ɒ
+zohir	z ɒ h i r
+zohiriy	z ɒ h i r i j

--- a/data/scrape/tsv/uzb_latn_narrow.tsv
+++ b/data/scrape/tsv/uzb_latn_narrow.tsv
@@ -1,0 +1,175 @@
+Afgʻoniston	a ɸ ʁ ɒ n ɪ s t̪ ɒ n
+Eron	ɛ r ɒ̽ n
+Fargʻona	f æ r ʁ ɒ̝ n æ
+Jizzax	d͡ʒ ɨ̞ z z ɑ̽ χ
+Margʻilon	m ɐ r ʁ ɯ̽ l ɒ̽ n
+Namangan	n a̽ m a̽ ŋ ˖ ɡ ˖ a̽ n
+Navoiy	n æ ʋ ɒ̝ ɪ j
+Nukus	n ʊ kʲ ʊ s
+Oʻzbekiston	ɵ z b ɛ k̟ ɪ s t̪ ɒ̽ n
+Qirgʻiziston	q ɨ ɾ ʁ ɨ z ɨ s t ɒ n
+Qoʻqon	q o q ɒ̝ n
+Termiz	t̪ e̞ r m ɨ̞ z
+Toshkent	t̪ ɒ̽ ʃ k̟ ɛ n t̪
+abad	æ b æ d̪
+achimsiq	ɑ t͡ʃ ɪ m s ɨ q
+adabiyot	æ d̪ æ b i j ɒ̝ t̪
+adash	æ d̪ æ ʃ
+adashmoq	æ d æ ʃ m ɒ q
+adolat	ɐ d̪ ɒ̽ l a̽ t̪
+aka	æ k̟ æ
+arslon	ɐ r s l ɒ̽ n
+asosan	æ s ɒ s æ n
+axir	æ χ ɨ r
+ayniqsa	a j n ɨ q s a
+aytmoq	æ j t̪ m ɒ̝ q
+bek	b ɛ k̟
+besh	b ɛ ʃ
+bilan	b ɨ̞ l a̽ n
+bilmoq	b ɪ̈ l m ɒ̽ q
+bir	b ɪ̈ r
+bizga	b ɨ̞ z ɡ ˖ æ
+bola	b ɒ̽ l æ
+boʻlmoq	b ɵ l m ɒ̝ q
+bu	b ʊ
+bugun	b ʏ ɡ ˖ ʏ n
+bulut	b ʊ̈ l ʊ̈ t̪ʰ
+butun	b ʊ̈ t̪ʰ ʊ̈ n
+buyuk	b ʏ j ʏ k̟ʰ
+chalkashmoq	t͡ʃ æ l k æ ʃ m ɒ q
+chechak	t͡ʃ e̞ t͡ʃ æ kʲ
+chiqish	t͡ʃ ɨ q ɨ ʃ
+darvoqe	d æ r v ɒ q e
+davlat	d̪ ɐ ʋ l ɐ t̪
+din	d̪ i n
+doʻkon	d̪ ɵ k̟ ɒ̽ n
+dunyo	d̪ ʊ̈ n j ɒ̽
+dunyolar	d u n j ɒ l a r
+ellik	ɛ l l ɪ k̟
+emoq	e m ɒ q
+ermoq	e r m ɒ q
+ertaga	ɛ r t̪ æ ɡ ˖ æ
+eshak	e ʃ æ c
+fil	f i l
+gapirmoq	ɡ æ p ɨ r m ɒ q
+gul	ɡ ˖ ʏ l
+guruh	ɡ ˖ ʊ r u̞ h
+gʻaladon	ʁ ɑ l ɑ d ɒ n
+hukumat	h u̥ k̟ ʊ m ɐ t̪
+humo	h ʊ m ɒ̝
+hur	h ʊ r
+inqilob	ə n q ə l ɒ b
+inson	ɪ n s ɒ̝ n
+ipak	ɪ p æ kʲ
+ishlatmoq	ɨ ʃ l æ t m ɒ q
+ism	ʔ s m
+jahon	d͡ʒ ɐ̠ h ɒ̝ n
+jahonlar	d͡ʒ a h ɒ n l a r
+juma	d͡ʒ ʊ m ɐ
+katet	k æ t̪ e t̪
+kecha	k e t͡ʃ æ
+kel	k̟ ɛ l
+kelin	k̟ʰ ɛ l ɪ̈ n
+kelmoq	k̟ ɛ l m ɒ̝ q
+kerak	k̟ ɛ r æ k̟
+ketmoq	k e t m ɒ q
+kishi	k̟ ʃ ɨ̞
+kitob	kʲ ɪ̥̆ t̪ ɒ̝ b
+koʻl	k̟ʰ ɵ l
+koʻr	k ɵ ɾ
+koʻtarilmoq	k ɔ t æ ɾ ɪ l m ɒ q
+koʻtarinki	k o t̪ æ ɾ ɪ n k i
+kuch	k̟ʰ ʏ t͡ʃʰ
+kun	k̟ʰ ʏ n
+kuz	k̟ʰ ʏ z
+maktab	m æ k̟ʰ t̪ a̽ b
+mardona	m æ r d̪ ɒ̝ n æ
+men	m ɛ n
+ming	m ɪ ŋ ˖
+muz	m ʉ̞ z
+namoz	n æ m ɒ̝ z
+neft	n e f t
+notoʻgʻri	n ɒ t o ʁ r ɨ
+ochiq	ɒ t͡ʃ ɨ q
+ogʻir	ɒ̝ ʁ ɯ̽ r
+olma	ɒ̝ l m æ
+olmoq	ɒ̝ l m ɒ̝ q
+olti	ɒ̝ l t̪ ɨ̞
+oltin	ɒ̽ l t̪ ɪ̈ n
+ona	ɒ̽ n ɐ
+oshmoq	ɒ ʃ m ɒ q
+osmon	ɒ̽ s m ɒ̽ n
+osmonlamoq	ɒ s m ɒ n l æ m ɒ q
+ota	ɒ̽ t̪ ɐ
+oy	ɒ̽ j
+oydek	ɒ̽ j d̪ ɛ k̟
+ozod	ɒ̽ z ɒ̽ d̪
+ozodlik	ɒ̽ z ɒ̽ d̪ l ɪ k̟
+oʻqimoq	o q ɨ m ɒ q
+oʻrmon	o r m ɒ n
+oʻrmonlar	o r m ɒ n l a r
+oʻrta	o r t a
+oʻrta	o r t æ
+oʻyin	o j ɪ n
+oʻylamoq	o j l æ m ɒ q
+oʻynamoq	o j n æ m ɒ q
+pivo	p í ʋ ɐ
+pul	pʰ ʊ̈ l
+qanot	q ɐ̠ n ɒ̽ t̪
+qaror	q ɑ r ɒ r
+qatagʻon	q ɑ̽ t̪ ɐ ʁ ɒ̝ n
+qavat	q ɐ̠ ʋ ɐ t̪
+qaysi	q æ j s ɨ
+qilmoq	q ɯ̽ l m ɒ̝ q
+qimiz	q ɨ m ɨ z
+qirgʻiz	q ɨ ɾ ʁ ɨ z
+qirol	q ɨ r ɒ l
+qiz	q ɯ̽ z
+qum	q u̞ m
+rahmat	r ɑ̽ h m ɐ t̪
+rang	ɾ æ ŋʲ
+salom	s æ l ɒ̝ m
+sanʼat	s ɐ n ʔ ɐ t̪
+sevgi	s ɛ ʋ ɡ ˖ ɪ
+sezmoq	s e z m ɒ q
+shahar	ʃ ɐ h ɑ̽ r
+sher	ʃ ɛ r
+shod	ʃ o d
+sifat	s ɨ̞̊ f a t
+sizga	s ɨ̞ z ɡʲ æ
+soʻzlik	s o̟ z l ɪ k̟
+suv	s ʊ ʋ̞
+tashvishlanmoq	t æ ʃ v ɨ ʃ l æ n m ɒ q
+tegmoq	t e ɡ m ɒ q
+til	t̪ʰ ɪ̈ l
+topmoq	t ɒ p m ɒ q
+tosh	t̪ ɒ̽ ʃ
+toʻgʻri	t o ʁ r ɨ
+toʻrt	t̪ o̟ r t̪
+tuman	t̪ ʉ̞ m æ n
+tun	t̪ʰ ʊ n
+tushunmoq	t ʉ ʃ ʉ n m ɒ q
+tushuntirmoq	t ʉ ʃ ʉ n t ɨ r m ɒ q
+tutmoq	t ʉ t m ɒ q
+u	ʔ ʊ
+uch	ʔ ʊ̈ t͡ʃʰ
+uchun	ʔ ʊ̈ t͡ʃʰ ʊ̈ n
+ular	ʔ ʊ̈ l a̽ r
+uy	ʉ̞ j
+uzr	ʊ̈ z ʊ̈ r
+vazir	ʋ ɐ z ɨ̞ r
+vergul	v e r ɡ y l
+viloyat	ʋ ɪ l ɒ̽ j ɐ t̪
+xalq	χ ɑ̽ l q
+xoʻja	χ o d͡ʒ ɐ
+xursand	χ ʊ r s a n t
+yaxshi	j ɐ̠ χ ʃ ɨ̞
+yer	j ɛ r
+yil	j ɨ̞ l
+yomgʻir	j ɒ̽ m ʁ ɯ̽ r
+yoz	j ɒ̽ z
+yozuv	j ɒ z u v
+yoʻl	j ɵ l
+yoʻldosh	j ɵ l d̪ ɒ̽ ʃ
+yoʻq	j o q
+yulduz	j ʊ̈ l d̪ ʊ̈ z

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ requests-html==0.10.0
 requests==2.32.3
 segments==2.2.1
 setuptools==70.0.0
-twine==5.1.1
+twine==6.1.0
 unicodedataplus==16.0.0.post1


### PR DESCRIPTION
This was already in languages.json, but must have grown substantially larger since the last big scrape.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
