### PR TITLE
[lat] Update Latin XPath selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Unreleased
 
 ### Under `src/` and elsewhere
 
+-   Updates Latin XPath selectors. (\#578)
 -   Replaces `--skip-parens`/`--no-skip-parens` with `--parens` accepting
     `skip`, `show`, or `expand`. The `expand` option generates all
     pronunciation variants from parenthesized content and is the new

--- a/src/wikipron/extract/lat.py
+++ b/src/wikipron/extract/lat.py
@@ -12,9 +12,9 @@ In the underlying HTML, the Latin entry pages are in two different forms.
    a Latin entry page organizes the "homographs" in terms of "Etymologies".
    Each etymology has its own (correct) orthographic form and pronunciations:
 
-   <h3>
-       <span class="mw-headline" id = "Etymology_1">Etymology 1</span>
-   </h3>
+   <div class="mw-heading mw-heading3">
+       <h3 id="Etymology_1">Etymology 1</h3>
+   </div>
    <p>
        <!-- The orthographic form we want. -->
        <strong class="Latn headword" lang="la">...</strong>
@@ -28,9 +28,9 @@ In the underlying HTML, the Latin entry pages are in two different forms.
    structure is very similar, with everything moved up one level,
    from <h3> for an etymology to <h2> for Latin.
 
-   <h2>
-       <span class="mw-headline" id = "Latin">Latin</span>
-   </h2>
+   <div class="mw-heading mw-heading2">
+       <h2 id="Latin">Latin</h2>
+   </div>
    <p>
        <!-- The orthographic form we want. -->
        <strong class="Latn headword" lang="la">...</strong>
@@ -62,8 +62,9 @@ _TOC_ETYMOLOGY_XPATH_SELECTOR = """
 """
 
 _PRON_XPATH_TEMPLATE = """
-//{heading}[span[@class = "mw-headline" and @id = "{tag}"]]
-  /following-sibling::ul[1]
+//div[{heading}[@id = "{tag}"]]
+  /following-sibling::ul
+    [descendant::a[@title = "Appendix:Latin pronunciation"]][1]
     {dialect_selector}
 """
 
@@ -73,14 +74,14 @@ _PRON_WITH_DIALECT_XPATH_SELECTOR_TEMPLATE = """
   and
   span[contains(@class, "IPA")]
   and
-  span[@class = "ib-content" and a[{dialects_text}]]
+  span[contains(@class, "ib-content") and a[{dialects_text}]]
 ]
 """
 
 _WORD_XPATH_TEMPLATE = """
-//{heading}[span[@class = "mw-headline" and @id = "{tag}"]]
+//div[{heading}[@id = "{tag}"]]
   /following-sibling::p
-    /strong[@class = "Latn headword" and @lang = "la"][1]
+    //strong[@class = "Latn headword" and @lang = "la"][1]
 """
 
 
@@ -124,9 +125,7 @@ def _yield_latin_pron(
             )
         )
     else:
-        dialect_selector = (
-            '[descendant::a[@title = "Appendix:Latin pronunciation"]]'
-        )
+        dialect_selector = ""
     pron_xpath_selector = _PRON_XPATH_TEMPLATE.format(
         heading=heading, tag=tag, dialect_selector=dialect_selector
     )

--- a/tests/test_wikipron/test_scrape.py
+++ b/tests/test_wikipron/test_scrape.py
@@ -34,9 +34,8 @@ _SMOKE_TEST_LANGUAGES = [
     SmokeTestLanguage("khm", "Khmer", {}),
     SmokeTestLanguage("shn", "Shan", {}),
     SmokeTestLanguage("tha", "Thai", {}),
-    # TODO(#514): Latin extractor is broken; disabling. Uncomment the
-    # following line to re-enable.
-    # SmokeTestLanguage("lat", "Latin", {}),
+    # Latin data is narrow transcription only.
+    SmokeTestLanguage("lat", "Latin", {"narrow": True}),
     # Japanese data is mostly narrow transcription.
     SmokeTestLanguage("jpn", "Japanese", {"narrow": True}),
     SmokeTestLanguage("cmn", "Chinese", {"skip_spaces_pron": False}),
@@ -77,9 +76,6 @@ def test_special_languages_covered_by_smoke_test():
     """All languages handled by wikipron.extract must have a smoke test."""
     special_languages = {lang for lang in EXTRACTION_FUNCTIONS.keys()}
     smoke_test_languages = {lang.wik_name for lang in _SMOKE_TEST_LANGUAGES}
-    # TODO(#514): Latin extractor is broken; disabling its check here. Remove
-    # the following line to re-enable.
-    smoke_test_languages.add("Latin")
     assert special_languages.issubset(smoke_test_languages), (
         "These languages must also be included in the smoke test: "
         f"{special_languages - smoke_test_languages}"


### PR DESCRIPTION
This pull request updates the Latin XPath selectors due to upstream Wiktionary HTML changes. The previously commented-out smoke test for Latin is now re-enabled, though apparently the current Latin data is only narrow transcription now.

I was going to maybe also do a scrape run just for Latin to go with the PR, but then I noticed a couple things that we should optimize before running any scraping -- another PR's coming up for these.

This PR resolves #514.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
